### PR TITLE
CMake now only installs the aws-crt-java.jar file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,14 +152,10 @@ add_custom_command(
 )
 
 install(
-        TARGETS ${CMAKE_PROJECT_NAME} EXPORT ${CMAKE_PROJECT_NAME}-config
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+        FILES ${CMAKE_BINARY_DIR}/aws-crt-java.jar
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
         COMPONENT library
 )
-
-export(TARGETS ${CMAKE_PROJECT_NAME} FILE ${CMAKE_PROJECT_NAME}-config.cmake)
-install(EXPORT ${CMAKE_PROJECT_NAME}-config DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_PROJECT_NAME}/cmake/")
 
 if (NOT JUnit_FOUND)
     message(STATUS "JUnit could not be found, please ensure that JUNIT_HOME is defined in your environment. Tests will be disabled.")


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
