### PR TITLE
Always attach threads as daemons, so the JVM doesn't try to wait on t…

### DIFF
--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -68,7 +68,7 @@ struct aws_string *aws_jni_new_string_from_jstring(JNIEnv *env, jstring str) {
 
 JNIEnv *aws_jni_get_thread_env(JavaVM *jvm) {
     JNIEnv *env = NULL;
-    jint result = (*jvm)->AttachCurrentThread(jvm, (void **)&env, NULL);
+    jint result = (*jvm)->AttachCurrentThreadAsDaemon(jvm, (void **)&env, NULL);
     (void)result;
     assert(result == JNI_OK);
     return env;


### PR DESCRIPTION
…hem to shutdown
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
