### PR TITLE
Enforce Native Resource Memory Mangement in Unit Tests

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CrtResource.java
+++ b/src/main/java/software/amazon/awssdk/crt/CrtResource.java
@@ -14,11 +14,16 @@
  */
 package software.amazon.awssdk.crt;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * This wraps a native pointer to an AWS Common Runtime resource. It also ensures
  * that the first time a resource is referenced, the CRT will be loaded and bound.
  */
 public class CrtResource {
+    private static final ConcurrentHashMap<Long, String> NATIVE_RESOURCES = new ConcurrentHashMap<>();
     private long ptr;
 
     static {
@@ -26,14 +31,24 @@ public class CrtResource {
         new CRT();
     }
 
+    public static int getAllocatedNativeResourceCount() {
+        return NATIVE_RESOURCES.size();
+    }
+
+    public static Collection<String> getAllocatedNativeResources() {
+        return Collections.unmodifiableCollection(NATIVE_RESOURCES.values());
+    }
+
     public CrtResource() {
     }
 
     protected void acquire(long _ptr) {
+        NATIVE_RESOURCES.put(_ptr, this.getClass().getCanonicalName());
         ptr = _ptr;
     }
     
     protected long release() {
+        NATIVE_RESOURCES.remove(ptr);
         long addr = ptr;
         ptr = 0;
         return addr;

--- a/src/native/host_resolver.c
+++ b/src/native/host_resolver.c
@@ -68,6 +68,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_io_HostResolver_hostResol
         return;
     }
 
+    aws_host_resolver_clean_up(resolver);
     aws_mem_release(allocator, resolver);
 
     return;

--- a/src/test/java/software/amazon/awssdk/crt/test/EventLoopGroupTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/EventLoopGroupTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.crt.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -33,5 +34,6 @@ public class EventLoopGroupTest {
         } catch (CrtRuntimeException ex) {
             fail(ex.getMessage());
         }
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/IotServiceTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/IotServiceTest.java
@@ -15,11 +15,13 @@
 
 package software.amazon.awssdk.crt.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 
@@ -59,6 +61,8 @@ public class IotServiceTest extends MqttConnectionFixture {
             fail(ex.getMessage());
         }
         
-        disconnect();       
+        disconnect();
+        close();
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/PingTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/PingTest.java
@@ -15,10 +15,12 @@
 
 package software.amazon.awssdk.crt.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.fail;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.mqtt.MqttException;
 
 import software.amazon.awssdk.crt.test.MqttConnectionFixture;
@@ -40,6 +42,8 @@ public class PingTest extends MqttConnectionFixture {
             fail(mqttEx.getMessage());
         }
         
-        disconnect();       
+        disconnect();
+        close();
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/PublishTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/PublishTest.java
@@ -15,11 +15,13 @@
 
 package software.amazon.awssdk.crt.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.mqtt.*;
 
 import java.util.concurrent.CompletableFuture;
@@ -55,5 +57,7 @@ public class PublishTest extends MqttConnectionFixture {
         }
 
         disconnect();
+        close();
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.crt.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -23,6 +24,7 @@ import static org.junit.Assert.fail;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
 
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 
@@ -88,5 +90,7 @@ public class SelfPubSubTest extends MqttConnectionFixture {
         }
 
         disconnect();
+        close();
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/SubscribeTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/SubscribeTest.java
@@ -15,12 +15,14 @@
 
 package software.amazon.awssdk.crt.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
 
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 
@@ -60,6 +62,8 @@ public class SubscribeTest extends MqttConnectionFixture {
             fail(ex.getMessage());
         }
         
-        disconnect();       
+        disconnect();
+        close();
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
@@ -15,9 +15,11 @@
 
 package software.amazon.awssdk.crt.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.mqtt.MqttException;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
@@ -51,5 +53,7 @@ public class WillTest extends MqttConnectionFixture {
         }
 
         disconnect();
+        close();
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
     }
 };


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Adds checks to all existing Unit Tests that ensures Native Resources are freed correctly. Also fixes a bug uncovered by these new checks in `host_resolver.c` that wasn't cleaning up scheduled host resolver tasks from the Event Loop before freeing the Host Resolver, which could cause Segfaults if the task callback was called.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
