### PR TITLE
Move AsyncCallback to its own Class

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/AsyncCallback.java
+++ b/src/main/java/software/amazon/awssdk/crt/AsyncCallback.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.crt;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface AsyncCallback {
+
+    static <T> AsyncCallback wrapFuture(CompletableFuture<T> future, T value) {
+        return new AsyncCallback() {
+            @Override
+            public void onSuccess() {
+                future.complete(value);
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void onSuccess(Object val) {
+                future.complete((T)(val));
+            }
+
+            @Override
+            public void onFailure(Throwable reason) {
+                future.completeExceptionally(reason);
+            }
+        };
+    }
+
+    void onSuccess();
+    void onSuccess(Object value);
+    void onFailure(Throwable reason);
+}

--- a/src/native/async_callback.c
+++ b/src/native/async_callback.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <assert.h>
+#include <jni.h>
+
+#include "async_callback.h"
+
+struct crt_async_callback g_async_callback;
+
+void s_cache_async_callback(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/AsyncCallback");
+    assert(cls);
+    g_async_callback.on_success = (*env)->GetMethodID(env, cls, "onSuccess", "()V");
+    assert(g_async_callback.on_success);
+    g_async_callback.on_failure = (*env)->GetMethodID(env, cls, "onFailure", "(Ljava/lang/Throwable;)V");
+    assert(g_async_callback.on_failure);
+}

--- a/src/native/async_callback.h
+++ b/src/native/async_callback.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef AWS_JNI_CRT_ASYNC_CALLBACK_H
+#define AWS_JNI_CRT_ASYNC_CALLBACK_H
+
+#include <jni.h>
+
+/* methods of AsyncCallback */
+struct crt_async_callback {
+    jmethodID on_success;
+    jmethodID on_failure;
+};
+
+extern struct crt_async_callback g_async_callback;
+
+void s_cache_async_callback(JNIEnv *env);
+
+#endif /* AWS_JNI_CRT_ASYNC_CALLBACK_H */

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 
+#include "async_callback.h"
 #include "crt.h"
 
 struct aws_allocator *aws_jni_get_allocator() {
@@ -83,7 +84,6 @@ JNIEnv *aws_jni_get_thread_env(JavaVM *jvm) {
 #endif
 static void s_cache_jni_classes(JNIEnv *env) {
     extern void s_cache_mqtt_connection(JNIEnv *);
-    extern void s_cache_async_callback(JNIEnv *);
     extern void s_cache_message_handler(JNIEnv *);
     extern void s_cache_mqtt_exception(JNIEnv *);
     s_cache_mqtt_connection(env);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Move `AsyncCallback` into it's own class in preparation of adding `aws-c-http` integrations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
