### PR TITLE
Updated aws-c-common to v0.3.6, aws-c-io to v0.3.5, aws-c-http to v0.2.3

### DIFF
--- a/aws-common-runtime/CMakeLists.txt
+++ b/aws-common-runtime/CMakeLists.txt
@@ -16,7 +16,7 @@ set(AWS_DEPS_BUILD_DIR "${CMAKE_BINARY_DIR}/build" CACHE PATH "Dependencies buil
 set(AWS_DEPS_DOWNLOAD_DIR "${AWS_DEPS_BUILD_DIR}/downloads" CACHE PATH "Dependencies download directory.")
 
 set(AWS_C_COMMON_URL "https://github.com/awslabs/aws-c-common.git")
-set(AWS_C_COMMON_SHA "v0.3.5")
+set(AWS_C_COMMON_SHA "v0.3.6")
 include(BuildAwsCCommon)
 
 if (UNIX AND NOT APPLE)
@@ -30,7 +30,7 @@ if (UNIX AND NOT APPLE)
 endif()
 
 set(AWS_C_IO_URL "https://github.com/awslabs/aws-c-io.git")
-set(AWS_C_IO_SHA "v0.3.0")
+set(AWS_C_IO_SHA "v0.3.5")
 include(BuildAwsCIO)
 
 set(AWS_C_MQTT_URL "https://github.com/awslabs/aws-c-mqtt.git")
@@ -38,7 +38,7 @@ set(AWS_C_MQTT_SHA "v0.3.4")
 include(BuildAwsCMqtt)
 
 set(AWS_C_HTTP_URL "https://github.com/awslabs/aws-c-http.git")
-set(AWS_C_HTTP_SHA "v0.2.2")
+set(AWS_C_HTTP_SHA "v0.2.3")
 include(BuildAwsCHttp)
 
 # AwsCMqtt depends on AwsCIO


### PR DESCRIPTION
In preparation for pushing a new maven release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
