### PR TITLE
 Add JNI Http Connection Open/Close APIs 

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -28,6 +28,7 @@ import java.util.*;
  */
 public final class CRT {
     private static final String CRT_LIB_NAME = "aws-crt-jni";
+    public static final int AWS_CRT_SUCCESS = 0;
 
     static {
         try {

--- a/src/main/java/software/amazon/awssdk/crt/CrtResource.java
+++ b/src/main/java/software/amazon/awssdk/crt/CrtResource.java
@@ -16,14 +16,17 @@ package software.amazon.awssdk.crt;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This wraps a native pointer to an AWS Common Runtime resource. It also ensures
  * that the first time a resource is referenced, the CRT will be loaded and bound.
  */
-public class CrtResource {
+public class CrtResource implements AutoCloseable {
     private static final ConcurrentHashMap<Long, String> NATIVE_RESOURCES = new ConcurrentHashMap<>();
+    private static final long NULL = 0;
+    private final LinkedList<CrtResource> ownedSubResources = new LinkedList<>();
     private long ptr;
 
     static {
@@ -42,12 +45,42 @@ public class CrtResource {
     public CrtResource() {
     }
 
+    /**
+     * Marks a SubResource as owned by this Resource. This will cause the SubResource to be closed after this Resource
+     * is closed.
+     * @param subresource The owned subresource
+     * @return The original subresource.
+     */
+    public <T extends CrtResource> T own(T subresource) {
+        if (!isNull()) {
+            throw new IllegalStateException("Parent Resource already created and acquired, can't add sub-resources after the fact.");
+        }
+        ownedSubResources.push(subresource);
+        return subresource;
+    }
+
     protected void acquire(long _ptr) {
-        NATIVE_RESOURCES.put(_ptr, this.getClass().getCanonicalName());
+        if (!isNull()) {
+            throw new IllegalStateException("Can't acquire >1 Native Pointer");
+        }
+
+        if (_ptr == NULL) {
+            throw new IllegalStateException("Can't acquire NULL Pointer");
+        }
+
+        String lastValue = NATIVE_RESOURCES.put(_ptr, this.getClass().getCanonicalName());
+
+        if (lastValue != null) {
+            throw new IllegalStateException("Acquired two CrtResources to the same Native Resource! Class: " + lastValue);
+        }
+
         ptr = _ptr;
     }
     
     protected long release() {
+        if (isNull()) {
+            throw new IllegalStateException("Already Released Resource!");
+        }
         NATIVE_RESOURCES.remove(ptr);
         long addr = ptr;
         ptr = 0;
@@ -56,5 +89,21 @@ public class CrtResource {
 
     public long native_ptr() {
         return ptr;
+    }
+
+    public boolean isNull() {
+        return (ptr == NULL);
+    }
+
+    @Override
+    public void close() {
+        if (!isNull()) {
+            throw new IllegalStateException("Closing sub-resources before releasing parent Resource may cause use-after-free bugs!");
+        }
+
+        while(ownedSubResources.size() > 0) {
+            CrtResource r = ownedSubResources.pop();
+            r.close();
+        }
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpConnection.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.crt.http;
+
+import software.amazon.awssdk.crt.AsyncCallback;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+import static software.amazon.awssdk.crt.CRT.AWS_CRT_SUCCESS;
+
+
+/**
+ * This class wraps aws-c-http to provide the basic HTTP request/response functionality via the AWS Common Runtime.
+ *
+ * HttpConnection represents a single connection to a HTTP service endpoint.
+ *
+ * This class is not thread safe and should not be called from different threads.
+ */
+public class HttpConnection extends CrtResource {
+    private static final String HTTP = "http";
+    private static final String HTTPS = "https";
+    private static final int DEFAULT_HTTP_PORT = 80;
+    private static final int DEFAULT_HTTPS_PORT = 443;
+
+    private final ClientBootstrap clientBootstrap;
+    private final SocketOptions socketOptions;
+    private final TlsContext tlsContext;
+    private final URI uri;
+    private final int port;
+    private final boolean useTls;
+
+    private final CompletableFuture<HttpConnection> connectedFuture;
+    private final CompletableFuture<Void> shutdownFuture;
+
+    /**
+     * Creates a new CompletableFuture for a new HttpConnection.
+     * @param uri Must be non-null and contain a hostname
+     * @param bootstrap The ClientBootstrap to use for the Connection
+     * @param socketOptions The SocketOptions to use for the Connection
+     * @param tlsContext The TlsContext to use for the Connection
+     * @return CompletableFuture indicating when the connection has completed
+     * @throws CrtRuntimeException if Native threw a CrtRuntimeException
+     */
+    public static CompletableFuture<HttpConnection> createConnection(URI uri, ClientBootstrap bootstrap,
+                                                                     SocketOptions socketOptions, TlsContext tlsContext) throws CrtRuntimeException {
+        HttpConnection conn = new HttpConnection(uri, bootstrap, socketOptions, tlsContext);
+        return conn.connect();
+    }
+
+    /**
+     * Constructs a new HttpConnection.
+     * @param uri Must be non-null and contain a hostname
+     * @param bootstrap The ClientBootstrap to use for the Connection
+     * @param socketOptions The SocketOptions to use for the Connection
+     * @param tlsContext The TlsContext to use for the Connection
+     */
+    private HttpConnection(URI uri, ClientBootstrap bootstrap, SocketOptions socketOptions, TlsContext tlsContext) {
+        if (uri == null) {  throw new IllegalArgumentException("URI must not be null"); }
+        if (uri.getScheme() == null) { throw new IllegalArgumentException("URI does not have a Scheme"); }
+        if (!HTTP.equals(uri.getScheme()) && !HTTPS.equals(uri.getScheme())) { throw new IllegalArgumentException("URI has unknown Scheme"); }
+        if (uri.getHost() == null) { throw new IllegalArgumentException("URI does not have a Host name"); }
+        if (bootstrap == null || bootstrap.isNull()) {  throw new IllegalArgumentException("ClientBootstrap must not be null"); }
+        if (socketOptions == null || socketOptions.isNull()) { throw new IllegalArgumentException("SocketOptions must not be null"); }
+        if (HTTPS.equals(uri.getScheme()) && tlsContext == null) { throw new IllegalArgumentException("TlsContext must not be null if https is used"); }
+
+        int port = uri.getPort();
+
+        /* Pick a default port based on the scheme if one wasn't set in the URI */
+        if (port == -1) {
+            if (HTTP.equals(uri.getScheme()))  { port = DEFAULT_HTTP_PORT; }
+            if (HTTPS.equals(uri.getScheme())) { port = DEFAULT_HTTPS_PORT; }
+        }
+
+        if (port <= 0 || 65535 < port) {
+            throw new IllegalArgumentException("Invalid or missing port: " + uri);
+        }
+
+        this.uri = uri;
+        this.port = port;
+        this.useTls = HTTPS.equals(uri.getScheme());
+        this.clientBootstrap = bootstrap;
+        this.socketOptions = socketOptions;
+        this.tlsContext = tlsContext;
+        this.connectedFuture = new CompletableFuture<>();
+        this.shutdownFuture = new CompletableFuture<>();
+    }
+
+    /**
+     * Schedules a connection task on the EventLoop to connect to the Http Endpoint
+     * @return Future indicating when the connection has completed.
+     */
+    private CompletableFuture<HttpConnection> connect() throws CrtRuntimeException {
+        if (!isNull()) {
+            return connectedFuture;
+        }
+
+        acquire(httpConnectionNew(this,
+                clientBootstrap.native_ptr(),
+                socketOptions.native_ptr(),
+                useTls ? tlsContext.native_ptr() : 0,
+                uri.getHost(),
+                port));
+
+        return connectedFuture;
+    }
+
+    /**
+     * Closes and frees this HttpConnection and any native sub-resources associated with this connection
+     */
+    @Override
+    public void close() {
+        if (!isNull()) {
+            httpConnectionRelease(release());
+        }
+
+        super.close();
+    }
+
+    /** Called from Native EventLoop when the connection is established the first time **/
+    private void onConnectionComplete(int errorCode) {
+        if (errorCode == AWS_CRT_SUCCESS) {
+            connectedFuture.complete(this);
+        } else {
+            /* The user can't close this HttpConnection object since they never got a reference to it through the
+                CompletableFuture, so we need to close ourselves on Connection Error. */
+            this.close();
+            connectedFuture.completeExceptionally(new HttpException(errorCode));
+        }
+    }
+
+    /** Called from Native EventLoop when the connection is shutdown. **/
+    private void onConnectionShutdown(int errorCode) {
+        if (errorCode == AWS_CRT_SUCCESS) {
+           shutdownFuture.complete(null);
+        } else {
+            shutdownFuture.completeExceptionally(new HttpException(errorCode));
+        }
+    }
+
+    /**
+     * Returns the Shutdown Future
+     * @return CompletableFuture that will be completed when the connection is shut down.
+     */
+    public CompletableFuture<Void> getShutdownFuture() {
+        return shutdownFuture;
+    }
+
+    /**
+     * Schedules a task on the Native EventLoop to shut down the current connection
+     * @return When this future completes, the shutdown is complete
+     */
+    public CompletableFuture<Void> shutdown() {
+        if (isNull()) {
+           return shutdownFuture;
+        }
+        try {
+            httpConnectionShutdown(native_ptr());
+        } catch (CrtRuntimeException e) {
+            shutdownFuture.completeExceptionally(e);
+        }
+
+        return shutdownFuture;
+    }
+
+    /*******************************************************************************
+     * Native methods
+     ******************************************************************************/
+    private static native long httpConnectionNew(HttpConnection thisObj,
+                                                 long client_bootstrap,
+                                                 long socketOptions,
+                                                 long tlsContext,
+                                                 String endpoint,
+                                                 int port) throws CrtRuntimeException;
+
+    private static native void httpConnectionShutdown(long connection) throws CrtRuntimeException;
+    private static native void httpConnectionRelease(long connection);
+
+}

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpException.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.crt.http;
+
+import software.amazon.awssdk.crt.CRT;
+
+/**
+ * This exception will be thrown by any exceptional cases encountered within the
+ * JNI bindings to the AWS Common Runtime
+ */
+public class HttpException extends RuntimeException {
+    private int errorCode;
+
+    public HttpException(int errorCode) {
+        super(CRT.awsErrorString(errorCode));
+        this.errorCode = errorCode;
+    }
+
+    /**
+     * Returns the error code captured when the exception occurred. This can be fed to {@link CRT.awsErrorString} to
+     * get a user-friendly error string
+     * @return The error code associated with this exception
+     */
+    int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/software/amazon/awssdk/crt/io/ClientBootstrap.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/ClientBootstrap.java
@@ -14,19 +14,16 @@
  */
 package software.amazon.awssdk.crt.io;
 
-import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.CrtResource;
-
-import java.io.Closeable;
+import software.amazon.awssdk.crt.CrtRuntimeException;
 
 /**
  * This class wraps the aws_client_bootstrap from aws-c-io to provide
  * a client context for all protocol stacks in the AWS Common Runtime.
  */
-public final class ClientBootstrap extends CrtResource implements Closeable {
+public final class ClientBootstrap extends CrtResource {
     private final HostResolver hostResolver;
     private final EventLoopGroup elg;
-    private final boolean ownResources;
 
     /**
      * Creates a new ClientBootstrap. Most applications will only ever need one instance of this.
@@ -34,9 +31,9 @@ public final class ClientBootstrap extends CrtResource implements Closeable {
      * @throws CrtRuntimeException If the system is unable to allocate space for a native client bootstrap object
      */
     public ClientBootstrap(int numThreads) throws CrtRuntimeException {
-        this.elg = new EventLoopGroup(numThreads);
-        this.hostResolver = new HostResolver(elg);
-        this.ownResources = true;
+        this.elg = own(new EventLoopGroup(numThreads));
+        this.hostResolver = own(new HostResolver(elg));
+        acquire(clientBootstrapNew(elg.native_ptr(), hostResolver.native_ptr()));
     }
 
     /**
@@ -49,19 +46,15 @@ public final class ClientBootstrap extends CrtResource implements Closeable {
     public ClientBootstrap(EventLoopGroup elg, HostResolver hr) throws CrtRuntimeException {
         this.hostResolver = hr;
         this.elg = elg;
-        this.ownResources = false;
         acquire(clientBootstrapNew(elg.native_ptr(), hostResolver.native_ptr()));
     }
 
     @Override
     public void close() {
-        if (native_ptr() != 0) {
+        if (!isNull()) {
             clientBootstrapDestroy(release());
         }
-        if (ownResources) {
-            hostResolver.close();
-            elg.close();
-        }
+        super.close();
     }
 
     /*******************************************************************************

--- a/src/main/java/software/amazon/awssdk/crt/io/EventLoopGroup.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/EventLoopGroup.java
@@ -14,17 +14,15 @@
  */
 package software.amazon.awssdk.crt.io;
 
-import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.CrtResource;
-
-import java.io.Closeable;
+import software.amazon.awssdk.crt.CrtRuntimeException;
 
 /**
  * This class wraps the aws_event_loop_group from aws-c-io to provide
  * access to an event loop for the MQTT protocol stack in the AWS Common
  * Runtime.
  */
-public final class EventLoopGroup extends CrtResource implements Closeable {
+public final class EventLoopGroup extends CrtResource {
 
     /**
      * Creates a new event loop group for the I/O subsystem to use to run blocking I/O requests
@@ -41,9 +39,10 @@ public final class EventLoopGroup extends CrtResource implements Closeable {
      */
     @Override
     public void close() {
-        if (native_ptr() != 0) {
+        if (!isNull()) {
             eventLoopGroupDestroy(release());
         }
+        super.close();
     }
 
     /*******************************************************************************

--- a/src/main/java/software/amazon/awssdk/crt/io/HostResolver.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/HostResolver.java
@@ -1,11 +1,23 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package software.amazon.awssdk.crt.io;
 
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 
-import java.io.Closeable;
-
-public class HostResolver extends CrtResource implements Closeable {
+public class HostResolver extends CrtResource {
     private final static int DEFAULT_MAX_ENTRIES = 8;
     private final EventLoopGroup elg;
     private final int maxEntries;
@@ -22,9 +34,10 @@ public class HostResolver extends CrtResource implements Closeable {
 
     @Override
     public void close() {
-        if (native_ptr() != 0) {
+        if (!isNull()) {
             hostResolverRelease(release());
         }
+        super.close();
     }
 
     /*******************************************************************************

--- a/src/main/java/software/amazon/awssdk/crt/io/SocketOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/SocketOptions.java
@@ -14,16 +14,14 @@
  */
 package software.amazon.awssdk.crt.io;
 
-import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.CrtResource;
-
-import java.io.Closeable;
+import software.amazon.awssdk.crt.CrtRuntimeException;
 
 /**
  * This class wraps the aws_socket_options from aws-c-io to provide
  * access to TCP/UDP socket configuration in the AWS Common Runtime.
  */
-public final class SocketOptions extends CrtResource implements Closeable {
+public final class SocketOptions extends CrtResource {
 
     /**
      * Socket communications domain
@@ -90,9 +88,10 @@ public final class SocketOptions extends CrtResource implements Closeable {
      */
     @Override
     public void close() {
-        if (native_ptr() != 0) {
+        if (!isNull()) {
             socketOptionsDestroy(release());
         }
+        super.close();
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContext.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContext.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.crt.CrtRuntimeException;
 public final class TlsContext extends CrtResource {
 
     /**
-     * Creates a new TlsContext. There are significant native resources consumed to create a TlsContext, so most
+     * Creates a new Client TlsContext. There are significant native resources consumed to create a TlsContext, so most
      * applications will only need to create one and re-use it for all connections.
      * @param options A set of options for this context
      * @throws CrtRuntimeException If the provided options are malformed or the system is unable
@@ -32,6 +32,14 @@ public final class TlsContext extends CrtResource {
      */
     public TlsContext(TlsContextOptions options) throws CrtRuntimeException {
         acquire(tlsContextNew(options.native_ptr()));
+    }
+
+    /**
+     * Creates a new Client TlsContext. There are significant native resources consumed to create a TlsContext, so most
+     * applications will only need to create one and re-use it for all connections.
+     */
+    public TlsContext() throws CrtRuntimeException  {
+        acquire(tlsContextNew(own(new TlsContextOptions()).native_ptr()));
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContext.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContext.java
@@ -14,16 +14,14 @@
  */
 package software.amazon.awssdk.crt.io;
 
-import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.CrtResource;
-
-import java.io.Closeable;
+import software.amazon.awssdk.crt.CrtRuntimeException;
 
 /**
  * This class wraps the aws_tls_context from aws-c-io to provide
  * access to TLS configuration contexts in the AWS Common Runtime.
  */
-public final class TlsContext extends CrtResource implements Closeable {
+public final class TlsContext extends CrtResource {
 
     /**
      * Creates a new TlsContext. There are significant native resources consumed to create a TlsContext, so most
@@ -41,9 +39,10 @@ public final class TlsContext extends CrtResource implements Closeable {
      */
     @Override
     public void close() {
-        if (native_ptr() != 0) {
+        if (!isNull()) {
             tlsContextDestroy(release());
         }
+        super.close();
     }
 
     /*******************************************************************************

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -14,16 +14,14 @@
  */
 package software.amazon.awssdk.crt.io;
 
-import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.CrtResource;
-
-import java.io.Closeable;
+import software.amazon.awssdk.crt.CrtRuntimeException;
 
 /**
  * This class wraps the aws_tls_connection_options from aws-c-io to provide
  * access to TLS configuration contexts in the AWS Common Runtime.
  */
-public final class TlsContextOptions extends CrtResource implements Closeable {
+public final class TlsContextOptions extends CrtResource {
 
     public enum TlsVersions {
         /**
@@ -70,9 +68,10 @@ public final class TlsContextOptions extends CrtResource implements Closeable {
      */
     @Override
     public void close() {
-        if (native_ptr() != 0) {
+        if (!isNull()) {
             tlsContextOptionsDestroy(release());
         }
+        super.close();
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttClient.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttClient.java
@@ -15,12 +15,10 @@
  */
 package software.amazon.awssdk.crt.mqtt;
 
-import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.io.TlsContext;
-
-import java.io.Closeable;
 
 /**
  * This class wraps aws-c-mqtt to provide the basic MQTT pub/sub functionalities
@@ -29,7 +27,7 @@ import java.io.Closeable;
  * One MqttClient class is needed per application. It can create any number of connections to
  * any number of MQTT endpoints
  */
-public class MqttClient extends CrtResource implements Closeable {
+public class MqttClient extends CrtResource {
     private final ClientBootstrap bootstrap;
     private final TlsContext tlsContext;
 
@@ -67,9 +65,10 @@ public class MqttClient extends CrtResource implements Closeable {
      */
     @Override
     public void close() {
-        if (native_ptr() != 0) {
+        if (!isNull()) {
             mqttClientDestroy(release());
         }
+        super.close();
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnection.java
@@ -16,15 +16,14 @@
 package software.amazon.awssdk.crt.mqtt;
 
 import software.amazon.awssdk.crt.AsyncCallback;
-import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsContext;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.nio.ByteBuffer;
-import java.io.Closeable;
 
 /**
  * This class wraps aws-c-mqtt to provide the basic MQTT pub/sub
@@ -33,7 +32,7 @@ import java.io.Closeable;
  * MqttConnection represents a single connection from one MqttClient to an MQTT
  * service endpoint
  */
-public class MqttConnection extends CrtResource implements Closeable {
+public class MqttConnection extends CrtResource {
     private final MqttClient client;
     private volatile ConnectionState connectionState = ConnectionState.DISCONNECTED;
     private MqttConnectionEvents userConnectionCallbacks;
@@ -100,6 +99,7 @@ public class MqttConnection extends CrtResource implements Closeable {
     public void close() {
         disconnect();
         mqttConnectionDestroy(release());
+        super.close();
     }
 
     /**
@@ -222,7 +222,7 @@ public class MqttConnection extends CrtResource implements Closeable {
      */
     public CompletableFuture<Void> disconnect() {
         CompletableFuture<Void> future = new CompletableFuture<>();
-        if (native_ptr() == 0) {
+        if (isNull()) {
             future.complete(null);
             return future;
         }
@@ -241,7 +241,7 @@ public class MqttConnection extends CrtResource implements Closeable {
      */
     public CompletableFuture<Integer> subscribe(String topic, QualityOfService qos, Consumer<MqttMessage> handler) {
         CompletableFuture<Integer> future = new CompletableFuture<>();
-        if (native_ptr() == 0) {
+        if (isNull()) {
             future.completeExceptionally(new MqttException("Invalid connection during subscribe"));
             return future;
         }
@@ -265,7 +265,7 @@ public class MqttConnection extends CrtResource implements Closeable {
      */
     public CompletableFuture<Integer> unsubscribe(String topic) {
         CompletableFuture<Integer> future = new CompletableFuture<>();
-        if (native_ptr() == 0) {
+        if (isNull()) {
             future.completeExceptionally(new MqttException("Invalid connection during unsubscribe"));
             return future;
         }
@@ -285,7 +285,7 @@ public class MqttConnection extends CrtResource implements Closeable {
      */
     public CompletableFuture<Integer> publish(MqttMessage message, QualityOfService qos, boolean retain) {
         CompletableFuture<Integer> future = new CompletableFuture<>();
-        if (native_ptr() == 0) {
+        if (isNull()) {
             future.completeExceptionally(new MqttException("Invalid connection during publish"));
         }
 
@@ -310,7 +310,7 @@ public class MqttConnection extends CrtResource implements Closeable {
      * @throws MqttException If the connection is already connected, or is otherwise unable to set the will
      */
     public void setWill(MqttMessage message, QualityOfService qos, boolean retain) throws MqttException {
-        if (native_ptr() == 0) {
+        if (isNull()) {
             throw new MqttException("Invalid connection during setWill");
         }
 
@@ -327,7 +327,7 @@ public class MqttConnection extends CrtResource implements Closeable {
      * @throws MqttException If the connection is not connected, or the ping operation is otherwise unable to be attempted
      */
     public void ping() throws MqttException {
-        if (native_ptr() == 0) {
+        if (isNull()) {
             throw new MqttException("Invalid connection during ping");
         }
         try {

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -86,10 +86,12 @@ static void s_cache_jni_classes(JNIEnv *env) {
     extern void s_cache_mqtt_connection(JNIEnv *);
     extern void s_cache_message_handler(JNIEnv *);
     extern void s_cache_mqtt_exception(JNIEnv *);
+    extern void s_cache_http_connection(JNIEnv *);
     s_cache_mqtt_connection(env);
     s_cache_async_callback(env);
     s_cache_message_handler(env);
     s_cache_mqtt_exception(env);
+    s_cache_http_connection(env);
 }
 #if defined(_MSC_VER)
 #    pragma warning(pop)

--- a/src/native/http_connection.c
+++ b/src/native/http_connection.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <crt.h>
+#include <jni.h>
+#include <string.h>
+
+#include <aws/common/condition_variable.h>
+#include <aws/common/mutex.h>
+#include <aws/common/string.h>
+#include <aws/common/thread.h>
+
+#include <aws/io/channel.h>
+#include <aws/io/channel_bootstrap.h>
+#include <aws/io/event_loop.h>
+#include <aws/io/host_resolver.h>
+#include <aws/io/logging.h>
+#include <aws/io/socket.h>
+#include <aws/io/socket_channel_handler.h>
+#include <aws/io/tls_channel_handler.h>
+
+#include <aws/http/connection.h>
+#include <aws/http/http.h>
+#include <aws/http/request_response.h>
+
+/*******************************************************************************
+ * JNI class field/method maps
+ ******************************************************************************/
+
+/* methods of HttpConnection.AsyncCallback */
+static struct {
+    jmethodID on_success;
+    jmethodID on_failure;
+} s_async_callback = {0};
+
+void s_cache_http_async_callback(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/AsyncCallback");
+    assert(cls);
+    s_async_callback.on_success = (*env)->GetMethodID(env, cls, "onSuccess", "()V");
+    assert(s_async_callback.on_success);
+    s_async_callback.on_failure = (*env)->GetMethodID(env, cls, "onFailure", "(Ljava/lang/Throwable;)V");
+    assert(s_async_callback.on_failure);
+}
+
+/* methods of HttpConnection */
+static struct {
+    jmethodID on_connection_complete;
+    jmethodID on_connection_shutdown;
+} s_http_connection;
+
+void s_cache_http_connection(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/http/HttpConnection");
+    assert(cls);
+    s_http_connection.on_connection_complete = (*env)->GetMethodID(env, cls, "onConnectionComplete", "(I)V");
+    assert(s_http_connection.on_connection_complete);
+
+    s_http_connection.on_connection_shutdown = (*env)->GetMethodID(env, cls, "onConnectionShutdown", "(I)V");
+    assert(s_http_connection.on_connection_shutdown);
+}
+
+/*******************************************************************************
+ * http_jni_connection - represents an aws_http_connection to Java
+ ******************************************************************************/
+struct http_jni_connection {
+    struct aws_http_connection *native_http_conn;
+    struct aws_socket_options *socket_options;
+    struct aws_tls_connection_options *tls_options;
+
+    JavaVM *jvm;
+    jobject java_http_conn; /* The Java HttpConnection instance */
+};
+
+/* on 32-bit platforms, casting pointers to longs throws a warning we don't need */
+#if UINTPTR_MAX == 0xffffffff
+#    if defined(_MSC_VER)
+#        pragma warning(push)
+#        pragma warning(disable : 4305) /* 'type cast': truncation from 'jlong' to 'jni_tls_ctx_options *' */
+#    else
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
+#        pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
+#    endif
+#endif
+
+static void s_on_http_conn_setup(struct aws_http_connection *connection, int error_code, void *user_data) {
+    struct http_jni_connection *http_jni_conn = (struct http_jni_connection *)user_data;
+    assert(http_jni_conn);
+
+    // Save the native pointer
+    http_jni_conn->native_http_conn = connection;
+
+    assert(s_http_connection.on_connection_complete);
+    assert(http_jni_conn->java_http_conn);
+    // Call the Java Object's "onComplete" callback
+    if (http_jni_conn->java_http_conn) {
+        JNIEnv *env = aws_jni_get_thread_env(http_jni_conn->jvm);
+        (*env)->CallVoidMethod(
+            env, http_jni_conn->java_http_conn, s_http_connection.on_connection_complete, error_code);
+    }
+}
+
+static void s_on_http_conn_shutdown(struct aws_http_connection *connection, int error_code, void *user_data) {
+    struct http_jni_connection *http_jni_conn = (struct http_jni_connection *)user_data;
+
+    // Call the Java Object's "onShutdown" callback
+    if (http_jni_conn->java_http_conn) {
+        JNIEnv *env = aws_jni_get_thread_env(http_jni_conn->jvm);
+        (*env)->CallVoidMethod(
+            env, http_jni_conn->java_http_conn, s_http_connection.on_connection_shutdown, error_code);
+    }
+}
+
+/**
+ * Create a new aws_http_request_options struct with default values
+ */
+JNIEXPORT long JNICALL Java_software_amazon_awssdk_crt_http_HttpConnection_httpConnectionNew(
+    JNIEnv *env,
+    jclass jni_class,
+    jobject http_conn_jobject,
+    jlong jni_client_bootstrap,
+    jlong jni_socket_options,
+    jlong jni_tls_ctx,
+    jstring jni_endpoint,
+    jint jni_port) {
+
+    struct aws_client_bootstrap *client_bootstrap = (struct aws_client_bootstrap *)jni_client_bootstrap;
+    struct aws_socket_options *socket_options = (struct aws_socket_options *)jni_socket_options;
+    struct aws_tls_ctx *tls_ctx = (struct aws_tls_ctx *)jni_tls_ctx;
+
+    if (!client_bootstrap) {
+        aws_jni_throw_runtime_exception(env, "ClientBootstrap can't be null");
+        return (jlong)NULL;
+    }
+
+    if (!socket_options) {
+        aws_jni_throw_runtime_exception(env, "SocketOptions can't be null");
+        return (jlong)NULL;
+    }
+
+    struct aws_allocator *allocator = aws_jni_get_allocator();
+    struct aws_byte_cursor endpoint = aws_jni_byte_cursor_from_jstring(env, jni_endpoint);
+
+    if (jni_port <= 0 || 65535 < jni_port) {
+        aws_jni_throw_runtime_exception(env, "Port must be between 1 and 65535");
+        return (jlong)NULL;
+    }
+
+    uint16_t port = (uint16_t)jni_port;
+
+    int use_tls = (jni_tls_ctx != 0);
+
+    struct aws_tls_connection_options tls_conn_options = {0};
+
+    if (use_tls) {
+        aws_tls_connection_options_init_from_ctx(&tls_conn_options, tls_ctx);
+        aws_tls_connection_options_set_server_name(&tls_conn_options, allocator, &endpoint);
+    }
+
+    /* any error after this point needs to jump to error_cleanup */
+    struct http_jni_connection *http_jni_conn = aws_mem_acquire(allocator, sizeof(struct http_jni_connection));
+    if (!http_jni_conn) {
+        aws_jni_throw_runtime_exception(env, "Out of memory allocating JNI connection");
+        goto error_cleanup;
+    }
+
+    // Create a new reference to the HttpConnection Object.
+    http_jni_conn->java_http_conn = (*env)->NewGlobalRef(env, http_conn_jobject);
+
+    // GetJavaVM() reference doesn't need a NewGlobalRef() call since it's global by default
+    jint jvmresult = (*env)->GetJavaVM(env, &http_jni_conn->jvm);
+    (void)jvmresult;
+    assert(jvmresult == 0);
+
+    struct aws_http_client_connection_options http_options = AWS_HTTP_CLIENT_CONNECTION_OPTIONS_INIT;
+    http_options.self_size = sizeof(struct aws_http_client_connection_options);
+    http_options.allocator = allocator;
+    http_options.bootstrap = client_bootstrap;
+    http_options.host_name = endpoint;
+    http_options.port = port;
+    http_options.socket_options = socket_options;
+    http_options.tls_options = NULL;
+    http_options.user_data = http_jni_conn;
+    http_options.on_setup = s_on_http_conn_setup;
+    http_options.on_shutdown = s_on_http_conn_shutdown;
+
+    if (use_tls) {
+        http_options.tls_options = &tls_conn_options;
+    }
+
+    int rc = aws_http_client_connect(&http_options);
+
+    if (use_tls) {
+        aws_tls_connection_options_clean_up(&tls_conn_options);
+    }
+
+    if (rc != AWS_OP_SUCCESS) {
+        aws_jni_throw_runtime_exception(env, "There was an error calling aws_http_client_connect()");
+    }
+
+    return (jlong)http_jni_conn;
+
+error_cleanup:
+    if (http_jni_conn) {
+        aws_mem_release(allocator, http_jni_conn);
+    }
+
+    return (jlong)NULL;
+}
+
+JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpConnection_httpConnectionShutdown(
+    JNIEnv *env,
+    jclass jni_class,
+    jlong jni_connection) {
+
+    struct http_jni_connection *http_jni_conn = (struct http_jni_connection *)jni_connection;
+    aws_http_connection_close(http_jni_conn->native_http_conn);
+}
+
+JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpConnection_httpConnectionRelease(
+    JNIEnv *env,
+    jclass jni_class,
+    jlong jni_connection) {
+
+    struct http_jni_connection *http_jni_conn = (struct http_jni_connection *)jni_connection;
+    if (http_jni_conn->java_http_conn) {
+        // Delete our reference to the HttpConnection Object from the JVM.
+        (*env)->DeleteGlobalRef(env, http_jni_conn->java_http_conn);
+        http_jni_conn->java_http_conn = NULL;
+    }
+    if (http_jni_conn->native_http_conn) {
+        aws_http_connection_release(http_jni_conn->native_http_conn);
+    }
+
+    struct aws_allocator *allocator = aws_jni_get_allocator();
+    aws_mem_release(allocator, http_jni_conn);
+}
+
+#if UINTPTR_MAX == 0xffffffff
+#    if defined(_MSC_VER)
+#        pragma warning(pop)
+#    else
+#        pragma GCC diagnostic pop
+#    endif
+#endif

--- a/src/test/java/software/amazon/awssdk/crt/test/EventLoopGroupTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/EventLoopGroupTest.java
@@ -30,7 +30,7 @@ public class EventLoopGroupTest {
     public void testCreateDestroy() {
         try (EventLoopGroup elg = new EventLoopGroup(1)) {
             assertNotNull(elg);
-            assertTrue(elg.native_ptr() != 0);
+            assertTrue(!elg.isNull());
         } catch (CrtRuntimeException ex) {
             fail(ex.getMessage());
         }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpConnectionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.crt.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.http.HttpConnection;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+
+import java.net.URI;
+
+public class HttpConnectionTest {
+
+    protected void testConnection(URI uri, boolean expectConnected, String exceptionMsg) throws CrtRuntimeException {
+        boolean actuallyConnected = false;
+        boolean exceptionThrown = false;
+
+        ClientBootstrap bootstrap = new ClientBootstrap(1);
+        SocketOptions sockOpts = new SocketOptions();
+        TlsContext tlsContext =  new TlsContext();
+
+        try {
+            HttpConnection conn = HttpConnection.createConnection(uri, bootstrap, sockOpts, tlsContext).get();
+            actuallyConnected = true;
+            conn.shutdown().get();
+            conn.close();
+        } catch (Exception e) {
+            exceptionThrown = true;
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains(exceptionMsg));
+        } finally {
+            tlsContext.close();
+            sockOpts.close();
+            bootstrap.close();
+        }
+
+        Assert.assertEquals("URI: " + uri.toString(), expectConnected, actuallyConnected);
+        Assert.assertEquals("URI: " + uri.toString(), expectConnected, !exceptionThrown);
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
+    }
+
+    @Test
+    public void testHttpConnection() throws Exception {
+        testConnection(new URI("https://aws-crt-test-stuff.s3.amazonaws.com"), true, null);
+        testConnection(new URI("http://aws-crt-test-stuff.s3.amazonaws.com"), true, null);
+        testConnection(new URI("http://aws-crt-test-stuff.s3.amazonaws.com:80"), true, null);
+        testConnection(new URI("http://aws-crt-test-stuff.s3.amazonaws.com:443"), true, null);
+        testConnection(new URI("https://aws-crt-test-stuff.s3.amazonaws.com:443"), true, null);
+        testConnection(new URI("https://rsa2048.badssl.com/"), true, null);
+        testConnection(new URI("http://http.badssl.com/"), true, null);
+        testConnection(new URI("https://expired.badssl.com/"), false, "TLS (SSL) negotiation failed");
+        testConnection(new URI("https://self-signed.badssl.com/"), false, "TLS (SSL) negotiation failed");
+    }
+}

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttConnectionTest.java
@@ -117,7 +117,7 @@ class MqttConnectionFixture {
             tls = new TlsContext(tlsOptions);
             client = new MqttClient(bootstrap, tls);
             assertNotNull(client);
-            assertTrue(client.native_ptr() != 0);
+            assertTrue(!client.isNull());
 
             MqttConnectionEvents events = new MqttConnectionEvents(){
                 @Override


### PR DESCRIPTION
### Note: This PR builds on top of https://github.com/awslabs/aws-crt-java/pull/55, please merge that PR first.

## Issue #, if available:
N/A

## Description of changes:
Adds Integration with `aws-c-http` library for Http connection open and close API's, and adds Unit Tests that confirms connections are opened and closed. 

This Pull Request does **NOT** integrate with the Http request/response API yet, that will be added in a later PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
