### PR TITLE
Add Status Code API to HttpStream

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/http/HttpStream.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpStream.java
@@ -51,6 +51,15 @@ public class HttpStream extends CrtResource {
         httpStreamIncrementWindow(native_ptr(), windowSize);
     }
 
+    /**
+     * Retrieves the Http Response Status Code
+     * @return The Http Response Status Code
+     */
+    public int getResponseStatusCode() {
+        return httpStreamGetResponseStatusCode(native_ptr());
+    }
+
     private static native void httpStreamRelease(long http_stream);
     private static native void httpStreamIncrementWindow(long http_stream, int window_size);
+    private static native int  httpStreamGetResponseStatusCode(long http_stream);
 }

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -507,6 +507,29 @@ JNIEXPORT void JNICALL
     aws_http_stream_release(stream);
 }
 
+JNIEXPORT jint JNICALL Java_software_amazon_awssdk_crt_http_HttpStream_httpStreamGetResponseStatusCode(
+    JNIEnv *env,
+    jclass jni_class,
+    jlong jni_stream) {
+
+    struct aws_http_stream *stream = (struct aws_http_stream *)jni_stream;
+
+    if (stream == NULL) {
+        aws_jni_throw_runtime_exception(env, "HttpStream is null.");
+        return -1;
+    }
+
+    int status = -1;
+    int err_code = aws_http_stream_get_incoming_response_status(stream, &status);
+
+    if (err_code != AWS_OP_SUCCESS) {
+        aws_jni_throw_runtime_exception(env, "Error Getting Response Status Code from HttpStream.");
+        return -1;
+    }
+
+    return (jint)status;
+}
+
 JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpStream_httpStreamIncrementWindow(
     JNIEnv *env,
     jclass jni_class,

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -118,6 +118,7 @@ public class HttpRequestResponseTest {
                 @Override
                 public void onResponseHeaders(HttpStream stream, int responseStatusCode, HttpHeader[] nextHeaders) {
                     response.statusCode = responseStatusCode;
+                    Assert.assertEquals(responseStatusCode, stream.getResponseStatusCode());
                     response.headers.addAll(Arrays.asList(nextHeaders));
                 }
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Added `getResponseStatusCode()` method to `HttpStream` since otherwise there's no way to get the Http status code if there are zero headers in the response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
