### PR TITLE
CrtRuntimeException should be a RuntimeException

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CrtRuntimeException.java
+++ b/src/main/java/software/amazon/awssdk/crt/CrtRuntimeException.java
@@ -18,7 +18,7 @@ package software.amazon.awssdk.crt;
  * This exception will be thrown by any exceptional cases encountered within
  * the JNI bindings to the AWS Common Runtime
  */
-public class CrtRuntimeException extends Exception {
+public class CrtRuntimeException extends RuntimeException {
     CrtRuntimeException(String msg) {
         super(msg);
     }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Previously `CrtRuntimeException` was actually a Checked Exception, this change makes it a Runtime Exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
