### PR TITLE
 Add Java TLS Cipher API 

### DIFF
--- a/aws-common-runtime/CMakeLists.txt
+++ b/aws-common-runtime/CMakeLists.txt
@@ -30,7 +30,7 @@ if (UNIX AND NOT APPLE)
 endif()
 
 set(AWS_C_IO_URL "https://github.com/awslabs/aws-c-io.git")
-set(AWS_C_IO_SHA "v0.4.1")
+set(AWS_C_IO_SHA "v0.4.2")
 include(BuildAwsCIO)
 
 set(AWS_C_COMPRESSION_URL "https://github.com/awslabs/aws-c-compression.git")
@@ -42,7 +42,7 @@ set(AWS_C_MQTT_SHA "v0.4.1")
 include(BuildAwsCMqtt)
 
 set(AWS_C_HTTP_URL "https://github.com/awslabs/aws-c-http.git")
-set(AWS_C_HTTP_SHA "v0.3.2")
+set(AWS_C_HTTP_SHA "v0.3.3")
 include(BuildAwsCHttp)
 
 add_dependencies(AwsCCompression AwsCCommon)

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.crt.io;
+
+public enum TlsCipherPreference {
+    /**
+     * Use whatever the System Default Preference is. This is usually the best option, as it will be automatically
+     * updated as the underlying OS or platform changes.
+     */
+    TLS_CIPHER_SYSTEM_DEFAULT(0),
+
+    /**
+     * Contains Draft Hybrid TLS Ciphers: https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
+     *
+     * These ciphers perform two Key Exchanges (1 ECDHE + 1 Post-Quantum) during the TLS Handshake in order to
+     * combine the security of Classical ECDHE Key Exchange with the conjectured quantum-resistance of newly
+     * proposed key exchanges.
+     *
+     * The algorithms these new Post-Quantum ciphers are based on have been submitted to NIST's Post-Quantum Crypto
+     * Standardization Process, and are still under review.
+     *
+     * This Cipher Preference may stop being supported at any time.
+     */
+    TLS_CIPHER_KMS_PQ_TLSv1_0_2019_06(1);
+
+    private int val;
+
+    TlsCipherPreference(int val) {
+        this.val = val;
+    }
+
+    int getValue() { return val; }
+}

--- a/src/native/tls_options.c
+++ b/src/native/tls_options.c
@@ -158,6 +158,31 @@ void JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpti
 }
 
 JNIEXPORT
+void JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOptionsSetCipherPreference(
+    JNIEnv *env,
+    jclass jni_class,
+    jlong jni_tls,
+    jint jni_cipher_pref) {
+
+    (void)jni_class;
+    struct jni_tls_ctx_options *tls = (struct jni_tls_ctx_options *)jni_tls;
+
+    if (!tls) {
+        return;
+    }
+
+    if (jni_cipher_pref < 0 || AWS_IO_TLS_CIPHER_PREF_END_RANGE <= jni_cipher_pref) {
+        aws_jni_throw_runtime_exception(
+            env,
+            "TlsContextOptions.tlsContextOptionsSetCipherPreference: TlsCipherPreference is out of range: %d",
+            (int)jni_cipher_pref);
+        return;
+    }
+
+    tls->options.cipher_pref = (enum aws_tls_cipher_pref)jni_cipher_pref;
+}
+
+JNIEXPORT
 void JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOptionsInitMTLSFromPath(
     JNIEnv *env,
     jclass jni_class,
@@ -241,6 +266,26 @@ jboolean JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContext
     (void)env;
     (void)jni_class;
     return aws_tls_is_alpn_available();
+}
+
+JNIEXPORT
+jboolean JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOptionsIsCipherPreferenceSupported(
+    JNIEnv *env,
+    jclass jni_class,
+    jint jni_cipher_pref) {
+
+    (void)env;
+    (void)jni_class;
+
+    if (jni_cipher_pref < 0 || AWS_IO_TLS_CIPHER_PREF_END_RANGE <= jni_cipher_pref) {
+        aws_jni_throw_runtime_exception(
+            env,
+            "TlsContextOptions.tlsContextOptionsSetCipherPreference: TlsCipherPreference is out of range: %d",
+            (int)jni_cipher_pref);
+        return false;
+    }
+
+    return aws_tls_is_cipher_pref_supported((enum aws_tls_cipher_pref)jni_cipher_pref);
 }
 
 #if UINTPTR_MAX == 0xffffffff

--- a/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
@@ -1,0 +1,46 @@
+package software.amazon.awssdk.crt.test;
+
+import static software.amazon.awssdk.crt.io.TlsContextOptions.TlsVersions;
+
+import org.junit.Assert;
+import org.junit.Test;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.TlsCipherPreference;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
+
+public class TlsContextOptionsTest {
+
+    @Test
+    public void testTlsContextOptionsAPI() {
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
+
+        TlsContextOptions options = new TlsContextOptions();
+
+        for (TlsVersions tlsVersion: TlsContextOptions.TlsVersions.values()) {
+            options.setMinimumTlsVersion(tlsVersion);
+        }
+
+        options.setMinimumTlsVersion(TlsVersions.TLS_VER_SYS_DEFAULTS);
+
+        for (TlsCipherPreference pref: TlsCipherPreference.values()) {
+            if (TlsContextOptions.isCipherPreferenceSupported(pref)) {
+                options.setCipherPreference(pref);
+            }
+        }
+
+        boolean exceptionThrown = false;
+
+        try {
+            options.setCipherPreference(TlsCipherPreference.TLS_CIPHER_KMS_PQ_TLSv1_0_2019_06);
+            options.setMinimumTlsVersion(TlsVersions.TLSv1_2);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+            exceptionThrown = true;
+        }
+
+        Assert.assertTrue(exceptionThrown);
+
+        options.close();
+        Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
+    }
+}


### PR DESCRIPTION
**Note: This PR builds on top of two other PR's, and will fail to build until both of these are merged:**
 - [awslabs/aws-crt-java#73](https://github.com/awslabs/aws-crt-java/pull/73 )
 - [https://github.com/awslabs/aws-c-io/pull/161](https://github.com/awslabs/aws-c-io/pull/161)

*Issue #, if available:* N/A

*Description of changes:*
Adds API's to configure TLS Cipher. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
