### PR TITLE
Bump aws-c-io to version with Cert CA Loading Fix

### DIFF
--- a/aws-common-runtime/CMakeLists.txt
+++ b/aws-common-runtime/CMakeLists.txt
@@ -30,7 +30,7 @@ if (UNIX AND NOT APPLE)
 endif()
 
 set(AWS_C_IO_URL "https://github.com/awslabs/aws-c-io.git")
-set(AWS_C_IO_SHA "v0.4.3")
+set(AWS_C_IO_SHA "v0.4.4")
 include(BuildAwsCIO)
 
 set(AWS_C_COMPRESSION_URL "https://github.com/awslabs/aws-c-compression.git")


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Bump aws-c-io to version with Cert CA Loading Fix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
