### PR TITLE
Fix Bug that caused empty Http Headers to be returned to user

### DIFF
--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -123,7 +123,7 @@ struct aws_byte_cursor aws_jni_byte_cursor_from_jbyteArray(JNIEnv *env, jbyteArr
 jbyteArray aws_jni_byte_array_from_cursor(JNIEnv *env, const struct aws_byte_cursor *native_data) {
     jbyteArray jArray = aws_java_byte_array_new(env, native_data->len);
     if (jArray) {
-        if (aws_copy_native_array_to_java_byte_array(env, jArray, native_data->ptr, native_data->len)) {
+        if (!aws_copy_native_array_to_java_byte_array(env, jArray, native_data->ptr, native_data->len)) {
             return jArray;
         }
     }

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -308,6 +308,7 @@ static int s_on_incoming_headers_fn(
     JNIEnv *env = aws_jni_get_thread_env(callback->jvm);
     jobjectArray jHeaders = s_java_headers_array_from_native(user_data, header_array, num_headers);
     if (!jHeaders) {
+        AWS_LOGF_ERROR(AWS_LS_HTTP_STREAM, "id=%p: Failed to create HttpHeaders", (void *)stream);
         return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
     }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -217,6 +217,14 @@ public class HttpRequestResponseTest {
             response = getResponse(uri, request, requestBody);
         } while (shouldRetry(response) && numAttempts < 3);
 
+        boolean hasContentLengthHeader = false;
+        for (HttpHeader h: response.headers) {
+            if (h.getName().equals("Content-Length")) {
+                hasContentLengthHeader = true;
+            }
+        }
+
+        Assert.assertTrue(hasContentLengthHeader);
         Assert.assertEquals("Expected and Actual Status Codes don't match", expectedStatus, response.statusCode);
 
         return response;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Fixes bug introduced in https://github.com/awslabs/aws-crt-java/pull/77 that causes all HttpHeader Names and Values returned to the user to be empty.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
