### PR TITLE
Add Bindings for ConnManger onShutdownComplete()

### DIFF
--- a/aws-common-runtime/CMakeLists.txt
+++ b/aws-common-runtime/CMakeLists.txt
@@ -30,7 +30,7 @@ if (UNIX AND NOT APPLE)
 endif()
 
 set(AWS_C_IO_URL "https://github.com/awslabs/aws-c-io.git")
-set(AWS_C_IO_SHA "v0.4.5")
+set(AWS_C_IO_SHA "v0.4.6")
 include(BuildAwsCIO)
 
 set(AWS_C_COMPRESSION_URL "https://github.com/awslabs/aws-c-compression.git")
@@ -42,7 +42,7 @@ set(AWS_C_MQTT_SHA "v0.4.3")
 include(BuildAwsCMqtt)
 
 set(AWS_C_HTTP_URL "https://github.com/awslabs/aws-c-http.git")
-set(AWS_C_HTTP_SHA "v0.4.2")
+set(AWS_C_HTTP_SHA "v0.4.3")
 include(BuildAwsCHttp)
 
 add_dependencies(AwsCCompression AwsCCommon)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Fixes Race Condition between `HttpConnectionManager.close()` and `ClientBootstrap.close()` that could result in a Segfault. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
