### PR TITLE
Network tests now check for the NETWORK_TESTS_DISABLED property

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/HttpConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpConnectionManagerTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtResource;
@@ -131,6 +132,7 @@ public class HttpConnectionManagerTest {
 
     @Test
     public void testParallelRequests() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
 
         URI uri = new URI(endpoint);
@@ -148,6 +150,7 @@ public class HttpConnectionManagerTest {
 
     @Test
     public void connPoolParallelRequestMemLeakCheck() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         Callable<Void> fn = () -> { testParallelRequests(); return null; };
         CrtMemoryLeakDetector.leakCheck(fn);
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.crt.test;
 import static software.amazon.awssdk.crt.utils.ByteBufferUtils.transferData;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtResource;
@@ -47,7 +48,6 @@ public class HttpRequestResponseTest {
     private final static Charset UTF8 = StandardCharsets.UTF_8;
     private final String EMPTY_BODY = "";
     private final static String TEST_DOC_LINE = "This is a sample to prove that http downloads and uploads work. It doesn't really matter what's in here, we mainly just need to verify the downloads and uploads work.";
-    private final static int TEST_DOC_NUM_LINES = 86401;
     private final static String TEST_DOC_SHA256 = "C7FDB5314B9742467B16BD5EA2F8012190B5E2C44A005F7984F89AAB58219534";
 
     private class TestHttpResponse {
@@ -232,6 +232,7 @@ public class HttpRequestResponseTest {
 
     @Test
     public void testHttpDelete() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         testRequest("DELETE", "https://httpbin.org", "/delete", EMPTY_BODY, 200);
         testRequest("DELETE", "https://httpbin.org", "/get", EMPTY_BODY, 405);
         testRequest("DELETE", "https://httpbin.org", "/post", EMPTY_BODY, 405);
@@ -240,6 +241,7 @@ public class HttpRequestResponseTest {
 
     @Test
     public void testHttpGet() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         testRequest("GET", "https://httpbin.org", "/delete", EMPTY_BODY, 405);
         testRequest("GET", "https://httpbin.org", "/get", EMPTY_BODY, 200);
         testRequest("GET", "https://httpbin.org", "/post", EMPTY_BODY, 405);
@@ -248,6 +250,7 @@ public class HttpRequestResponseTest {
 
     @Test
     public void testHttpPost() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         testRequest("POST", "https://httpbin.org", "/delete", EMPTY_BODY, 405);
         testRequest("POST", "https://httpbin.org", "/get", EMPTY_BODY, 405);
         testRequest("POST", "https://httpbin.org", "/post", EMPTY_BODY, 200);
@@ -256,6 +259,7 @@ public class HttpRequestResponseTest {
 
     @Test
     public void testHttpPut() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         testRequest("PUT", "https://httpbin.org", "/delete", EMPTY_BODY, 405);
         testRequest("PUT", "https://httpbin.org", "/get", EMPTY_BODY, 405);
         testRequest("PUT", "https://httpbin.org", "/post", EMPTY_BODY, 405);
@@ -264,6 +268,7 @@ public class HttpRequestResponseTest {
 
     @Test
     public void testHttpResponseStatusCodes() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         testRequest("GET", "https://httpbin.org", "/status/200", EMPTY_BODY, 200);
         testRequest("GET", "https://httpbin.org", "/status/300", EMPTY_BODY, 300);
         testRequest("GET", "https://httpbin.org", "/status/400", EMPTY_BODY, 400);
@@ -272,6 +277,7 @@ public class HttpRequestResponseTest {
 
     @Test
     public void testHttpDownload() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         TestHttpResponse response = testRequest("GET", "https://aws-crt-test-stuff.s3.amazonaws.com", "/http_test_doc.txt", EMPTY_BODY, 200);
 
         ByteBuffer body = response.bodyBuffer;
@@ -294,6 +300,7 @@ public class HttpRequestResponseTest {
 
     @Test
     public void testHttpUpload() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         String bodyToSend = TEST_DOC_LINE;
         TestHttpResponse response = testRequest("PUT", "https://httpbin.org", "/anything", bodyToSend, 200);
 

--- a/src/test/java/software/amazon/awssdk/crt/test/IotServiceTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/IotServiceTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.crt.test;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -41,6 +42,7 @@ public class IotServiceTest extends MqttConnectionFixture {
 
     @Test
     public void testIotService() {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         connect( true, (short)0);
 
         Consumer<MqttMessage> messageHandler = (message) -> {};

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttConnectionTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.crt.test;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -176,6 +177,7 @@ public class MqttConnectionTest extends MqttConnectionFixture {
 
     @Test
     public void testConnectDisconnect() {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         connect();
         disconnect();
         close();

--- a/src/test/java/software/amazon/awssdk/crt/test/PublishTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/PublishTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.crt.test;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
@@ -41,6 +42,7 @@ public class PublishTest extends MqttConnectionFixture {
 
     @Test
     public void testPublish() {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         connect();
         
         try {

--- a/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.crt.test;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
@@ -48,6 +49,7 @@ public class SelfPubSubTest extends MqttConnectionFixture {
 
     @Test
     public void testPubSub() {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         connect();
 
         try {

--- a/src/test/java/software/amazon/awssdk/crt/test/SubscribeTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/SubscribeTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.crt.test;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -42,6 +43,7 @@ public class SubscribeTest extends MqttConnectionFixture {
 
     @Test
     public void testSubscribeUnsubscribe() {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         connect();
 
         Consumer<MqttMessage> messageHandler = (message) -> { };

--- a/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.crt.test;
 import static software.amazon.awssdk.crt.io.TlsContextOptions.TlsVersions;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
@@ -12,6 +13,7 @@ public class TlsContextOptionsTest {
 
     @Test
     public void testTlsContextOptionsAPI() {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         Assert.assertEquals(0, CrtResource.getAllocatedNativeResourceCount());
 
         TlsContextOptions options = new TlsContextOptions();

--- a/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.crt.test;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
@@ -41,6 +42,7 @@ public class WillTest extends MqttConnectionFixture {
 
     @Test
     public void testWill() {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
         connect();
 
         try {


### PR DESCRIPTION
…and skip if it's defined

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
