### PR TITLE
Updated leak detector to separate native/java, threaded conn test

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -158,7 +158,7 @@ public final class CRT {
     }
 
     // Called internally when bootstrapping the CRT, allows native code to do any static initialization it needs
-    private static native void awsCrtInit(int  memoryTracingLevel) throws CrtRuntimeException;
+    private static native void awsCrtInit(int memoryTracingLevel) throws CrtRuntimeException;
 
     /**
      * Given an integer error code from an internal operation

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -131,7 +131,11 @@ public final class CRT {
             // load the shared lib from the temp path
             System.load(libTempPath.toString());
 
-            awsCrtInit(Boolean.parseBoolean(System.getProperty("aws.crt.memory.tracing")));
+            int memoryTracingLevel = 0;
+            try {
+                memoryTracingLevel = Integer.parseInt(System.getProperty("aws.crt.memory.tracing"));
+            } catch (Exception ex) {}
+            awsCrtInit(memoryTracingLevel);
 
             try {
                 Log.initLoggingFromSystemProperties();
@@ -154,7 +158,7 @@ public final class CRT {
     }
 
     // Called internally when bootstrapping the CRT, allows native code to do any static initialization it needs
-    private static native void awsCrtInit(boolean memoryTracingEnabled) throws CrtRuntimeException;
+    private static native void awsCrtInit(int  memoryTracingLevel) throws CrtRuntimeException;
 
     /**
      * Given an integer error code from an internal operation
@@ -164,7 +168,8 @@ public final class CRT {
     public static native String awsErrorString(int errorCode);
 
     /**
-     * @return The number of bytes allocated in native resources
+     * @return The number of bytes allocated in native resources. If aws.crt.memory.tracing > 0, this will
+     *         be a non-zero value. Otherwise, no tracing will be done, and the value will always be 0
      */
     public static long nativeMemory() {
         return awsNativeMemory();

--- a/src/main/java/software/amazon/awssdk/crt/CrtResource.java
+++ b/src/main/java/software/amazon/awssdk/crt/CrtResource.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 import software.amazon.awssdk.crt.Log;
 
@@ -228,14 +229,22 @@ public abstract class CrtResource implements AutoCloseable {
         }
     }
 
+    public static void collectNativeResources(Consumer<String> fn) {
+        for (Map.Entry<Long, String> entry : NATIVE_RESOURCES.entrySet()) {
+            String resource = String.format(" * %s class instance using native pointer %d", entry.getValue(),
+                    entry.getKey().longValue());
+            fn.accept(resource);
+        }
+    }
+
     /**
      * Debug method to log all of the currently un-closed CRTResource objects.
      */
     public static void logNativeResources() {
         Log.log(Log.LogLevel.Trace, Log.LogSubject.JavaCrtResource, "Dumping native object set:");
-        for (Map.Entry<Long, String> entry : NATIVE_RESOURCES.entrySet()) {
-            Log.log(Log.LogLevel.Trace, Log.LogSubject.JavaCrtResource, String.format(" * %s class instance using native pointer %d", entry.getValue(), entry.getKey().longValue()));
-        }
+        collectNativeResources((resource) -> {
+            Log.log(Log.LogLevel.Trace, Log.LogSubject.JavaCrtResource, resource);
+        });
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpHeaderBlock.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpHeaderBlock.java
@@ -16,8 +16,7 @@
 package software.amazon.awssdk.crt.http;
 
 /**
- * Quality of Service associated with a publish action or subscription
- * [MQTT-4.3].
+ * Type of header block
  */
 public enum HttpHeaderBlock {
     

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -45,17 +45,24 @@
 /* 0 = off, 1 = bytes, 2 = stack traces */
 static int s_memory_tracing = 0;
 
+#define ALLOC_TRACING_FRAMES 8
+
 struct alloc_t {
     size_t size;
     time_t time;
-    struct aws_byte_buf stacktrace;
+    uint64_t stack;
+};
+
+struct stacktrace_t {
+    void *const frames[ALLOC_TRACING_FRAMES];
 };
 
 struct alloc_tracker {
     struct aws_allocator *allocator;
     struct aws_atomic_var allocated;
-    struct aws_mutex mutex;
-    struct aws_hash_table allocs;
+    struct aws_mutex mutex;       /* protects everything below */
+    struct aws_hash_table allocs; /* live allocations, maps address -> alloc_t */
+    struct aws_hash_table stacks; /* unique stack traces, maps hash -> stacktrace_t */
 };
 
 static void *s_jni_mem_acquire(struct aws_allocator *allocator, size_t size);
@@ -74,17 +81,39 @@ static struct aws_allocator s_jni_allocator = {
 static void s_destroy_alloc(void *data) {
     struct aws_allocator *allocator = ((struct alloc_tracker *)s_jni_allocator.impl)->allocator;
     struct alloc_t *alloc = data;
-    aws_byte_buf_clean_up(&alloc->stacktrace);
     aws_mem_release(allocator, alloc);
+}
+
+static void s_destroy_stack(void *data) {
+    struct aws_allocator *allocator = ((struct alloc_tracker *)s_jni_allocator.impl)->allocator;
+    struct stacktrace_t *stack = data;
+    aws_mem_release(allocator, stack);
+}
+
+static uint64_t s_stack_hash(const void *item) {
+    uint64_t value = (uint64_t)item;
+    return aws_hash_ptr((void*)value);
+}
+
+static bool s_stack_eq(const void *a, const void *b) {
+    uint64_t va = (uint64_t)a;
+    uint64_t vb = (uint64_t)b;
+    return va == vb;
 }
 
 static void s_alloc_tracker_init(struct alloc_tracker *tracker, struct aws_allocator *allocator) {
     tracker->allocator = allocator;
     aws_atomic_init_int(&tracker->allocated, 0);
     AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_mutex_init(&tracker->mutex));
-    if (aws_hash_table_init(
-            &tracker->allocs, tracker->allocator, 1024, aws_hash_ptr, aws_ptr_eq, NULL, s_destroy_alloc)) {
-        AWS_FATAL_ASSERT(!"FAILED TO INITIALIZE ALLOCATION TRACKER");
+    AWS_FATAL_ASSERT(
+        AWS_OP_SUCCESS ==
+        aws_hash_table_init(
+            &tracker->allocs, tracker->allocator, 1024, aws_hash_ptr, aws_ptr_eq, NULL, s_destroy_alloc));
+    if (s_memory_tracing == 2) {
+        AWS_FATAL_ASSERT(
+            AWS_OP_SUCCESS ==
+            aws_hash_table_init(
+                &tracker->stacks, tracker->allocator, 1024, s_stack_hash, s_stack_eq, NULL, s_destroy_stack));
     }
 }
 
@@ -95,21 +124,22 @@ static void s_alloc_tracker_track(struct alloc_tracker *tracker, void *ptr, size
 
 #if defined(ALLOC_TRACE_AVAILABLE)
     if (s_memory_tracing == 2) {
-        aws_byte_buf_init(&alloc->stacktrace, tracker->allocator, 1600);
-        void *stack_frames[10];
+        /* capture stack frames */
+        void *stack_frames[2 + ALLOC_TRACING_FRAMES];
         int stack_depth = backtrace(stack_frames, AWS_ARRAY_SIZE(stack_frames));
-        char **symbols = backtrace_symbols(stack_frames, stack_depth);
-        struct aws_byte_cursor newline = aws_byte_cursor_from_c_str("\n");
-        for (int idx = 2; idx < stack_depth && idx < 10; ++idx) {
-            if (idx > 2) {
-                aws_byte_buf_append(&alloc->stacktrace, &newline);
-            }
-            const char *caller = symbols[idx];
-            struct aws_byte_cursor cursor = aws_byte_cursor_from_c_str(caller);
-            aws_byte_buf_append(&alloc->stacktrace, &cursor);
+        struct aws_byte_cursor stack_cursor = aws_byte_cursor_from_array(stack_frames, stack_depth * sizeof(void*));
+        /* hash the stack pointers */
+        uint64_t stack_id = aws_hash_byte_cursor_ptr(&stack_cursor);
+        alloc->stack = stack_id; /* associate the stack with the alloc */
+        struct aws_hash_element *item = NULL;
+        int was_created = 0;
+        AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_hash_table_create(&tracker->stacks, (void *)stack_id, &item, &was_created));
+        /* If this is a new stack, save it to the hash */
+        if (was_created) {
+            struct stacktrace_t *stack = aws_mem_calloc(tracker->allocator, 1, sizeof(struct stacktrace_t));
+            memcpy((void **)&stack->frames[0], &stack_frames[2], (stack_depth - 2) * sizeof(void*));
+            item->value = stack;
         }
-
-        free(symbols);
     }
 #endif
 
@@ -130,7 +160,96 @@ static void s_alloc_tracker_untrack(struct alloc_tracker *tracker, void *ptr) {
     s_destroy_alloc(item.value);
 }
 
-static int s_alloc_tracker_each(void *context, struct aws_hash_element *item) {
+#if defined(ALLOC_TRACE_AVAILABLE)
+/* used only to resolve stacks -> trace, count, size at dump time */
+struct stack_info_t {
+    struct aws_string *trace;
+    size_t count;
+    size_t size;
+};
+
+static int s_collect_stack_trace(void *context, struct aws_hash_element *item) {
+    struct aws_hash_table *all_stacks = context;
+    struct aws_allocator *allocator = ((struct alloc_tracker *)s_jni_allocator.impl)->allocator;
+    struct stack_info_t *stack_info = item->value;
+    struct aws_hash_element *stack_item = NULL;
+    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_hash_table_find(all_stacks, item->key, &stack_item));
+    AWS_FATAL_ASSERT(stack_item);
+    struct stacktrace_t *stack = stack_item->value;
+    void *const *stack_frames = &stack->frames[0];
+    size_t num_frames = 0;
+    while (stack_frames[num_frames] != NULL && num_frames < ALLOC_TRACING_FRAMES) {
+        ++num_frames;
+    }
+
+    /* convert the frame pointers to symbols, and concat into a buffer */
+    char buf[4096] = {0};
+    struct aws_byte_buf stacktrace = aws_byte_buf_from_empty_array(buf, AWS_ARRAY_SIZE(buf));
+    struct aws_byte_cursor newline = aws_byte_cursor_from_c_str("\n");
+    char **symbols = backtrace_symbols(stack_frames, num_frames);
+    for (int idx = 0; idx < num_frames; ++idx) {
+        if (idx > 0) {
+            aws_byte_buf_append(&stacktrace, &newline);
+        }
+        const char *caller = symbols[idx];
+        if (!caller || !caller[0]) {
+            break;
+        }
+        struct aws_byte_cursor cursor = aws_byte_cursor_from_c_str(caller);
+        aws_byte_buf_append(&stacktrace, &cursor);
+    }
+    free(symbols);
+    /* record the resultant buffer as a string */
+    stack_info->trace = aws_string_new_from_array(allocator, stacktrace.buffer, stacktrace.len);
+    aws_byte_buf_clean_up(&stacktrace);
+    return AWS_COMMON_HASH_TABLE_ITER_CONTINUE;
+}
+
+static int s_stack_info_compare_size(const void *a, const void *b) {
+    const struct stack_info_t *stack_a = *(const struct stack_info_t**)a;
+    const struct stack_info_t *stack_b = *(const struct stack_info_t**)b;
+    return stack_b->size > stack_a->size;
+}
+
+static int s_stack_info_compare_count(const void *a, const void *b) {
+    const struct stack_info_t *stack_a = *(const struct stack_info_t**)a;
+    const struct stack_info_t *stack_b = *(const struct stack_info_t**)b;
+    return stack_b->count > stack_a->count;
+}
+
+static void s_stack_info_destroy(void *data) {
+    struct aws_allocator *allocator = ((struct alloc_tracker *)s_jni_allocator.impl)->allocator;
+    struct stack_info_t *stack = data;
+    aws_string_destroy(stack->trace);
+    aws_mem_release(allocator, stack);
+}
+
+/* tally up count/size per stack from all allocs */
+static int s_collect_stack_stats(void *context, struct aws_hash_element *item) {
+    struct aws_hash_table *stacks = context;
+    struct alloc_t *alloc = item->value;
+    struct aws_hash_element *stack_item = NULL;
+    int was_created = 0;
+    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_hash_table_create(stacks, (void*)alloc->stack, &stack_item, &was_created));
+    if (was_created) {
+        struct aws_allocator *allocator = ((struct alloc_tracker *)s_jni_allocator.impl)->allocator;
+        stack_item->value = aws_mem_calloc(allocator, 1, sizeof(struct stack_info_t));
+    }
+    struct stack_info_t *stack = stack_item->value;
+    stack->count++;
+    stack->size += alloc->size;
+    return AWS_COMMON_HASH_TABLE_ITER_CONTINUE;
+}
+
+static int s_insert_stacks(void *context, struct aws_hash_element *item) {
+    struct aws_priority_queue *pq = context;
+    struct stack_info_t *stack = item->value;
+    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_priority_queue_push(pq, &stack));
+    return AWS_COMMON_HASH_TABLE_ITER_CONTINUE;
+}
+#endif
+
+static int s_insert_allocs(void *context, struct aws_hash_element *item) {
     struct aws_priority_queue *allocs = context;
     struct alloc_t *alloc = item->value;
     AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_priority_queue_push(allocs, &alloc));
@@ -138,8 +257,8 @@ static int s_alloc_tracker_each(void *context, struct aws_hash_element *item) {
 }
 
 static int s_alloc_compare(const void *a, const void *b) {
-    const struct alloc_t *alloc_a = a;
-    const struct alloc_t *alloc_b = b;
+    const struct alloc_t *alloc_a = *(const struct alloc_t**)a;
+    const struct alloc_t *alloc_b = *(const struct alloc_t**)b;
     return alloc_a->time > alloc_b->time;
 }
 
@@ -154,18 +273,82 @@ static void s_alloc_tracker_dump(struct alloc_tracker *tracker) {
         "TRACKER: %zu bytes still allocated in %zu allocations\n",
         aws_atomic_load_int(&tracker->allocated),
         num_allocs);
+#if defined(ALLOC_TRACE_AVAILABLE)
+    /* convert stacks from pointers -> symbols */
+    struct aws_hash_table stacks; /* maps stack hash/id -> stack_info_t */
+    AWS_FATAL_ASSERT(
+        AWS_OP_SUCCESS ==
+        aws_hash_table_init(
+            &stacks, tracker->allocator, 64, s_stack_hash, s_stack_eq, NULL, s_stack_info_destroy));
+    /* insert only active stacks tally up sizes and counts */
+    aws_hash_table_foreach(&tracker->allocs, s_collect_stack_stats, &stacks);
+    aws_hash_table_foreach(&stacks, s_collect_stack_trace, &tracker->stacks);
+#endif
     /* sort allocs by time */
     struct aws_priority_queue allocs;
     aws_priority_queue_init_dynamic(&allocs, tracker->allocator, num_allocs, sizeof(struct alloc_t *), s_alloc_compare);
-    aws_hash_table_foreach(&tracker->allocs, s_alloc_tracker_each, &allocs);
+    aws_hash_table_foreach(&tracker->allocs, s_insert_allocs, &allocs);
+    /* dump allocs by time */
+    fprintf(stderr, "################################################################################\n");
+    fprintf(stderr, "Leaks in order of allocation:\n");
+    fprintf(stderr, "################################################################################\n");
     while (aws_priority_queue_size(&allocs)) {
         struct alloc_t *alloc = NULL;
         aws_priority_queue_pop(&allocs, &alloc);
         fprintf(stderr, "ALLOC %zu bytes\n", alloc->size);
-        if (alloc->stacktrace.len) {
-            fprintf(stderr, "  stacktrace:\n" PRInSTR "\n", AWS_BYTE_BUF_PRI(alloc->stacktrace));
+#if defined(ALLOC_TRACE_AVAILABLE)
+        if (alloc->stack) {
+            struct aws_hash_element *item = NULL;
+            AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_hash_table_find(&stacks, (void *)alloc->stack, &item));
+            struct stack_info_t *stack = item->value;
+            fprintf(stderr, "  stacktrace:\n%s\n", (const char *)aws_string_bytes(stack->trace));
         }
+#endif
     }
+
+    aws_priority_queue_clean_up(&allocs);
+#if defined(ALLOC_TRACE_AVAILABLE)
+    size_t num_stacks = aws_hash_table_get_entry_count(&stacks);
+    /* sort stacks by total size leaked */
+    struct aws_priority_queue stacks_by_size;
+    AWS_FATAL_ASSERT(
+        AWS_OP_SUCCESS ==
+        aws_priority_queue_init_dynamic(
+            &stacks_by_size, tracker->allocator, num_stacks, sizeof(struct stack_info_t *), s_stack_info_compare_size));
+    aws_hash_table_foreach(&stacks, s_insert_stacks, &stacks_by_size);
+    fprintf(stderr, "################################################################################\n");
+    fprintf(stderr, "Stacks by bytes leaked:\n");
+    fprintf(stderr, "################################################################################\n");
+    while (aws_priority_queue_size(&stacks_by_size) > 0) {
+        struct stack_info_t *stack = NULL;
+        aws_priority_queue_pop(&stacks_by_size, &stack);
+        fprintf(stderr, "%zu bytes in %zu allocations:\n", stack->size, stack->count);
+        fprintf(stderr, "%s\n", (const char *)aws_string_bytes(stack->trace));
+    }
+    aws_priority_queue_clean_up(&stacks_by_size);
+
+    /* sort stacks by number of leaks */
+    struct aws_priority_queue stacks_by_count;
+    AWS_FATAL_ASSERT(
+        AWS_OP_SUCCESS == aws_priority_queue_init_dynamic(
+                              &stacks_by_count,
+                              tracker->allocator,
+                              num_stacks,
+                              sizeof(struct stack_info_t *),
+                              s_stack_info_compare_count));
+    fprintf(stderr, "################################################################################\n");
+    fprintf(stderr, "Stacks by number of leaks:\n");
+    fprintf(stderr, "################################################################################\n");
+    aws_hash_table_foreach(&stacks, s_insert_stacks, &stacks_by_count);
+    while (aws_priority_queue_size(&stacks_by_count) > 0) {
+        struct stack_info_t *stack = NULL;
+        aws_priority_queue_pop(&stacks_by_count, &stack);
+        fprintf(stderr, "%zu allocations leaking %zu bytes:\n", stack->count, stack->size);
+        fprintf(stderr, "%s\n", (const char *)aws_string_bytes(stack->trace));
+    }
+    aws_priority_queue_clean_up(&stacks_by_count);
+    aws_hash_table_clean_up(&stacks);
+#endif
     fflush(stderr);
     // abort();
 }
@@ -470,7 +653,7 @@ JNIEXPORT
 void JNICALL Java_software_amazon_awssdk_crt_CRT_awsCrtInit(JNIEnv *env, jclass jni_crt_class, jint jni_memtrace) {
     (void)jni_crt_class;
 
-    s_memory_tracing = jni_memtrace;
+    s_memory_tracing = 2;//jni_memtrace;
 #if !defined(ALLOC_TRACE_AVAILABLE)
     s_memory_tracing = (s_memory_tracing > 1) ? 1 : s_memory_tracing;
 #endif

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -284,8 +284,9 @@ static void s_alloc_tracker_dump(struct alloc_tracker *tracker) {
         AWS_OP_SUCCESS ==
         aws_hash_table_init(
             &stacks, tracker->allocator, 64, s_stack_hash, s_stack_eq, NULL, s_stack_info_destroy));
-    /* insert only active stacks tally up sizes and counts */
+    /* collect active stacks, tally up sizes and counts */
     aws_hash_table_foreach(&tracker->allocs, s_collect_stack_stats, &stacks);
+    /* collect stack traces for active stacks */
     aws_hash_table_foreach(&stacks, s_collect_stack_trace, &tracker->stacks);
 #endif
     /* sort allocs by time */
@@ -655,7 +656,7 @@ JNIEXPORT
 void JNICALL Java_software_amazon_awssdk_crt_CRT_awsCrtInit(JNIEnv *env, jclass jni_crt_class, jint jni_memtrace) {
     (void)jni_crt_class;
 
-    s_memory_tracing = 2;//jni_memtrace;
+    s_memory_tracing = jni_memtrace;
 #if !defined(ALLOC_TRACE_AVAILABLE)
     s_memory_tracing = (s_memory_tracing > 1) ? 1 : s_memory_tracing;
 #endif

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -45,6 +45,7 @@
 /* 0 = off, 1 = bytes, 2 = stack traces */
 static int s_memory_tracing = 0;
 
+/* number of stack frames to collect per stack */
 #define ALLOC_TRACING_FRAMES 8
 
 /* describes a single live allocation */
@@ -88,7 +89,7 @@ static void s_destroy_alloc(void *data) {
     aws_mem_release(allocator, alloc);
 }
 
-static void s_destroy_stack(void *data) {
+static void s_destroy_stacktrace(void *data) {
     struct aws_allocator *allocator = ((struct alloc_tracker *)s_jni_allocator.impl)->allocator;
     struct stacktrace_t *stack = data;
     aws_mem_release(allocator, stack);
@@ -117,7 +118,7 @@ static void s_alloc_tracker_init(struct alloc_tracker *tracker, struct aws_alloc
         AWS_FATAL_ASSERT(
             AWS_OP_SUCCESS ==
             aws_hash_table_init(
-                &tracker->stacks, tracker->allocator, 1024, s_stack_hash, s_stack_eq, NULL, s_destroy_stack));
+                &tracker->stacks, tracker->allocator, 1024, s_stack_hash, s_stack_eq, NULL, s_destroy_stacktrace));
     }
 }
 

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -483,17 +483,6 @@ jobject aws_java_byte_array_to_java_byte_buffer(JNIEnv *env, jbyteArray jArray) 
 }
 
 /**
- * Converts a Java byte[] to a Native aws_byte_cursor
- */
-struct aws_byte_cursor aws_jni_byte_cursor_from_jbyteArray(JNIEnv *env, jbyteArray array) {
-
-    jboolean isCopy;
-    jbyte *data = (*env)->GetByteArrayElements(env, array, &isCopy);
-    jsize len = (*env)->GetArrayLength(env, array);
-    return aws_byte_cursor_from_array((const uint8_t *)data, (size_t)len);
-}
-
-/**
  * Converts a Native aws_byte_cursor to a Java byte[]
  */
 jbyteArray aws_jni_byte_array_from_cursor(JNIEnv *env, const struct aws_byte_cursor *native_data) {

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -467,11 +467,6 @@ jbyteArray aws_java_byte_array_new(JNIEnv *env, size_t size) {
     return jArray;
 }
 
-bool aws_copy_java_byte_array_to_native_array(JNIEnv *env, jbyteArray src, uint8_t *dst, size_t amount) {
-    (*env)->GetByteArrayRegion(env, src, 0, (jsize)amount, (jbyte *)dst);
-    return (*env)->ExceptionCheck(env);
-}
-
 bool aws_copy_native_array_to_java_byte_array(JNIEnv *env, jbyteArray dst, uint8_t *src, size_t amount) {
     (*env)->SetByteArrayRegion(env, dst, 0, (jsize)amount, (jbyte *)src);
     return (*env)->ExceptionCheck(env);

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -255,11 +255,8 @@ void s_cache_crt_http_stream_handler(JNIEnv *env) {
 
 static jobjectArray s_java_headers_array_from_native(
     JNIEnv *env,
-    struct http_stream_callback_data *callback,
     const struct aws_http_header *header_array,
     size_t num_headers) {
-
-    // JNIEnv *env = aws_jni_get_thread_env(callback->jvm);
 
     AWS_FATAL_ASSERT(s_http_header.header_class);
     AWS_FATAL_ASSERT(s_http_header.constructor);
@@ -312,7 +309,7 @@ static int s_on_incoming_headers_fn(
         return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
     }
 
-    jobjectArray jHeaders = s_java_headers_array_from_native(env, user_data, header_array, num_headers);
+    jobjectArray jHeaders = s_java_headers_array_from_native(env, header_array, num_headers);
     if (!jHeaders) {
         AWS_LOGF_ERROR(AWS_LS_HTTP_STREAM, "id=%p: Failed to create HttpHeaders", (void *)stream);
         return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
@@ -570,11 +567,11 @@ static bool s_fill_out_request(
         jbyteArray jname = (*env)->GetObjectField(env, jHeader, s_http_header.name);
         jbyteArray jvalue = (*env)->GetObjectField(env, jHeader, s_http_header.value);
 
-        size_t name_len = (*env)->GetArrayLength(env, jname);
+        const size_t name_len = (*env)->GetArrayLength(env, jname);
         jbyte *name = (*env)->GetPrimitiveArrayCritical(env, jname, NULL);
         struct aws_byte_cursor name_cursor = aws_byte_cursor_from_array(name, name_len);
 
-        size_t value_len = (*env)->GetArrayLength(env, jvalue);
+        const size_t value_len = (*env)->GetArrayLength(env, jvalue);
         jbyte *value = (*env)->GetPrimitiveArrayCritical(env, jvalue, NULL);
         struct aws_byte_cursor value_cursor = aws_byte_cursor_from_array(value, value_len);
 

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -259,7 +259,7 @@ static jobjectArray s_java_headers_array_from_native(
     const struct aws_http_header *header_array,
     size_t num_headers) {
 
-    //JNIEnv *env = aws_jni_get_thread_env(callback->jvm);
+    // JNIEnv *env = aws_jni_get_thread_env(callback->jvm);
 
     AWS_FATAL_ASSERT(s_http_header.header_class);
     AWS_FATAL_ASSERT(s_http_header.constructor);
@@ -570,22 +570,13 @@ static bool s_fill_out_request(
         jbyteArray jname = (*env)->GetObjectField(env, jHeader, s_http_header.name);
         jbyteArray jvalue = (*env)->GetObjectField(env, jHeader, s_http_header.value);
 
-        struct aws_byte_buf header_buf;
-        aws_byte_buf_init(&header_buf, aws_jni_get_allocator(), 1024);
-
         size_t name_len = (*env)->GetArrayLength(env, jname);
         jbyte *name = (*env)->GetPrimitiveArrayCritical(env, jname, NULL);
         struct aws_byte_cursor name_cursor = aws_byte_cursor_from_array(name, name_len);
-        aws_byte_buf_append(&header_buf, &name_cursor);
-        (*env)->ReleasePrimitiveArrayCritical(env, jname, name, 0);
-        name_cursor = aws_byte_cursor_from_array(header_buf.buffer + (header_buf.len - name_len), name_len);
 
         size_t value_len = (*env)->GetArrayLength(env, jvalue);
         jbyte *value = (*env)->GetPrimitiveArrayCritical(env, jvalue, NULL);
         struct aws_byte_cursor value_cursor = aws_byte_cursor_from_array(value, value_len);
-        aws_byte_buf_append(&header_buf, &value_cursor);
-        (*env)->ReleasePrimitiveArrayCritical(env, jvalue, value, 0);
-        value_cursor = aws_byte_cursor_from_array(header_buf.buffer + (header_buf.len - value_len), value_len);
 
         struct aws_http_header c_header = {
             .name = name_cursor,
@@ -593,15 +584,15 @@ static bool s_fill_out_request(
         };
 
         result = aws_http_message_add_header(request, c_header);
-        aws_byte_buf_clean_up(&header_buf);
-        
+
+        (*env)->ReleasePrimitiveArrayCritical(env, jname, name, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, jvalue, value, 0);
+
         if (result != AWS_OP_SUCCESS) {
             aws_jni_throw_runtime_exception(env, "HttpClientConnection.MakeRequest: Header[%d] error", i);
             return false;
         }
     }
-
-    
 
     return true;
 }

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -254,11 +254,12 @@ void s_cache_crt_http_stream_handler(JNIEnv *env) {
 }
 
 static jobjectArray s_java_headers_array_from_native(
+    JNIEnv *env,
     struct http_stream_callback_data *callback,
     const struct aws_http_header *header_array,
     size_t num_headers) {
 
-    JNIEnv *env = aws_jni_get_thread_env(callback->jvm);
+    //JNIEnv *env = aws_jni_get_thread_env(callback->jvm);
 
     AWS_FATAL_ASSERT(s_http_header.header_class);
     AWS_FATAL_ASSERT(s_http_header.constructor);
@@ -311,7 +312,7 @@ static int s_on_incoming_headers_fn(
         return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
     }
 
-    jobjectArray jHeaders = s_java_headers_array_from_native(user_data, header_array, num_headers);
+    jobjectArray jHeaders = s_java_headers_array_from_native(env, user_data, header_array, num_headers);
     if (!jHeaders) {
         AWS_LOGF_ERROR(AWS_LS_HTTP_STREAM, "id=%p: Failed to create HttpHeaders", (void *)stream);
         return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
@@ -569,17 +570,38 @@ static bool s_fill_out_request(
         jbyteArray jname = (*env)->GetObjectField(env, jHeader, s_http_header.name);
         jbyteArray jvalue = (*env)->GetObjectField(env, jHeader, s_http_header.value);
 
+        struct aws_byte_buf header_buf;
+        aws_byte_buf_init(&header_buf, aws_jni_get_allocator(), 1024);
+
+        size_t name_len = (*env)->GetArrayLength(env, jname);
+        jbyte *name = (*env)->GetPrimitiveArrayCritical(env, jname, NULL);
+        struct aws_byte_cursor name_cursor = aws_byte_cursor_from_array(name, name_len);
+        aws_byte_buf_append(&header_buf, &name_cursor);
+        (*env)->ReleasePrimitiveArrayCritical(env, jname, name, 0);
+        name_cursor = aws_byte_cursor_from_array(header_buf.buffer + (header_buf.len - name_len), name_len);
+
+        size_t value_len = (*env)->GetArrayLength(env, jvalue);
+        jbyte *value = (*env)->GetPrimitiveArrayCritical(env, jvalue, NULL);
+        struct aws_byte_cursor value_cursor = aws_byte_cursor_from_array(value, value_len);
+        aws_byte_buf_append(&header_buf, &value_cursor);
+        (*env)->ReleasePrimitiveArrayCritical(env, jvalue, value, 0);
+        value_cursor = aws_byte_cursor_from_array(header_buf.buffer + (header_buf.len - value_len), value_len);
+
         struct aws_http_header c_header = {
-            .name = aws_jni_byte_cursor_from_jbyteArray(env, jname),
-            .value = aws_jni_byte_cursor_from_jbyteArray(env, jvalue),
+            .name = name_cursor,
+            .value = value_cursor,
         };
 
         result = aws_http_message_add_header(request, c_header);
+        aws_byte_buf_clean_up(&header_buf);
+        
         if (result != AWS_OP_SUCCESS) {
             aws_jni_throw_runtime_exception(env, "HttpClientConnection.MakeRequest: Header[%d] error", i);
             return false;
         }
     }
+
+    
 
     return true;
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
@@ -22,8 +22,7 @@ public class CrtMemoryLeakDetector {
     static {
         new CRT(); // force the CRT to load before doing anything
     };
-    // Allow up to 512 byte increase in memory usage between CRT Test Runs
-    private final static int DEFAULT_ALLOWED_MEDIAN_MEMORY_BYTE_DELTA = 1024;
+    
     private final static int DEFAULT_NUM_LEAK_TEST_ITERATIONS = 20;
 
     private static long getNativeMemoryInUse() {
@@ -55,7 +54,7 @@ public class CrtMemoryLeakDetector {
     }
 
     public static void leakCheck(Callable<Void> fn) throws Exception {
-        leakCheck(DEFAULT_NUM_LEAK_TEST_ITERATIONS, DEFAULT_ALLOWED_MEDIAN_MEMORY_BYTE_DELTA, fn);
+        leakCheck(DEFAULT_NUM_LEAK_TEST_ITERATIONS, expectedFixedGrowth(), fn);
     }
 
     public static void leakCheck(int numIterations, int maxLeakage, Callable<Void> fn) throws Exception {

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
@@ -124,7 +124,7 @@ public class CrtMemoryLeakDetector {
         });
     }
 
-    static final int FIXED_EXECUTOR_GROWTH = 2664;
+    public static final int FIXED_EXECUTOR_GROWTH = 2664;
 
     private static void runViaThreadPool(int numThreads) throws Exception {
         final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Callable;
 import org.junit.Assert;
 
 import software.amazon.awssdk.crt.CRT;
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.Log;
 
 /**
@@ -72,6 +73,14 @@ public class CrtMemoryLeakDetector {
         }
         if (medianNativeDelta > maxLeakage) {
             output += "Potential Native Memory Leak!\n";
+        }
+
+        final List<String> resources = new ArrayList<>();
+        CrtResource.collectNativeResources((resource) -> {
+            resources.add(resource);
+        });
+        if (resources.size() > 0) {
+            output += resources.toString();
         }
 
         if (output.length() > 0) {

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
@@ -124,6 +124,8 @@ public class CrtMemoryLeakDetector {
         });
     }
 
+    // This is the median growth seen from thousands of samples of creating an executor with any number
+    // of threads and then running the empty jobs below. It seems to be relatively portable and consistent.
     public static final int FIXED_EXECUTOR_GROWTH = 2664;
 
     private static void runViaThreadPool(int numThreads) throws Exception {

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
@@ -14,6 +14,9 @@ import software.amazon.awssdk.crt.Log;
  * detect very small leaks but will likely find obvious large ones.
  */
 public class CrtMemoryLeakDetector {
+    static {
+        new CRT(); // force the CRT to load before doing anything
+    }
     // Allow up to 512 byte increase in memory usage between CRT Test Runs
     private final static int DEFAULT_ALLOWED_MEDIAN_MEMORY_BYTE_DELTA = 1024;
     private final static int DEFAULT_NUM_LEAK_TEST_ITERATIONS = 20;
@@ -54,6 +57,8 @@ public class CrtMemoryLeakDetector {
         List<Long> jvmSamples = new ArrayList<>();
         List<Long> nativeSamples = new ArrayList<>();
         numIterations = Math.max(2, numIterations); // There need to be at least 2 iterations to get deltas
+
+        getJvmMemoryInUse(); // force a few GCs to get a good baseline
 
         for (int i = 0; i < numIterations; i++) {
             fn.call();

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
@@ -5,32 +5,41 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import org.junit.Assert;
 
+import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.Log;
 
 /**
- * Checks that the CRT doesn't have any major memory leaks. Probably won't detect very small leaks but will likely find
- * obvious large ones.
+ * Checks that the CRT doesn't have any major memory leaks. Probably won't
+ * detect very small leaks but will likely find obvious large ones.
  */
 public class CrtMemoryLeakDetector {
     // Allow up to 512 byte increase in memory usage between CRT Test Runs
     private final static int DEFAULT_ALLOWED_MEDIAN_MEMORY_BYTE_DELTA = 1024;
     private final static int DEFAULT_NUM_LEAK_TEST_ITERATIONS = 20;
 
-    private static long getEstimatedMemoryInUse() {
+    private static long getNativeMemoryInUse() {
+        long nativeMemory = CRT.nativeMemory();
+        Log.log(Log.LogLevel.Trace, Log.LogSubject.JavaCrtGeneral, String.format("Native MemUsage: %d", nativeMemory));
+        return nativeMemory;
+    }
 
-        Log.log(Log.LogLevel.Trace, Log.LogSubject.JavaCrtGeneral, "Checking Memory Usage");
+    private static long getJvmMemoryInUse() {
+
+        Log.log(Log.LogLevel.Trace, Log.LogSubject.JavaCrtGeneral, "Checking JVM Memory Usage");
 
         long estimatedMemInUse = Long.MAX_VALUE;
 
         for (int i = 0; i < 10; i++) {
-            // Force a Java Garbage Collection before measuring to reduce noise in measurement
+            // Force a Java Garbage Collection before measuring to reduce noise in
+            // measurement
             System.gc();
 
             // Take the minimum of several measurements to reduce noise
-            estimatedMemInUse = Long.min(estimatedMemInUse, (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()));
+            estimatedMemInUse = Long.min(estimatedMemInUse,
+                    (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()));
         }
 
-        Log.log(Log.LogLevel.Trace, Log.LogSubject.JavaCrtGeneral, String.format("MemUsage: %d", estimatedMemInUse));
+        Log.log(Log.LogLevel.Trace, Log.LogSubject.JavaCrtGeneral, String.format("JVM MemUsage: %d", estimatedMemInUse));
 
         return estimatedMemInUse;
     }
@@ -40,29 +49,45 @@ public class CrtMemoryLeakDetector {
     }
 
     public static void leakCheck(int numIterations, int maxLeakage, Callable<Void> fn) throws Exception {
-        List<Long> memoryUsedMeasurements = new ArrayList<>();
+        List<Long> jvmSamples = new ArrayList<>();
+        List<Long> nativeSamples = new ArrayList<>();
+        numIterations = Math.max(2, numIterations); // There need to be at least 2 iterations to get deltas
 
         for (int i = 0; i < numIterations; i++) {
             fn.call();
-            memoryUsedMeasurements.add(getEstimatedMemoryInUse());
+            jvmSamples.add(getJvmMemoryInUse());
+            nativeSamples.add(getNativeMemoryInUse());
         }
 
+        List<Long> jvmDeltas = getDeltas(jvmSamples);
+        // Get the median delta
+        long p50MemoryUsageDelta = jvmDeltas.get(jvmDeltas.size() / 2);
+        if (p50MemoryUsageDelta > maxLeakage) {
+            Assert.fail(
+                    String.format("Potential Java Memory Leak!\nMemory usage Deltas: %s\nMeasurements: %s\nDiff: %d",
+                            jvmDeltas.toString(), jvmSamples.toString(), p50MemoryUsageDelta - maxLeakage));
+        }
+        List<Long> nativeDeltas = getDeltas(nativeSamples);
+        // Get the median delta
+        p50MemoryUsageDelta = nativeDeltas.get(nativeDeltas.size() / 2);
+        if (p50MemoryUsageDelta > maxLeakage) {
+            Assert.fail(
+                    String.format("Potential Native Memory Leak!\nMemory usage Deltas: %s\nMeasurements: %s\nDiff: %d",
+                            nativeDeltas.toString(), nativeSamples.toString(), p50MemoryUsageDelta - maxLeakage));
+        }
+    }
+
+    private static List<Long> getDeltas(List<Long> samples) {
         List<Long> memUseDeltas = new ArrayList<>();
-        for (int i = 0; i < memoryUsedMeasurements.size() - 1; i++) {
-            long prev = memoryUsedMeasurements.get(i);
-            long curr = memoryUsedMeasurements.get(i + 1);
+        for (int i = 0; i < samples.size() - 1; i++) {
+            long prev = samples.get(i);
+            long curr = samples.get(i + 1);
             long delta = (curr - prev);
             memUseDeltas.add(delta);
         }
 
         // Sort from smallest to largest
         memUseDeltas.sort(null);
-
-        // Get the median delta
-        long p50MemoryUsageDelta = memUseDeltas.get(memUseDeltas.size() / 2);
-
-        if (p50MemoryUsageDelta > maxLeakage) {
-            Assert.fail(String.format("Potential Memory Leak!\nMemory usage Deltas: %s\nMeasurements: %s\nDiff: %d", memUseDeltas.toString(), memoryUsedMeasurements.toString(), p50MemoryUsageDelta - maxLeakage) );
-        }
+        return memUseDeltas;
     }
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtMemoryLeakDetector.java
@@ -90,7 +90,7 @@ public class CrtMemoryLeakDetector {
             resources.add(resource);
         });
         if (resources.size() > 0) {
-            output += resources.toString();
+            output += String.join("\n", resources);
         }
 
         if (output.length() > 0) {

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -30,8 +30,8 @@ public class HttpClientConnectionManagerTest {
     private final static Charset UTF8 = StandardCharsets.UTF_8;
     private final static int NUM_THREADS = 10;
     private final static int NUM_CONNECTIONS = 20;
-    private final static int NUM_REQUESTS = 1000;
-    private final static int NUM_ITERATIONS = 20;
+    private final static int NUM_REQUESTS = 60;
+    private final static int NUM_ITERATIONS = 10;
     private final static int GROWTH_PER_THREAD = 0; // expected VM footprint growth per thread
     private final static int EXPECTED_HTTP_STATUS = 200;
     private final static String endpoint = "https://aws-crt-test-stuff.s3.amazonaws.com";
@@ -135,13 +135,14 @@ public class HttpClientConnectionManagerTest {
         CrtResource.waitForNoResources();
 
         URI uri = new URI(endpoint);
+        System.out.println("  StartTest");
 
         try (HttpClientConnectionManager connectionPool = createConnectionPool(uri, numThreads, NUM_CONNECTIONS)) {
             HttpRequest request = createHttpRequest("GET", endpoint, path, EMPTY_BODY);
             testParallelConnections(connectionPool, request, 1, numRequests);
         }
 
-        Log.log(Log.LogLevel.Trace, Log.LogSubject.HttpConnectionManager, "EndTest");
+        System.out.println("  EndTest");
         CrtResource.logNativeResources();
 
         CrtResource.waitForNoResources();
@@ -155,22 +156,29 @@ public class HttpClientConnectionManagerTest {
             return null;
         };
 
-        final int fixedGrowth = CrtMemoryLeakDetector.expectedFixedGrowth();
-        CrtMemoryLeakDetector.leakCheck(NUM_ITERATIONS, fixedGrowth + (numThreads * GROWTH_PER_THREAD), fn);   
+        
+        int fixedGrowth = CrtMemoryLeakDetector.expectedFixedGrowth();
+        CrtMemoryLeakDetector.leakCheck(NUM_ITERATIONS, fixedGrowth + (numThreads * GROWTH_PER_THREAD), fn);
     }
 
     @Test
     public void testSerialRequests() throws Exception {
+        System.out.println("testSerialRequests START");
         testParallelRequestsWithLeakCheck(1, NUM_REQUESTS / NUM_THREADS);
+        System.out.println("testSerialRequests COMPLETE");
     }
 
     @Test
     public void testParallelRequests() throws Exception {
+        System.out.println("testParallelRequests START");
         testParallelRequestsWithLeakCheck(2, (NUM_REQUESTS / NUM_THREADS) * 2);
+        System.out.println("testParallelRequests END");
     }
 
     @Test
     public void testMaxParallelRequests() throws Exception {
+        System.out.println("testMaxParallelRequests START");
         testParallelRequestsWithLeakCheck(NUM_THREADS, NUM_REQUESTS);
+        System.out.println("testMaxParallelRequests END");
     }
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -30,9 +30,9 @@ public class HttpClientConnectionManagerTest {
     private final static Charset UTF8 = StandardCharsets.UTF_8;
     private final static int NUM_THREADS = 10;
     private final static int NUM_CONNECTIONS = 20;
-    private final static int NUM_REQUESTS = 100;
+    private final static int NUM_REQUESTS = 1000;
+    private final static int NUM_ITERATIONS = 20;
     private final static int GROWTH_PER_THREAD = 0; // expected VM footprint growth per thread
-    private final static int FIXED_GROWTH = CrtMemoryLeakDetector.FIXED_EXECUTOR_GROWTH; // base growth expected in the VM/GC to do just about anything
     private final static int EXPECTED_HTTP_STATUS = 200;
     private final static String endpoint = "https://aws-crt-test-stuff.s3.amazonaws.com";
     private final static String path = "/random_32_byte.data";
@@ -155,7 +155,8 @@ public class HttpClientConnectionManagerTest {
             return null;
         };
 
-        CrtMemoryLeakDetector.leakCheck(4, FIXED_GROWTH + (numThreads * GROWTH_PER_THREAD), fn);   
+        final int fixedGrowth = CrtMemoryLeakDetector.expectedFixedGrowth();
+        CrtMemoryLeakDetector.leakCheck(NUM_ITERATIONS, fixedGrowth + (numThreads * GROWTH_PER_THREAD), fn);   
     }
 
     @Test

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -110,19 +110,22 @@ public class HttpClientConnectionManagerTest {
         }
 
         // Wait for all Requests to complete
-        for (CompletableFuture f: requestCompleteFutures) {
+        for (CompletableFuture f : requestCompleteFutures) {
             f.join();
         }
+        
+        final int requiredSuccesses = (int) Math.floor(numRequests * 0.95);
+        final int allowedFailures = numRequests - requiredSuccesses;
 
         // Verify we got some Http Status Code for each Request
-        Assert.assertEquals(numRequests, reqIdToStatus.size());
+        Assert.assertTrue(reqIdToStatus.size() >= requiredSuccesses);
 
         // Verify Status code is Http 200 for each Request
         for (Integer status : reqIdToStatus.values()) {
             Assert.assertEquals(EXPECTED_HTTP_STATUS, status.intValue());
         }
-        Assert.assertTrue(numErrorCode.get() < numRequests * 0.02);
-        Assert.assertTrue(numConnectionFailures.get() < numRequests * 0.02);
+        Assert.assertTrue(numErrorCode.get() <= allowedFailures);
+        Assert.assertTrue(numConnectionFailures.get() <= allowedFailures);
     }
 
     public void testParallelRequests(int numThreads, int numRequests) throws Exception {

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -31,8 +31,8 @@ public class HttpClientConnectionManagerTest {
     private final static int NUM_THREADS = 10;
     private final static int NUM_CONNECTIONS = 20;
     private final static int NUM_REQUESTS = 100;
-    private final static int GROWTH_PER_THREAD = 1024; // expected VM footprint growth per thread
-    private final static int FIXED_GROWTH = 1024; // base growth expected in the VM/GC to do just about anything
+    private final static int GROWTH_PER_THREAD = 0; // expected VM footprint growth per thread
+    private final static int FIXED_GROWTH = CrtMemoryLeakDetector.FIXED_EXECUTOR_GROWTH; // base growth expected in the VM/GC to do just about anything
     private final static int EXPECTED_HTTP_STATUS = 200;
     private final static String endpoint = "https://aws-crt-test-stuff.s3.amazonaws.com";
     private final static String path = "/random_32_byte.data";


### PR DESCRIPTION
Sample output:
```
> mvn test -Dtest=HttpClientConnectionManagerTest -DargLine="-Daws.crt.memory.tracing=true"
```
```
...
[ERROR] testMaxParallelRequests(software.amazon.awssdk.crt.test.HttpClientConnectionManagerTest)  Time elapsed: 6.025 s  <<< FAILURE!
java.lang.AssertionError: 
Potential Java Memory Leak!

JVM Usage Deltas: [3392]
JVM Samples: [1236856, 1240248]
Native Usage Deltas: [0]
Native Samples: [5120, 5120]

        at software.amazon.awssdk.crt.test.HttpClientConnectionManagerTest.testMaxParallelRequests(HttpClientConnectionManagerTest.java:181)

[ERROR] testParallelRequests(software.amazon.awssdk.crt.test.HttpClientConnectionManagerTest)  Time elapsed: 5.142 s  <<< FAILURE!
java.lang.AssertionError: 
Potential Java Memory Leak!

JVM Usage Deltas: [1984]
JVM Samples: [1251464, 1253448]
Native Usage Deltas: [0]
Native Samples: [5120, 5120]

        at software.amazon.awssdk.crt.test.HttpClientConnectionManagerTest.testParallelRequests(HttpClientConnectionManagerTest.java:169)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
