### PR TITLE
Move check for invalid Status earlier in function

### DIFF
--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -295,6 +295,13 @@ static int s_on_incoming_headers_fn(
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
     }
 
+    int resp_status = -1;
+    int err_code = aws_http_stream_get_incoming_response_status(stream, &resp_status);
+    if (err_code != AWS_OP_SUCCESS) {
+        AWS_LOGF_ERROR(AWS_LS_HTTP_STREAM, "id=%p: Invalid Incoming Response Status", (void *)stream);
+        return AWS_OP_ERR;
+    }
+
     JNIEnv *env = aws_jni_get_thread_env(callback->jvm);
 
     /* All New Java Objects created through JNI have Thread-local references in the current Environment Frame, and
@@ -315,12 +322,6 @@ static int s_on_incoming_headers_fn(
     if (!jHeaders) {
         AWS_LOGF_ERROR(AWS_LS_HTTP_STREAM, "id=%p: Failed to create HttpHeaders", (void *)stream);
         return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
-    }
-
-    int resp_status = -1;
-    int err_code = aws_http_stream_get_incoming_response_status(stream, &resp_status);
-    if (err_code != AWS_OP_SUCCESS) {
-        return AWS_OP_ERR;
     }
 
     (*env)->CallVoidMethod(


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Was re-reading Http Header callback and found a potential case where we'd have an unmatched `Push`/`Pop` Java Env Frame. 

I don't think this would result in a memory leak since the Http Status comes before the Headers, so the Headers should always be empty, but it's good to fix it just in case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
