### PR TITLE
Topic name should come from the received message

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttClientConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttClientConnection.java
@@ -41,16 +41,14 @@ public class MqttClientConnection extends CrtResource {
      * buffer and topic
      */
     private class MessageHandler {
-        String topic;
         Consumer<MqttMessage> callback;
 
-        private MessageHandler(String topic, Consumer<MqttMessage> callback) {
+        private MessageHandler(Consumer<MqttMessage> callback) {
             this.callback = callback;
-            this.topic = topic;
         }
 
         /* called from native when a message is delivered */
-        void deliver(byte[] payload) {
+        void deliver(String topic, byte[] payload) {
             callback.accept(new MqttMessage(topic, payload));
         }
     }
@@ -229,7 +227,7 @@ public class MqttClientConnection extends CrtResource {
 
         AsyncCallback subAck = AsyncCallback.wrapFuture(future, 0);
         try {
-            int packetId = mqttClientConnectionSubscribe(getNativeHandle(), topic, qos.getValue(), new MessageHandler(topic, handler), subAck);
+            int packetId = mqttClientConnectionSubscribe(getNativeHandle(), topic, qos.getValue(), new MessageHandler(handler), subAck);
             // When the future completes, complete the returned future with the packetId
             return future.thenApply(unused -> packetId);
         }

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -302,3 +302,15 @@ jlong JNICALL Java_software_amazon_awssdk_crt_CRT_awsNativeMemory(JNIEnv *env, j
     }
     return allocated;
 }
+
+jstring aws_jni_string_from_cursor(JNIEnv *env, const struct aws_byte_cursor *native_data) {
+    struct aws_string *string = aws_string_new_from_array(aws_jni_get_allocator(), native_data->ptr, native_data->len);
+    if (string == NULL) {
+        return NULL;
+    }
+
+    jstring java_string = (*env)->NewStringUTF(env, (const char *)string->bytes);
+    aws_string_destroy(string);
+
+    return java_string;
+}

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -309,7 +309,7 @@ jstring aws_jni_string_from_cursor(JNIEnv *env, const struct aws_byte_cursor *na
         return NULL;
     }
 
-    jstring java_string = (*env)->NewStringUTF(env, (const char *)string->bytes);
+    jstring java_string = (*env)->NewStringUTF(env, aws_string_c_str(string));
     aws_string_destroy(string);
 
     return java_string;

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -53,7 +53,7 @@ bool aws_copy_native_array_to_java_byte_array(JNIEnv *env, jbyteArray dst, uint8
 struct aws_byte_cursor aws_jni_byte_cursor_from_jbyteArray(JNIEnv *env, jbyteArray array);
 
 /*******************************************************************************
- * aws_jni_byte_cursor_from_jbyteArray - Creates an aws_byte_cursor from a jbyteArray.
+ * aws_jni_byte_array_from_cursor - Creates a jbyteArray from a aws_byte_cursor.
  ******************************************************************************/
 jbyteArray aws_jni_byte_array_from_cursor(JNIEnv *env, const struct aws_byte_cursor *native_data);
 
@@ -61,6 +61,11 @@ jbyteArray aws_jni_byte_array_from_cursor(JNIEnv *env, const struct aws_byte_cur
  * jni_byte_buffer_copy_from_cursor - Creates a Java ByteBuffer from a native aws_byte_cursor
  ******************************************************************************/
 jobject aws_jni_byte_buffer_copy_from_cursor(JNIEnv *env, const struct aws_byte_cursor *native_data);
+
+/*******************************************************************************
+ * aws_jni_string_from_cursor - Creates a Java String from a cursor.
+ ******************************************************************************/
+jstring aws_jni_string_from_cursor(JNIEnv *env, const struct aws_byte_cursor *native_data);
 
 /*******************************************************************************
  * aws_jni_native_byte_buf_from_java_direct_byte_buf - Populates a aws_byte_buf from a Java DirectByteBuffer


### PR DESCRIPTION
Stop caching the topic of a subscription in the callback handler so that wildcard subscribes don't appear to be received message topics.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
