### PR TITLE
Removed incorrect http message release from websocket teardown.

### DIFF
--- a/aws-common-runtime/CMakeLists.txt
+++ b/aws-common-runtime/CMakeLists.txt
@@ -38,7 +38,7 @@ set(AWS_C_COMPRESSION_SHA "v0.2.4")
 include(BuildAwsCCompression)
 
 set(AWS_C_MQTT_URL "https://github.com/awslabs/aws-c-mqtt.git")
-set(AWS_C_MQTT_SHA "v0.4.21")
+set(AWS_C_MQTT_SHA "v0.4.22")
 include(BuildAwsCMqtt)
 
 set(AWS_C_HTTP_URL "https://github.com/awslabs/aws-c-http.git")

--- a/aws-common-runtime/CMakeLists.txt
+++ b/aws-common-runtime/CMakeLists.txt
@@ -38,7 +38,7 @@ set(AWS_C_COMPRESSION_SHA "v0.2.4")
 include(BuildAwsCCompression)
 
 set(AWS_C_MQTT_URL "https://github.com/awslabs/aws-c-mqtt.git")
-set(AWS_C_MQTT_SHA "v0.4.20")
+set(AWS_C_MQTT_SHA "v0.4.21")
 include(BuildAwsCMqtt)
 
 set(AWS_C_HTTP_URL "https://github.com/awslabs/aws-c-http.git")

--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -862,8 +862,6 @@ static void s_ws_handshake_destroy(struct mqtt_jni_ws_handshake *ws_handshake) {
     }
 
     s_mqtt_jni_connection_release(ws_handshake->connection);
-    aws_http_message_release(ws_handshake->http_request);
-
     aws_mem_release(aws_jni_get_allocator(), ws_handshake);
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
