### PR TITLE
check return codes in tls_context_options.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library is licensed under the Apache 2.0 License.
 ## Building
 
 ### Linux/Unix
-Requirements: 
+Requirements:
 * Clang 3.9+ or GCC 4.4+
 * cmake 3.1+
 * Java: Any JDK8 or above, ensure JAVA_HOME is set
@@ -49,15 +49,18 @@ From the aws-crt-java directory:
 From maven: (https://search.maven.org/artifact/software.amazon.awssdk.crt/aws-crt/)
 
 ## Testing
-Once you've set up an IoT Thing [here](https://console.aws.amazon.com/iot), put the certificates into the 
-src/test/resources/credentials directory. You should have:
-* AmazonRootCA1.pem - Amazon Web Services root certificate
-* <thingid>-certificate.pem.crt - Your Thing's cert
-* <thingid>-private.pem.key - Your Thing's private key
+Many tests require custom arguments. These tests will be quietly skipped if their arguments are not set.
+Arguments can be passed like so:
+```
+mvn test -Dcertificate=path/to/cert -Dprivatekey=path/to/key ...
+```
+Many tests require that you have [set up](https://console.aws.amazon.com/iot) an AWS IoT Thing.
 
-If the certs are not found, then tests which connect to the IoT Core service will simply quietly be skipped
-```mvn test``` will run all of the JUnit tests
-
-If you are running the tests in a constrained environment where network access is not guaranteed/allowed,
-the network tests can be disabled by setting the Java system property NETWORK_TESTS_DISABLED. You can do
-this on the command line with ```mvn test -DargLine="-DNETWORK_TESTS_DISABLED=true"```.
+Full list of test arguments:
+- endpoint: AWS IoT service endpoint hostname
+- certificate: Path to the IoT thing certificate
+- privatekey: Path to the IoT thing private key
+- rootca: Path to the root certificate
+- proxyhost: Hostname of proxy
+- proxyport: Port of proxy
+- NETWORK_TESTS_DISABLED: Set this if tests are running in a constrained environment where network access is not guaranteed/allowed.

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -170,6 +170,10 @@ struct aws_byte_cursor aws_jni_byte_cursor_from_direct_byte_buffer(JNIEnv *env, 
 struct aws_string *aws_jni_new_string_from_jstring(JNIEnv *env, jstring str) {
     struct aws_allocator *allocator = aws_jni_get_allocator();
     const char *str_chars = (*env)->GetStringUTFChars(env, str, NULL);
+    if (!str_chars) {
+        aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+        return NULL;
+    }
     struct aws_string *result = aws_string_new_from_c_str(allocator, str_chars);
     (*env)->ReleaseStringUTFChars(env, str, str_chars);
     return result;

--- a/src/native/host_resolver.c
+++ b/src/native/host_resolver.c
@@ -52,7 +52,13 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_io_HostResolver_hostReso
     }
 
     struct aws_host_resolver *resolver = aws_mem_calloc(allocator, 1, sizeof(struct aws_host_resolver));
-    aws_host_resolver_init_default(resolver, allocator, (size_t)max_entries, el_group);
+    AWS_FATAL_ASSERT(resolver);
+
+    if (aws_host_resolver_init_default(resolver, allocator, (size_t)max_entries, el_group)) {
+        aws_jni_throw_runtime_exception(env, "aws_host_resolver_init_default failed");
+        aws_mem_release(allocator, resolver);
+        return (jlong)NULL;
+    }
 
     return (jlong)resolver;
 }

--- a/src/test/resources/credentials/README.md
+++ b/src/test/resources/credentials/README.md
@@ -1,9 +1,0 @@
-Place your Thing certificates in this folder. You should have:
-* AmazonRootCA1.pem
-* {certId}-certificate.pem.crt
-* {certId}-private.pem.key
-
-The certificate and private key can be obtained by creating a certificate in the 
-[AWS IoT console](https://console.aws.amazon.com/iot/home) and extracting the certs into this folder. The root
-certificate can be obtained via the [X.509 Certificates and AWS IoT](https://docs.aws.amazon.com/iot/latest/developerguide/managing-device-certs.html)
-page.


### PR DESCRIPTION
A customer had typed their cert path in wrong, and we didn't detect it until way later when TLS negotiation failed. Turns out there were a lot of return codes we were never checking in this .c file.

There are **lots** of other native/*.c files that need an error-handling pass like this. I got overwhelmed, so this PR just:
1) tls_context_options.c
2) host_resolver.c

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
