### PR TITLE
Check java.io.tmpdir

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -98,14 +98,11 @@ public final class CRT {
             // Check tmpdir and give explicit errors
             Path tmpdirPath = Paths.get(System.getProperty("java.io.tmpdir"));
             File tmpdirFile = tmpdirPath.toFile();
-            if (!tmpdirFile.exists()) {
-                throw new CrtRuntimeException("java.io.tmpdir=\"" + tmpdirPath.toString() + "\" directory does not exist");
-            }
-            if (!tmpdirFile.isDirectory()) {
-                throw new CrtRuntimeException("java.io.tmpdir=\"" + tmpdirPath.toString() + "\" is not a directory");
+            if (!tmpdirFile.exists() || !tmpdirFile.isDirectory()) {
+                throw new NotDirectoryException("java.io.tmpdir=\"" + tmpdirPath.toString() + "\"");
             }
             if (!tmpdirFile.canRead() || !tmpdirFile.canWrite()) {
-                throw new CrtRuntimeException("java.io.tmpdir=\"" + tmpdirPath.toString() + "\" directory lacks read/write permission");
+                throw new AccessDeniedException("java.io.tmpdir=\"" + tmpdirPath.toString() + "\"");
             }
 
             // Prefix the lib


### PR DESCRIPTION
We had a customer whose "java.io.tmpdir" was set to a non-existent directory. Resulting exception looked like:

`Unable to initialize AWS CRT: java.nio.file.NoSuchFileException: /local/home/...redacted.../tmp/AWSCRT_15768129594383460159480481437974libaws-crt-jni.so`

I can't find much official documentation on "java.io.tmpdir" beyond [this](https://docs.oracle.com/javase/7/docs/api/java/lang/System.html#getProperties()), which basically just says "yes this is an official property that will be defined". I would hesitate to try and create the directory if it doesn't already exist. Instead, I'm throwing more explicit errors if the tmpdir is invalid. So the user will instead see:

`Unable to unpack AWS CRT lib: java.nio.file.NotDirectoryException: java.io.tmpdir="/local/home/...redacted.../tmp"`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
