### PR TITLE
Rename aws_jni_throw_runtime_exception()

### DIFF
--- a/src/native/aws_signing.c
+++ b/src/native/aws_signing.c
@@ -271,7 +271,7 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
     struct s_aws_sign_request_callback_data *callback_data =
         aws_mem_calloc(allocator, 1, sizeof(struct s_aws_sign_request_callback_data));
     if (callback_data == NULL) {
-        aws_jni_throw_runtime_exception(env, "Failed to allocated sign request callback data");
+        aws_jni_throw_last_error(env, "Failed to allocated sign request callback data");
         return;
     }
 
@@ -289,7 +289,7 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
     AWS_ZERO_STRUCT(signing_config);
 
     if (s_build_signing_config(env, callback_data, java_signing_config, &signing_config)) {
-        aws_jni_throw_runtime_exception(env, "Failed to allocated sign request callback data");
+        aws_jni_throw_last_error(env, "Failed to allocated sign request callback data");
         s_cleanup_callback_data(callback_data);
         return;
     }
@@ -302,14 +302,14 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
     callback_data->native_request = aws_http_request_new_from_java_http_request(
         env, java_method, java_uri, java_http_request_headers, java_http_request_body_stream);
     if (callback_data->native_request == NULL) {
-        aws_jni_throw_runtime_exception(env, "Failed to create native http request from Java HttpRequest");
+        aws_jni_throw_last_error(env, "Failed to create native http request from Java HttpRequest");
         s_cleanup_callback_data(callback_data);
         return;
     }
 
     callback_data->original_message_signable = aws_signable_new_http_request(allocator, callback_data->native_request);
     if (callback_data->original_message_signable == NULL) {
-        aws_jni_throw_runtime_exception(env, "Failed to create signable from http request");
+        aws_jni_throw_last_error(env, "Failed to create signable from http request");
         s_cleanup_callback_data(callback_data);
         return;
     }
@@ -321,7 +321,7 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
             (struct aws_signing_config_base *)&signing_config,
             s_aws_signing_complete,
             callback_data)) {
-        aws_jni_throw_runtime_exception(env, "Failed to initiate signing process for HttpRequest");
+        aws_jni_throw_last_error(env, "Failed to initiate signing process for HttpRequest");
         s_cleanup_callback_data(callback_data);
     }
 }

--- a/src/native/client_bootstrap.c
+++ b/src/native/client_bootstrap.c
@@ -77,12 +77,12 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_ClientBootstrap_clientBootstrap
     struct aws_host_resolver *resolver = (struct aws_host_resolver *)jni_hr;
 
     if (!elg) {
-        aws_jni_throw_runtime_exception(env, "ClientBootstrap.client_bootstrap_new: Invalid EventLoopGroup");
+        aws_jni_throw_illegal_argument_exception(env, "ClientBootstrap.client_bootstrap_new: Invalid EventLoopGroup");
         return (jlong)NULL;
     }
 
     if (!resolver) {
-        aws_jni_throw_runtime_exception(env, "ClientBootstrap.client_bootstrap_new: Invalid HostResolver");
+        aws_jni_throw_illegal_argument_exception(env, "ClientBootstrap.client_bootstrap_new: Invalid HostResolver");
         return (jlong)NULL;
     }
 
@@ -90,21 +90,15 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_ClientBootstrap_clientBootstrap
 
     struct shutdown_callback_data *callback_data = aws_mem_calloc(allocator, 1, sizeof(struct shutdown_callback_data));
     if (!callback_data) {
-        aws_jni_throw_runtime_exception(env, "ClientBootstrap.client_bootstrap_new: Unable to allocate");
+        aws_jni_throw_last_error(env, "ClientBootstrap.client_bootstrap_new: Unable to allocate");
         return (jlong)NULL;
     }
 
     jint jvmresult = (*env)->GetJavaVM(env, &callback_data->jvm);
-    if (jvmresult != 0) {
-        aws_jni_throw_runtime_exception(env, "ClientBootstrap.client_bootstrap_new: Unable to get JVM");
-        goto error;
-    }
+    AWS_FATAL_ASSERT(jvmresult != 0);
 
     callback_data->java_client_bootstrap = (*env)->NewGlobalRef(env, jni_bootstrap);
-    if (!callback_data->java_client_bootstrap) {
-        aws_jni_throw_runtime_exception(env, "ClientBootstrap.client_bootstrap_new: Unable to create global ref");
-        goto error;
-    }
+    AWS_FATAL_ASSERT(callback_data->java_client_bootstrap);
 
     struct aws_client_bootstrap_options bootstrap_options = {
         .event_loop_group = elg,
@@ -115,7 +109,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_ClientBootstrap_clientBootstrap
 
     struct aws_client_bootstrap *bootstrap = aws_client_bootstrap_new(allocator, &bootstrap_options);
     if (!bootstrap) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_last_error(
             env, "ClientBootstrap.client_bootstrap_new: Unable to allocate new aws_client_bootstrap");
         goto error;
     }

--- a/src/native/client_bootstrap.c
+++ b/src/native/client_bootstrap.c
@@ -95,7 +95,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_ClientBootstrap_clientBootstrap
     }
 
     jint jvmresult = (*env)->GetJavaVM(env, &callback_data->jvm);
-    AWS_FATAL_ASSERT(jvmresult != 0);
+    AWS_FATAL_ASSERT(jvmresult == 0 && "Unable to acquire JNIEnv on this thread");
 
     callback_data->java_client_bootstrap = (*env)->NewGlobalRef(env, jni_bootstrap);
     AWS_FATAL_ASSERT(callback_data->java_client_bootstrap);

--- a/src/native/credentials_provider.c
+++ b/src/native/credentials_provider.c
@@ -95,7 +95,7 @@ JNIEXPORT jlong JNICALL
     struct aws_credentials_provider *provider = aws_credentials_provider_new_static(allocator, &options);
     if (provider == NULL) {
         aws_mem_release(allocator, callback_data);
-        aws_jni_throw_runtime_exception(env, "Failed to create static credentials provider");
+        aws_jni_throw_last_error(env, "Failed to create static credentials provider");
     } else {
         callback_data->provider = provider;
     }
@@ -137,7 +137,7 @@ JNIEXPORT jlong JNICALL
     struct aws_credentials_provider *provider = aws_credentials_provider_new_chain_default(allocator, &options);
     if (provider == NULL) {
         aws_mem_release(allocator, callback_data);
-        aws_jni_throw_runtime_exception(env, "Failed to create default credentials provider chain");
+        aws_jni_throw_last_error(env, "Failed to create default credentials provider chain");
     } else {
         callback_data->provider = provider;
     }
@@ -155,7 +155,7 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_credentials_CredentialsProvide
     (void)cp_object;
     struct aws_credentials_provider *provider = (struct aws_credentials_provider *)cp_addr;
     if (!provider) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_illegal_argument_exception(
             env, "CredentialsProvider.credentialsProviderDestroy: instance should be non-null at destruction time");
         return;
     }
@@ -241,13 +241,13 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_credentials_CredentialsProvide
     (void)jni_cp;
     struct aws_credentials_provider *provider = (struct aws_credentials_provider *)native_credentials_provider;
     if (!provider) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_illegal_argument_exception(
             env, "CredentialsProvider.credentialsProviderGetCredentials: instance should be non-null");
         return;
     }
 
     if (java_crt_credentials_provider == NULL || java_credentials_future == NULL) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_illegal_argument_exception(
             env, "CredentialsProvider.credentialsProviderGetCredentials: called with null parameters");
         return;
     }
@@ -265,7 +265,7 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_credentials_CredentialsProvide
     aws_credentials_provider_acquire(provider);
 
     if (aws_credentials_provider_get_credentials(provider, s_on_get_credentials_callback, callback_data)) {
-        aws_jni_throw_runtime_exception(env, "CrtCredentialsProvider.credentialsProviderGetCredentials: call failure");
+        aws_jni_throw_last_error(env, "CrtCredentialsProvider.credentialsProviderGetCredentials: call failure");
         aws_credentials_provider_release(provider);
     }
 }

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -23,12 +23,19 @@
 struct aws_allocator *aws_jni_get_allocator();
 
 /*******************************************************************************
- * aws_jni_throw_runtime_exception - throws a crt.CrtRuntimeException with the
- * supplied message, sprintf formatted. Control WILL return from this function,
+ * aws_jni_throw_last_error - throws an crt.CrtRuntimeException based on
+ * aws_last_error(). Supplied message is sprintf formatted, along with info
+ * about the AWS error code. Control WILL return from this function,
  * so after calling it, make sure to clean up any native resources before exiting
  * the calling JNIEXPORT function.
  ******************************************************************************/
-void aws_jni_throw_runtime_exception(JNIEnv *env, const char *msg, ...);
+void aws_jni_throw_last_error(JNIEnv *env, const char *msg, ...);
+
+/*******************************************************************************
+ * aws_jni_throw_illegal_argument_exception - throw IllegalArgumentException
+ * with supplied message, sprintf formatted.
+ ******************************************************************************/
+void aws_jni_throw_illegal_argument_exception(JNIEnv *env, const char *msg, ...);
 
 /*******************************************************************************
  * aws_java_byte_array_new - Creates a new Java byte[]
@@ -117,13 +124,6 @@ struct aws_byte_cursor aws_jni_byte_cursor_from_jbyteArray_acquire(JNIEnv *env, 
  * aws_jni_byte_cursor_from_jbyteArray_release - Releases the array back to the JVM
  ********************************************************************************/
 void aws_jni_byte_cursor_from_jbyteArray_release(JNIEnv *env, jbyteArray str, struct aws_byte_cursor cur);
-
-/*******************************************************************************
- * aws_jni_byte_cursor_from_direct_byte_buffer - Creates an aws_byte_cursor from the
- * direct byte buffer. Note that the buffer is not reference pinned, so the cursor
- * is only valid for the current JNI call
- ******************************************************************************/
-struct aws_byte_cursor aws_jni_byte_cursor_from_direct_byte_buffer(JNIEnv *env, jobject byte_buffer);
 
 /*******************************************************************************
  * aws_jni_new_string_from_jstring - Creates a new aws_string from the UTF-8

--- a/src/native/event_loop_group.c
+++ b/src/native/event_loop_group.c
@@ -45,8 +45,7 @@ jlong JNICALL
     if (result != AWS_OP_SUCCESS) {
         aws_event_loop_group_clean_up(elg);
         aws_mem_release(allocator, elg);
-        aws_jni_throw_runtime_exception(
-            env, "EventLoopGroup.event_loop_group_new: aws_event_loop_group_default_init failed");
+        aws_jni_throw_last_error(env, "EventLoopGroup.event_loop_group_new: aws_event_loop_group_default_init failed");
         return (jlong)NULL;
     }
 
@@ -95,7 +94,7 @@ void JNICALL Java_software_amazon_awssdk_crt_io_EventLoopGroup_eventLoopGroupDes
     (void)jni_elg;
     struct aws_event_loop_group *elg = (struct aws_event_loop_group *)elg_addr;
     if (!elg) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_illegal_argument_exception(
             env, "EventLoopGroup.eventLoopGroupDestroy: instance should be non-null at clean_up time");
         return;
     }

--- a/src/native/host_resolver.c
+++ b/src/native/host_resolver.c
@@ -42,12 +42,12 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_io_HostResolver_hostReso
     struct aws_event_loop_group *el_group = (struct aws_event_loop_group *)jni_elg;
 
     if (!el_group) {
-        aws_jni_throw_runtime_exception(env, "HostResolver.hostResolverNew: Invalid EventLoopGroup");
+        aws_jni_throw_illegal_argument_exception(env, "HostResolver.hostResolverNew: Invalid EventLoopGroup");
         return (jlong)NULL;
     }
 
     if (max_entries <= 0) {
-        aws_jni_throw_runtime_exception(env, "HostResolver.hostResolverNew: max_entries must be >= 0");
+        aws_jni_throw_illegal_argument_exception(env, "HostResolver.hostResolverNew: max_entries must be >= 0");
         return (jlong)NULL;
     }
 
@@ -55,7 +55,7 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_io_HostResolver_hostReso
     AWS_FATAL_ASSERT(resolver);
 
     if (aws_host_resolver_init_default(resolver, allocator, (size_t)max_entries, el_group)) {
-        aws_jni_throw_runtime_exception(env, "aws_host_resolver_init_default failed");
+        aws_jni_throw_last_error(env, "aws_host_resolver_init_default failed");
         aws_mem_release(allocator, resolver);
         return (jlong)NULL;
     }
@@ -74,7 +74,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_io_HostResolver_hostResol
     struct aws_host_resolver *resolver = (struct aws_host_resolver *)jni_host_resolver;
 
     if (!resolver) {
-        aws_jni_throw_runtime_exception(env, "HostResolver.hostResolverRelease: Invalid aws_host_resolver");
+        aws_jni_throw_illegal_argument_exception(env, "HostResolver.hostResolverRelease: Invalid aws_host_resolver");
         return;
     }
 

--- a/src/native/http_connection_manager.c
+++ b/src/native/http_connection_manager.c
@@ -96,12 +96,12 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnectio
     struct aws_http_connection_manager *conn_manager = NULL;
 
     if (!client_bootstrap) {
-        aws_jni_throw_runtime_exception(env, "ClientBootstrap can't be null");
+        aws_jni_throw_illegal_argument_exception(env, "ClientBootstrap can't be null");
         return (jlong)NULL;
     }
 
     if (!socket_options) {
-        aws_jni_throw_runtime_exception(env, "SocketOptions can't be null");
+        aws_jni_throw_illegal_argument_exception(env, "SocketOptions can't be null");
         return (jlong)NULL;
     }
 
@@ -109,17 +109,17 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnectio
     struct aws_byte_cursor endpoint = aws_jni_byte_cursor_from_jstring_acquire(env, jni_endpoint);
 
     if (jni_port <= 0 || 65535 < jni_port) {
-        aws_jni_throw_runtime_exception(env, "Port must be between 1 and 65535");
+        aws_jni_throw_illegal_argument_exception(env, "Port must be between 1 and 65535");
         goto cleanup;
     }
 
     if (jni_window_size <= 0) {
-        aws_jni_throw_runtime_exception(env, "Window Size must be > 0");
+        aws_jni_throw_illegal_argument_exception(env, "Window Size must be > 0");
         goto cleanup;
     }
 
     if (jni_max_conns <= 0) {
-        aws_jni_throw_runtime_exception(env, "Max Connections must be > 0");
+        aws_jni_throw_illegal_argument_exception(env, "Max Connections must be > 0");
         goto cleanup;
     }
 
@@ -236,7 +236,7 @@ JNIEXPORT void JNICALL
     struct aws_http_connection_manager *conn_manager = (struct aws_http_connection_manager *)jni_conn_manager;
 
     if (!conn_manager) {
-        aws_jni_throw_runtime_exception(env, "Connection Manager can't be null");
+        aws_jni_throw_illegal_argument_exception(env, "Connection Manager can't be null");
         return;
     }
 
@@ -286,7 +286,7 @@ JNIEXPORT void JNICALL
     struct aws_http_connection_manager *conn_manager = (struct aws_http_connection_manager *)jni_conn_manager;
 
     if (!conn_manager) {
-        aws_jni_throw_runtime_exception(env, "Connection Manager can't be null");
+        aws_jni_throw_illegal_argument_exception(env, "Connection Manager can't be null");
         return;
     }
 
@@ -318,12 +318,12 @@ JNIEXPORT void JNICALL
     struct aws_http_connection *conn = (struct aws_http_connection *)jni_conn;
 
     if (!conn_manager) {
-        aws_jni_throw_runtime_exception(env, "Connection Manager can't be null");
+        aws_jni_throw_illegal_argument_exception(env, "Connection Manager can't be null");
         return;
     }
 
     if (!conn) {
-        aws_jni_throw_runtime_exception(env, "Connection can't be null");
+        aws_jni_throw_illegal_argument_exception(env, "Connection can't be null");
         return;
     }
 

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -297,12 +297,12 @@ JNIEXPORT jobject JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnect
     struct aws_http_connection *native_conn = (struct aws_http_connection *)jni_connection;
 
     if (!native_conn) {
-        aws_jni_throw_runtime_exception(env, "HttpClientConnection.MakeRequest: Invalid aws_http_connection");
+        aws_jni_throw_illegal_argument_exception(env, "HttpClientConnection.MakeRequest: Invalid aws_http_connection");
         return (jobject)NULL;
     }
 
     if (!jni_http_response_callback_handler) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_illegal_argument_exception(
             env, "HttpClientConnection.MakeRequest: Invalid jni_http_response_callback_handler");
         return (jobject)NULL;
     }
@@ -366,7 +366,7 @@ JNIEXPORT jobject JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnect
     if (!native_stream) {
         // Failed to create native aws_http_stream. Clean up callback_data.
         AWS_LOGF_ERROR(AWS_LS_HTTP_CONNECTION, "Stream Request Failed. conn: %p", (void *)native_conn);
-        aws_jni_throw_runtime_exception(env, "HttpClientConnection.MakeRequest: Unable to Execute Request");
+        aws_jni_throw_last_error(env, "HttpClientConnection.MakeRequest: Unable to Execute Request");
         http_stream_callback_destroy(env, callback_data);
         return NULL;
     } else if (!jHttpStream) {
@@ -395,7 +395,7 @@ JNIEXPORT void JNICALL
     struct aws_http_stream *stream = (struct aws_http_stream *)jni_stream;
 
     if (stream == NULL) {
-        aws_jni_throw_runtime_exception(env, "HttpStream is null.");
+        aws_jni_throw_illegal_argument_exception(env, "HttpStream is null.");
         return;
     }
 
@@ -413,7 +413,7 @@ JNIEXPORT jint JNICALL Java_software_amazon_awssdk_crt_http_HttpStream_httpStrea
     struct aws_http_stream *stream = (struct aws_http_stream *)jni_stream;
 
     if (stream == NULL) {
-        aws_jni_throw_runtime_exception(env, "HttpStream is null.");
+        aws_jni_throw_illegal_argument_exception(env, "HttpStream is null.");
         return -1;
     }
 
@@ -421,7 +421,7 @@ JNIEXPORT jint JNICALL Java_software_amazon_awssdk_crt_http_HttpStream_httpStrea
     int err_code = aws_http_stream_get_incoming_response_status(stream, &status);
 
     if (err_code != AWS_OP_SUCCESS) {
-        aws_jni_throw_runtime_exception(env, "Error Getting Response Status Code from HttpStream.");
+        aws_jni_throw_last_error(env, "Error Getting Response Status Code from HttpStream.");
         return -1;
     }
 
@@ -439,12 +439,12 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpStream_httpStrea
     struct aws_http_stream *stream = (struct aws_http_stream *)jni_stream;
 
     if (stream == NULL) {
-        aws_jni_throw_runtime_exception(env, "HttpStream is null.");
+        aws_jni_throw_illegal_argument_exception(env, "HttpStream is null.");
         return;
     }
 
     if (window_update < 0) {
-        aws_jni_throw_runtime_exception(env, "Window Update is < 0");
+        aws_jni_throw_illegal_argument_exception(env, "Window Update is < 0");
         return;
     }
 

--- a/src/native/http_request_utils.c
+++ b/src/native/http_request_utils.c
@@ -216,7 +216,7 @@ int aws_apply_java_http_request_changes_to_native_request(
         (*env)->DeleteLocalRef(env, jHeader);
 
         if (result != AWS_OP_SUCCESS) {
-            aws_jni_throw_runtime_exception(env, "HttpRequest.applyChangesToNativeRequest: Header[%d] error", i);
+            aws_jni_throw_last_error(env, "HttpRequest.applyChangesToNativeRequest: Header[%d] error", i);
             return result;
         }
     }
@@ -226,7 +226,7 @@ int aws_apply_java_http_request_changes_to_native_request(
     aws_jni_byte_cursor_from_jstring_release(env, jni_uri, path_and_query_cur);
 
     if (result != AWS_OP_SUCCESS) {
-        aws_jni_throw_runtime_exception(env, "HttpRequest.applyChangesToNativeRequest: set uri failed");
+        aws_jni_throw_last_error(env, "HttpRequest.applyChangesToNativeRequest: set uri failed");
     }
 
     return result;
@@ -241,7 +241,7 @@ struct aws_http_message *aws_http_request_new_from_java_http_request(
 
     struct aws_http_message *request = aws_http_message_new_request(aws_jni_get_allocator());
     if (request == NULL) {
-        aws_jni_throw_runtime_exception(env, "aws_http_request_new_from_java_http_request: Unable to allocate request");
+        aws_jni_throw_last_error(env, "aws_http_request_new_from_java_http_request: Unable to allocate request");
         return NULL;
     }
 
@@ -249,7 +249,7 @@ struct aws_http_message *aws_http_request_new_from_java_http_request(
     int result = aws_http_message_set_request_method(request, method_cursor);
     aws_jni_byte_cursor_from_jstring_release(env, jni_method, method_cursor);
     if (result != AWS_OP_SUCCESS) {
-        aws_jni_throw_runtime_exception(env, "HttpClientConnection.MakeRequest: Unable to set Method");
+        aws_jni_throw_last_error(env, "HttpClientConnection.MakeRequest: Unable to set Method");
         goto on_error;
     }
 
@@ -257,7 +257,7 @@ struct aws_http_message *aws_http_request_new_from_java_http_request(
     result = aws_http_message_set_request_path(request, path_cursor);
     aws_jni_byte_cursor_from_jstring_release(env, jni_uri, path_cursor);
     if (result != AWS_OP_SUCCESS) {
-        aws_jni_throw_runtime_exception(env, "HttpClientConnection.MakeRequest: Unable to set Path");
+        aws_jni_throw_last_error(env, "HttpClientConnection.MakeRequest: Unable to set Path");
         goto on_error;
     }
 
@@ -291,7 +291,7 @@ struct aws_http_message *aws_http_request_new_from_java_http_request(
         (*env)->DeleteLocalRef(env, jHeader);
 
         if (result != AWS_OP_SUCCESS) {
-            aws_jni_throw_runtime_exception(env, "HttpClientConnection.MakeRequest: Header[%d] error", i);
+            aws_jni_throw_last_error(env, "HttpClientConnection.MakeRequest: Header[%d] error", i);
             goto on_error;
         }
     }
@@ -300,7 +300,7 @@ struct aws_http_message *aws_http_request_new_from_java_http_request(
         struct aws_input_stream *body_stream =
             aws_input_stream_new_from_java_http_request_body_stream(aws_jni_get_allocator(), env, jni_body_stream);
         if (body_stream == NULL) {
-            aws_jni_throw_runtime_exception(env, "aws_fill_out_request: Error building body stream");
+            aws_jni_throw_last_error(env, "aws_fill_out_request: Error building body stream");
             goto on_error;
         }
 

--- a/src/native/logging.c
+++ b/src/native/logging.c
@@ -58,12 +58,12 @@ static void s_aws_init_logging_internal(JNIEnv *env, struct aws_logger_standard_
 
     if (g_memory_tracing == 0) {
         if (aws_logger_init_standard(&s_logger, allocator, options)) {
-            aws_jni_throw_runtime_exception(env, "Failed to initialize standard logger");
+            aws_jni_throw_last_error(env, "Failed to initialize standard logger");
             return;
         }
     } else {
         if (aws_logger_init_noalloc(&s_logger, allocator, options)) {
-            aws_jni_throw_runtime_exception(env, "Failed to initialize no-alloc logger");
+            aws_jni_throw_last_error(env, "Failed to initialize no-alloc logger");
             return;
         }
     }

--- a/src/native/mqtt_client.c
+++ b/src/native/mqtt_client.c
@@ -35,14 +35,14 @@ JNIEXPORT jlong JNICALL
     (void)jni_class;
     struct aws_client_bootstrap *bootstrap = (struct aws_client_bootstrap *)jni_bootstrap;
     if (!bootstrap) {
-        aws_jni_throw_runtime_exception(env, "Invalid ClientBootstrap");
+        aws_jni_throw_illegal_argument_exception(env, "Invalid ClientBootstrap");
         return (jlong)NULL;
     }
 
     struct aws_allocator *allocator = aws_jni_get_allocator();
     struct aws_mqtt_client *client = aws_mem_calloc(allocator, 1, sizeof(struct aws_mqtt_client));
     if (!client) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_last_error(
             env, "MqttClient.mqtt_client_init: aws_mem_calloc failed, unable to allocate new aws_mqtt_client");
         return (jlong)NULL;
     }
@@ -51,7 +51,7 @@ JNIEXPORT jlong JNICALL
 
     int result = aws_mqtt_client_init(client, allocator, bootstrap);
     if (result != AWS_OP_SUCCESS) {
-        aws_jni_throw_runtime_exception(env, "MqttClient.mqtt_client_init: aws_mqtt_client_init failed");
+        aws_jni_throw_last_error(env, "MqttClient.mqtt_client_init: aws_mqtt_client_init failed");
         goto error_cleanup;
     }
 
@@ -73,7 +73,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt_MqttClient_mqttClien
     (void)jni_class;
     struct aws_mqtt_client *client = (struct aws_mqtt_client *)jni_mqtt_client;
     if (!client) {
-        aws_jni_throw_runtime_exception(env, "MqttClient.mqtt_client_clean_up: Invalid/null client");
+        aws_jni_throw_illegal_argument_exception(env, "MqttClient.mqtt_client_clean_up: Invalid/null client");
         return;
     }
 

--- a/src/native/tls_connection_options.c
+++ b/src/native/tls_connection_options.c
@@ -41,7 +41,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsConnectionOptions_tlsConnect
     struct aws_tls_connection_options *options =
         (struct aws_tls_connection_options *)aws_mem_calloc(allocator, 1, sizeof(struct aws_tls_connection_options));
     if (!options) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_last_error(
             env, "TlsConnectionOptions.tlsConnectionOptionsNew: Unable to allocate new aws_tls_connection_options");
         return (jlong)NULL;
     }
@@ -86,7 +86,7 @@ void JNICALL Java_software_amazon_awssdk_crt_io_TlsConnectionOptions_tlsConnecti
     struct aws_byte_cursor server_name_cursor = aws_jni_byte_cursor_from_jstring_acquire(env, jni_server_name);
     struct aws_allocator *allocator = aws_jni_get_allocator();
     if (aws_tls_connection_options_set_server_name(options, allocator, &server_name_cursor)) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_last_error(
             env, "TlsConnectionOptions.tlsConnectionOptionsSetServerName: Unable to set server name");
     }
     aws_jni_byte_cursor_from_jstring_release(env, jni_server_name, server_name_cursor);
@@ -108,8 +108,7 @@ void JNICALL Java_software_amazon_awssdk_crt_io_TlsConnectionOptions_tlsConnecti
     struct aws_byte_cursor alpn_list_cursor = aws_jni_byte_cursor_from_jstring_acquire(env, jni_alpn_list);
     struct aws_allocator *allocator = aws_jni_get_allocator();
     if (aws_tls_connection_options_set_alpn_list(options, allocator, (char *)alpn_list_cursor.ptr)) {
-        aws_jni_throw_runtime_exception(
-            env, "TlsConnectionOptions.tlsConnectionOptionsSetAlpnList: Unable to set alpn list");
+        aws_jni_throw_last_error(env, "TlsConnectionOptions.tlsConnectionOptionsSetAlpnList: Unable to set alpn list");
     }
     aws_jni_byte_cursor_from_jstring_release(env, jni_alpn_list, alpn_list_cursor);
 }

--- a/src/native/tls_context_options.c
+++ b/src/native/tls_context_options.c
@@ -99,12 +99,12 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     if (jni_certificate && jni_private_key) {
         tls->certificate = aws_jni_new_string_from_jstring(env, jni_certificate);
         if (!tls->certificate) {
-            aws_jni_throw_runtime_exception(env, "failed to get certificate string");
+            aws_jni_throw_last_error(env, "failed to get certificate string");
             goto on_error;
         }
         tls->private_key = aws_jni_new_string_from_jstring(env, jni_private_key);
         if (!tls->private_key) {
-            aws_jni_throw_runtime_exception(env, "failed to get privateKey string");
+            aws_jni_throw_last_error(env, "failed to get privateKey string");
             goto on_error;
         }
 
@@ -112,18 +112,18 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
         struct aws_byte_cursor key_cursor = aws_byte_cursor_from_string(tls->private_key);
 
         if (aws_tls_ctx_options_init_client_mtls(&tls->options, allocator, &cert_cursor, &key_cursor)) {
-            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_init_client_mtls failed");
+            aws_jni_throw_last_error(env, "aws_tls_ctx_options_init_client_mtls failed");
             goto on_error;
         }
     } else if (jni_cert_path && jni_key_path) {
         tls->certificate_path = aws_jni_new_string_from_jstring(env, jni_cert_path);
         if (!tls->certificate_path) {
-            aws_jni_throw_runtime_exception(env, "failed to get certificatePath string");
+            aws_jni_throw_last_error(env, "failed to get certificatePath string");
             goto on_error;
         }
         tls->private_key_path = aws_jni_new_string_from_jstring(env, jni_key_path);
         if (!tls->private_key_path) {
-            aws_jni_throw_runtime_exception(env, "failed to get privateKeyPath string");
+            aws_jni_throw_last_error(env, "failed to get privateKeyPath string");
             goto on_error;
         }
 
@@ -132,7 +132,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
                 allocator,
                 aws_string_c_str(tls->certificate_path),
                 aws_string_c_str(tls->private_key_path))) {
-            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_init_client_mtls_from_path failed");
+            aws_jni_throw_last_error(env, "aws_tls_ctx_options_init_client_mtls_from_path failed");
             goto on_error;
         }
     }
@@ -140,12 +140,12 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     if (jni_ca) {
         tls->ca_root = aws_jni_new_string_from_jstring(env, jni_ca);
         if (!tls->ca_root) {
-            aws_jni_throw_runtime_exception(env, "failed to get caRoot string");
+            aws_jni_throw_last_error(env, "failed to get caRoot string");
             goto on_error;
         }
         struct aws_byte_cursor ca_cursor = aws_byte_cursor_from_string(tls->ca_root);
         if (aws_tls_ctx_options_override_default_trust_store(&tls->options, &ca_cursor)) {
-            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_override_default_trust_store failed");
+            aws_jni_throw_last_error(env, "aws_tls_ctx_options_override_default_trust_store failed");
             goto on_error;
         }
     } else if (jni_ca_filepath || jni_ca_dirpath) {
@@ -154,7 +154,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
         if (jni_ca_filepath) {
             tls->ca_file = aws_jni_new_string_from_jstring(env, jni_ca_filepath);
             if (!tls->ca_file) {
-                aws_jni_throw_runtime_exception(env, "failed to get caFile string");
+                aws_jni_throw_last_error(env, "failed to get caFile string");
                 goto on_error;
             }
 
@@ -163,7 +163,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
         if (jni_ca_dirpath) {
             tls->ca_path = aws_jni_new_string_from_jstring(env, jni_ca_dirpath);
             if (!tls->ca_path) {
-                aws_jni_throw_runtime_exception(env, "failed to get caPath string");
+                aws_jni_throw_last_error(env, "failed to get caPath string");
                 goto on_error;
             }
 
@@ -171,7 +171,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
         }
 
         if (aws_tls_ctx_options_override_default_trust_store_from_path(&tls->options, ca_path, ca_file)) {
-            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_override_default_trust_store_from_path failed");
+            aws_jni_throw_last_error(env, "aws_tls_ctx_options_override_default_trust_store_from_path failed");
             goto on_error;
         }
     }
@@ -180,19 +180,19 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     if (jni_pkcs12_path && jni_pkcs12_password) {
         tls->pkcs12_path = aws_jni_new_string_from_jstring(env, jni_pkcs12_path);
         if (!tls->pkcs12_path) {
-            aws_jni_throw_runtime_exception(env, "failed to get pkcs12Path string");
+            aws_jni_throw_last_error(env, "failed to get pkcs12Path string");
             goto on_error;
         }
         tls->pkcs12_password = aws_jni_new_string_from_jstring(env, jni_pkcs12_password);
         if (!tls->pkcs12_password) {
-            aws_jni_throw_runtime_exception(env, "failed to get pkcs12Password string");
+            aws_jni_throw_last_error(env, "failed to get pkcs12Password string");
             goto on_error;
         }
 
         struct aws_byte_cursor password = aws_byte_cursor_from_string(tls->pkcs12_password);
         if (aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(
                 &tls->options, allocator, aws_string_c_str(tls->pkcs12_path), &password)) {
-            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_init_client_mtls_pkcs12_from_path failed");
+            aws_jni_throw_last_error(env, "aws_tls_ctx_options_init_client_mtls_pkcs12_from_path failed");
             goto on_error;
         }
     }
@@ -208,12 +208,12 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     if (jni_alpn) {
         tls->alpn_list = aws_jni_new_string_from_jstring(env, jni_alpn);
         if (!tls->alpn_list) {
-            aws_jni_throw_runtime_exception(env, "failed to get alpnList string");
+            aws_jni_throw_last_error(env, "failed to get alpnList string");
             goto on_error;
         }
 
         if (aws_tls_ctx_options_set_alpn_list(&tls->options, aws_string_c_str(tls->alpn_list))) {
-            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_set_alpn_list failed");
+            aws_jni_throw_last_error(env, "aws_tls_ctx_options_set_alpn_list failed");
             goto on_error;
         }
     }
@@ -257,7 +257,7 @@ jboolean JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContext
     (void)jni_class;
 
     if (jni_cipher_pref < 0 || AWS_IO_TLS_CIPHER_PREF_END_RANGE <= jni_cipher_pref) {
-        aws_jni_throw_runtime_exception(
+        aws_jni_throw_illegal_argument_exception(
             env,
             "TlsContextOptions.tlsContextOptionsSetCipherPreference: TlsCipherPreference is out of range: %d",
             (int)jni_cipher_pref);

--- a/src/native/tls_ctx.c
+++ b/src/native/tls_ctx.c
@@ -38,14 +38,14 @@ jlong JNICALL
     (void)jni_class;
     struct aws_tls_ctx_options *options = (struct aws_tls_ctx_options *)jni_options;
     if (!options) {
-        aws_jni_throw_runtime_exception(env, "TlsContext.tls_ctx_new: Invalid TlsOptions");
+        aws_jni_throw_illegal_argument_exception(env, "TlsContext.tls_ctx_new: Invalid TlsOptions");
         return (jlong)NULL;
     }
 
     struct aws_allocator *allocator = aws_jni_get_allocator();
     struct aws_tls_ctx *tls_ctx = aws_tls_client_ctx_new(allocator, options);
     if (!tls_ctx) {
-        aws_jni_throw_runtime_exception(env, "TlsContext.tls_ctx_new: Failed to create new aws_tls_ctx");
+        aws_jni_throw_last_error(env, "TlsContext.tls_ctx_new: Failed to create new aws_tls_ctx");
         return (jlong)NULL;
     }
     return (jlong)tls_ctx;


### PR DESCRIPTION
Problem:
aws_jni_throw_runtime_exception() prints info about the aws_last_error(), but it was OFTEN used when no aws_error had been raised, usually after checking if an argument was null.

Solution:
Rename aws_jni_throw_runtime_exception() -> aws_jni_throw_last_error()
Introduce aws_jni_throw_illegal_argument_exception() for when we're just null-checking.

This is NOT a full eyeball scrub of our error-handling. Just renaming/fixing uses of 1 function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
