### PR TITLE
Potential fix for Raspberry Pi arm issue

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -90,7 +90,9 @@ public final class CRT {
             }
         } else if (arch.startsWith("aarch64")) {
            return "armv8";
-        }
+        } else if (arch.equals("arm")) {
+           return "armv7";
+	}
 
         throw new UnknownPlatformException("AWS CRT: architecture not supported: " + arch);
     }


### PR DESCRIPTION
*Description of changes:*
Adding additional case for getArchIdentifier method for when property os.arch equals "arm".  This is in reference to the following issue: https://github.com/awslabs/aws-crt-java/issues/153

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
