### PR TITLE
Allow s2n to auto-detect Post Quantum Assembly support

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -53,7 +53,6 @@
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DBUILD_DEPS=ON",
                         "-DBUILD_TESTING=OFF",
-                        "-DS2N_NO_PQ_ASM=ON"
                     ]
                 },
                 "armv7": {
@@ -69,7 +68,6 @@
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DBUILD_DEPS=ON",
                         "-DBUILD_TESTING=OFF",
-                        "-DS2N_NO_PQ_ASM=ON"
                     ]
                 },
                 "arm64": {
@@ -85,7 +83,6 @@
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DBUILD_DEPS=ON",
                         "-DBUILD_TESTING=OFF",
-                        "-DS2N_NO_PQ_ASM=ON"
                     ]
                 }
             }

--- a/builder.json
+++ b/builder.json
@@ -52,7 +52,7 @@
                     "!cmake_args": [
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DBUILD_DEPS=ON",
-                        "-DBUILD_TESTING=OFF",
+                        "-DBUILD_TESTING=OFF"
                     ]
                 },
                 "armv7": {
@@ -67,7 +67,7 @@
                     "!cmake_args": [
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DBUILD_DEPS=ON",
-                        "-DBUILD_TESTING=OFF",
+                        "-DBUILD_TESTING=OFF"
                     ]
                 },
                 "arm64": {
@@ -82,7 +82,7 @@
                     "!cmake_args": [
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DBUILD_DEPS=ON",
-                        "-DBUILD_TESTING=OFF",
+                        "-DBUILD_TESTING=OFF"
                     ]
                 }
             }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
s2n's CMake build can now [auto-detect if Post Quantum Assembly is supported](https://github.com/awslabs/s2n/blob/master/CMakeLists.txt#L116) by the Platform/Compiler combination. There's no longer a need to force it to be turned off. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
