### PR TITLE
Added PackageInfo test, fixed unit test case where there's no manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,14 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <!-- make build dir for cmake -->
             <plugin>

--- a/src/main/java/software/amazon/awssdk/crt/utils/PackageInfo.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/PackageInfo.java
@@ -15,16 +15,26 @@
  */
 package software.amazon.awssdk.crt.utils;
 
+import software.amazon.awssdk.crt.CRT;
+
 public final class PackageInfo {
     public class Version {
         private final String version;
         public final int major;
         public final int minor;
         public final int patch;
+        public final String tag;
 
         public Version(String v) {
             version = v != null ? v : "UNKNOWN";
             
+            int dashIdx = version.indexOf('-');
+            if (dashIdx != -1) {
+                tag = version.substring(dashIdx + 1);
+            } else {
+                tag = "";
+            }
+
             v = version.replace("-.+$", ""); // remove -SNAPSHOT or any other suffix
             String[] parts = v.split("\\.", 3);
 
@@ -51,7 +61,16 @@ public final class PackageInfo {
     public Version version;
 
     public PackageInfo() {
-        version = new Version(PackageInfo.class.getPackage().getImplementationVersion());
+        Package pkg = CRT.class.getPackage();
+        String pkgVersion = pkg.getSpecificationVersion();
+        if (pkgVersion == null) {
+            pkgVersion = pkg.getImplementationVersion();
+        }
+        // There is no JAR/manifest during internal tests
+        if (pkgVersion == null) {
+            pkgVersion = "0.0.0-UNITTEST";
+        }
+        version = new Version(pkgVersion);
     }
     
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/PackageInfoTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/PackageInfoTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.crt.test;
+
+import org.junit.Test;
+import org.junit.Assert;
+import software.amazon.awssdk.crt.utils.PackageInfo;
+
+public class PackageInfoTest {
+    public PackageInfoTest() {}
+    
+    @Test
+    public void testPackageInfo() {
+        PackageInfo pkgInfo = new PackageInfo();
+        Assert.assertNotEquals("UNKNOWN", pkgInfo.version.toString());
+        Assert.assertEquals(0, pkgInfo.version.major);
+        Assert.assertEquals(0, pkgInfo.version.minor);
+        Assert.assertEquals(0, pkgInfo.version.patch);
+        Assert.assertEquals("UNITTEST", pkgInfo.version.tag);
+    }
+};


### PR DESCRIPTION
ensure our package has versions in manifest

*Issue #, if available:* #180 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
