### PR TITLE
Conditionally add generator control if set in environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
                             <exportAntProperties>true</exportAntProperties>
                             <target>
                                 <property environment="env"/>
-                                <condition property="cmake.generator" value="-G${env.AWS_CMAKE_GENERATOR}" else="">
+                                <condition property="cmake.generator" value="-G${env.AWS_CMAKE_GENERATOR}" else="-DGENERATOR_DUMMY=1">
                                     <isset property="env.AWS_CMAKE_GENERATOR" />
                                 </condition>
                                 <echo message="Generator = ${cmake.generator}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
                                         <argument>${cmake.libcrypto_shared}</argument>
                                         <argument>${cmake.libcrypto_static}</argument>
                                         <argument>-Wno-unused-variables</argument>
+                                        <argument>${cmake.generator}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -312,6 +313,7 @@
             <!-- make build dir for cmake -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>create-build-dir</id>
@@ -324,6 +326,22 @@
                         <goals>
                             <goal>run</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <exportAntProperties>true</exportAntProperties>
+                            <target>
+                                <property environment="env"/>
+                                <condition property="cmake.generator" value="-G${env.AWS_CMAKE_GENERATOR}" else="">
+                                    <isset property="env.AWS_CMAKE_GENERATOR" />
+                                </condition>
+                                <echo message="Generator = ${cmake.generator}"/>
+                            </target>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
cd build scripts were setting AWS_CMAKE_GENERATOR but it wasn't getting propagated to the actual cmake call as controlled by the pom file.

Tested with
1) VS 14 2015 Win64 generator (x86_64 result)
1) VS 14 2015 generator (x86_32 result)
1) Unset AWS_CMAKE_GENERATOR (nothing gets passed on command line, cmake default)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
