### PR TITLE
Made git tag detection more robust

### DIFF
--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -20,9 +20,9 @@ Properties getGitTag() {
         version['major'] = matcher.group(1)
         version['minor'] = matcher.group(2)
         version['patch'] = matcher.group(3)
-        if (matcher.groupCount() > 4) {
+        try {
             version['tag'] = matcher.group(5)
-        }
+        } catch (Exception ex) {}
     }
     return version
 }


### PR DESCRIPTION
Turns out ```matcher.groupCount()``` is always the number of groups in the pattern, even if some were optional and didn't match.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
