### PR TITLE
OSX TLS ReadMe Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ This library is licensed under the Apache 2.0 License.
 
 ## Mac-Only TLS Behavior
 
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.
+```
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Java Bindings for the AWS Common Runtime
 
 This library is licensed under the Apache 2.0 License.
 
+## OSX-Only TLS Behavior
+
+Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programatically.
+
 ## Building
 
 ### Linux/Unix

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Java Bindings for the AWS Common Runtime
 
 This library is licensed under the Apache 2.0 License.
 
-## OSX-Only TLS Behavior
+## Mac-Only TLS Behavior
 
-Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Java Bindings for the AWS Common Runtime
 
 This library is licensed under the Apache 2.0 License.
 
-## OSX Only TLS Behavior
+## OSX-Only TLS Behavior
 
 Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Java Bindings for the AWS Common Runtime
 
 This library is licensed under the Apache 2.0 License.
 
-## OSX-Only TLS Behavior
+## OSX Only TLS Behavior
 
-Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programatically.
+Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 
 ## Building
 


### PR DESCRIPTION
*Description of changes:*
Adding OSX TLS Keychain information to README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
