### PR TITLE
Fix mqtt pubsub tests

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
@@ -90,22 +90,20 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
     @Test
     public void testPubSubOnMessage() {
         Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
-        connect();
+        Consumer<MqttMessage> messageHandler = (message) -> {
+            byte[] payload = message.getPayload();
+            try {
+                assertEquals(TEST_TOPIC, message.getTopic());
+                String contents = new String(payload, "UTF-8");
+                assertEquals("Message is intact", TEST_PAYLOAD, contents);
+            } catch (UnsupportedEncodingException ex) {
+                fail("Unable to decode payload: " + ex.getMessage());
+            }
+        };
+
+        connect(messageHandler);
 
         try {
-            Consumer<MqttMessage> messageHandler = (message) -> {
-                byte[] payload = message.getPayload();
-                try {
-                    assertEquals(TEST_TOPIC, message.getTopic());
-                    String contents = new String(payload, "UTF-8");
-                    assertEquals("Message is intact", TEST_PAYLOAD, contents);
-                } catch (UnsupportedEncodingException ex) {
-                    fail("Unable to decode payload: " + ex.getMessage());
-                }
-            };
-
-            connection.onMessage(messageHandler);
-
             CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE);
             subscribed.thenApply(unused -> subsAcked++);
             int packetId = subscribed.get();


### PR DESCRIPTION
* You can't set the on any message handler after connection connect(), so update the test fixture to support setting it at a valid time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
