### PR TITLE
Static elg hr

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/ClientBootstrap.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/ClientBootstrap.java
@@ -25,6 +25,14 @@ public final class ClientBootstrap extends CrtResource {
      * or if the system is unable to allocate space for a native client bootstrap object
      */
     public ClientBootstrap(EventLoopGroup elg, HostResolver hr) throws CrtRuntimeException {
+        if (elg == null) {
+            elg = EventLoopGroup.getOrCreateStaticDefault();
+        }
+
+        if (hr == null) {
+            hr = HostResolver.getOrCreateStaticDefault();
+        }
+
         acquireNativeHandle(clientBootstrapNew(this, elg.getNativeHandle(), hr.getNativeHandle()));
 
         // Order is likely important here

--- a/src/main/java/software/amazon/awssdk/crt/io/EventLoopGroup.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/EventLoopGroup.java
@@ -73,7 +73,7 @@ public final class EventLoopGroup extends CrtResource {
      */
     public static void setStaticDefaultNumThreads(int numThreads) {
         synchronized (EventLoopGroup.class) {
-            staticDefaultNumThreads = numThreads;
+            staticDefaultNumThreads = Math.max(1, numThreads);
         }
     }
 
@@ -107,7 +107,7 @@ public final class EventLoopGroup extends CrtResource {
         return elg;
     }
 
-    private static int staticDefaultNumThreads = 1;
+    private static int staticDefaultNumThreads = Math.max(1, Runtime.getRuntime().availableProcessors());
     private static EventLoopGroup staticDefaultEventLoopGroup;
 
     /*******************************************************************************

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
@@ -72,7 +72,19 @@ public enum TlsCipherPreference {
      *
      * This Cipher Preference may stop being supported at any time.
      */
-    TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2020_02(4);
+    TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2020_02(4),
+
+    /**
+     * This TlsCipherPreference contains Kyber Round 2, BIKE Round 2, SIKE Round 2, BIKE Round 1, and SIKE Round 1 Draft
+     * Hybrid TLS Ciphers at the top of the preference list.
+     *
+     * For more info see:
+     *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
+     *   - https://aws.amazon.com/blogs/security/post-quantum-tls-now-supported-in-aws-kms/
+     *
+     * This Cipher Preference may stop being supported at any time.
+     */
+    TLS_CIPHER_PREF_KMS_PQ_TLSv1_0_2020_07(5);
 
     private int val;
 

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -8,6 +8,8 @@ package software.amazon.awssdk.crt.test;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtPlatform;
 import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.crt.test.CrtTestContext;
@@ -40,6 +42,9 @@ public class CrtTestFixture {
         }
 
         context = null;
+
+        EventLoopGroup.closeStaticDefault();
+        HostResolver.closeStaticDefault();
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
@@ -105,4 +105,25 @@ public class HttpClientConnectionTest extends HttpClientTestFixture {
         testConnectionWithAllCiphers(new URI("https://expired.badssl.com/"), false, "TLS (SSL) negotiation failed");
         testConnectionWithAllCiphers(new URI("https://self-signed.badssl.com/"), false, "TLS (SSL) negotiation failed");
     }
+
+    @Test
+    public void testStaticDefaults() throws Exception {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
+
+        URI uri = new URI("https://aws-crt-test-stuff.s3.amazonaws.com");
+        try (ClientBootstrap bootstrap = new ClientBootstrap(null, null);
+             SocketOptions socketOptions = new SocketOptions();
+             TlsContextOptions tlsOpts = TlsContextOptions.createDefaultClient();
+             TlsContext tlsCtx = new TlsContext(tlsOpts)) {
+
+            HttpClientConnectionManagerOptions options = new HttpClientConnectionManagerOptions();
+            options.withClientBootstrap(bootstrap).withSocketOptions(socketOptions).withTlsContext(tlsCtx).withUri(uri);
+
+            try (HttpClientConnectionManager connectionPool = HttpClientConnectionManager.create(options)) {
+                try (HttpClientConnection conn = connectionPool.acquireConnection().get(60, TimeUnit.SECONDS)) {
+                    ;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds support for static fallback event loop group and host resolver.  This allows us to provide a safe alternative for users that don't want to manage CRT resources with the associated ref-juggling.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
