### PR TITLE
clean up local reference of java_continuation_handler and java_continuation

### DIFF
--- a/src/native/event_stream_rpc_server.c
+++ b/src/native/event_stream_rpc_server.c
@@ -218,6 +218,8 @@ static int s_on_incoming_stream_fn(
     continuation_options->on_continuation = s_stream_continuation_fn;
     continuation_options->on_continuation_closed = s_stream_continuation_closed_fn;
     continuation_callback_data->java_continuation_handler = (*env)->NewGlobalRef(env, java_continuation_handler);
+    (*env)->DeleteLocalRef(env, java_continuation_handler);
+    (*env)->DeleteLocalRef(env, java_continuation);
     return AWS_OP_SUCCESS;
 }
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
`java_contunation_handler` and `java_contuation` local references are not cleaned up.

The fix is tested on device.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
