### PR TITLE
Fixing IllegalMonitorException in JUnit tests and cleaning up static …

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CrtResource.java
+++ b/src/main/java/software/amazon/awssdk/crt/CrtResource.java
@@ -4,6 +4,9 @@
  */
 package software.amazon.awssdk.crt;
 
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Map;
@@ -379,6 +382,9 @@ public abstract class CrtResource implements AutoCloseable {
      * a period of waiting.
      */
     public static void waitForNoResources() {
+        EventLoopGroup.closeStaticDefault();
+        HostResolver.closeStaticDefault();
+
         if (debugNativeObjects) {
             lock.lock();
 

--- a/src/test/java/software/amazon/awssdk/crt/test/EventStreamClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/EventStreamClientConnectionTest.java
@@ -82,6 +82,7 @@ public class EventStreamClientConnectionTest extends CrtTestFixture {
 
         connectFuture.get(1, TimeUnit.SECONDS);
         assertNotNull(clientConnectionArray[0]);
+        serverConnectionAccepted.get(1, TimeUnit.SECONDS);
         assertNotNull(serverConnections[0]);
         clientConnectionArray[0].closeConnection(0);
         clientConnectionArray[0].getClosedFuture().get(1, TimeUnit.SECONDS);


### PR DESCRIPTION
…resources in CrtResource.waitForNoResources() for unit test use cases as well.

*Description of changes:*
 * Added clean up of static host resolver and event loop group in CrtResource.
 * Updated sync functions used in JUnit test cases to eliminate IllegalMonitorException being thrown (and ignored).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
