### PR TITLE
MqttMessage now contains qos, retain, dup

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnectionConfig.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnectionConfig.java
@@ -30,8 +30,8 @@ public final class MqttConnectionConfig extends CrtResource {
 
     /* will */
     private MqttMessage willMessage;
-    private QualityOfService willQos;
-    private boolean willRetain;
+    private QualityOfService deprecatedWillQos;
+    private Boolean deprecatedWillRetain;
 
     /* websockets */
     private boolean useWebsockets = false;
@@ -289,43 +289,44 @@ public final class MqttConnectionConfig extends CrtResource {
      * @return the message to publish as the will
      */
     public MqttMessage getWillMessage() {
+        if (willMessage == null || (deprecatedWillRetain == null && deprecatedWillQos == null)) {
         return willMessage;
     }
+        QualityOfService qos = deprecatedWillQos == null ? willMessage.getQos() : deprecatedWillQos;
+        boolean retain = deprecatedWillRetain == null ? willMessage.getRetain() : deprecatedWillRetain;
+        return new MqttMessage(willMessage.getTopic(), willMessage.getPayload(), qos, retain);
+    }
 
     /**
-     * Configures the quality of service for the will message's publish action
-     *
-     * @param qos the quality of service for the will message's publish action
+     * @deprecated Set QoS directly on the will's {@link MqttMessage}.
      */
+    @Deprecated
     public void setWillQos(QualityOfService qos) {
-        this.willQos = qos;
+        this.deprecatedWillQos = qos;
     }
 
     /**
-     * Queries the quality of service for the will message's publish action
-     *
-     * @return the quality of service for the will message's publish action
+     * @deprecated Query QoS directly from the will's {@link MqttMessage}.
      */
+    @Deprecated
     public QualityOfService getWillQos() {
-        return willQos;
+        return deprecatedWillQos;
     }
 
     /**
-     * Configures whether or not the message should be retained by the broker to be delivered to future subscribers
-     *
-     * @param retain whether or not the message should be retained by the broker to be delivered to future subscribers
+     * @deprecated Set retain directly on the will's {@link MqttMessage}.
      */
+    @Deprecated
     public void setWillRetain(boolean retain) {
-        this.willRetain = retain;
+        this.deprecatedWillRetain = retain;
     }
 
     /**
-     * Queries whether or not the message should be retained by the broker to be delivered to future subscribers
-     *
-     * @return whether or not the message should be retained by the broker to be delivered to future subscribers
+     * @deprecated Query retain directly from the will's {@link MqttMessage}.
      */
+    @Deprecated
     public boolean getWillRetain() {
-        return willRetain;
+        return deprecatedWillRetain;
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnectionConfig.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnectionConfig.java
@@ -290,8 +290,8 @@ public final class MqttConnectionConfig extends CrtResource {
      */
     public MqttMessage getWillMessage() {
         if (willMessage == null || (deprecatedWillRetain == null && deprecatedWillQos == null)) {
-        return willMessage;
-    }
+            return willMessage;
+        }
         QualityOfService qos = deprecatedWillQos == null ? willMessage.getQos() : deprecatedWillQos;
         boolean retain = deprecatedWillRetain == null ? willMessage.getRetain() : deprecatedWillRetain;
         return new MqttMessage(willMessage.getTopic(), willMessage.getPayload(), qos, retain);
@@ -310,7 +310,13 @@ public final class MqttConnectionConfig extends CrtResource {
      */
     @Deprecated
     public QualityOfService getWillQos() {
-        return deprecatedWillQos;
+        if (deprecatedWillQos != null) {
+            return deprecatedWillQos;
+        }
+        if (willMessage != null) {
+            return willMessage.getQos();
+        }
+        return null;
     }
 
     /**
@@ -326,7 +332,13 @@ public final class MqttConnectionConfig extends CrtResource {
      */
     @Deprecated
     public boolean getWillRetain() {
-        return deprecatedWillRetain;
+        if (deprecatedWillRetain != null) {
+            return deprecatedWillRetain;
+        }
+        if (willMessage != null) {
+            return willMessage.getRetain();
+        }
+        return false;
     }
 
     /**
@@ -414,8 +426,6 @@ public final class MqttConnectionConfig extends CrtResource {
             clone.setCleanSession(getCleanSession());
 
             clone.setWillMessage(getWillMessage());
-            clone.setWillQos(getWillQos());
-            clone.setWillRetain(getWillRetain());
 
             clone.setUseWebsockets(getUseWebsockets());
             clone.setWebsocketProxyOptions(getWebsocketProxyOptions());

--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttMessage.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttMessage.java
@@ -5,20 +5,72 @@
 package software.amazon.awssdk.crt.mqtt;
 
 /**
- * Represents a single message to be published or that was published to a connection
+ * Represents a message to publish, or a message that was received.
  */
 public final class MqttMessage {
     private String topic;
     private final byte[] payload;
+    private QualityOfService qos;
+    private boolean retain;
+    private boolean dup;
 
     /**
-     * Constructs a new payload
-     * @param topic The topic this message is to be published on or was published to
-     * @param payload The message payload. 
+     * Constructs a new message.
+     *
+     * @param topic   Message topic.
+     * @param payload Message payload.
+     * @param qos     {@link QualityOfService}. When sending, the
+     *                {@link QualityOfService} to use for delivery. When receiving,
+     *                the {@link QualityOfService} used for delivery.
+     * @param retain  Retain flag. When sending, whether the message should be
+     *                retained by the broker and delivered to future subscribers.
+     *                When receiving, whether the message was sent as a result of a
+     *                new subscription being made.
+     * @param dup     DUP flag. Ignored when sending. When receiving, indicates
+     *                whether this might be re-delivery of an earlier attempt to
+     *                send the message.
      */
-    public MqttMessage(String topic, byte[] payload) {
+    public MqttMessage(String topic, byte[] payload, QualityOfService qos, boolean retain, boolean dup) {
         this.topic = topic;
         this.payload = payload;
+        this.dup = dup;
+        this.qos = qos;
+        this.retain = retain;
+    }
+
+    /**
+     * Constructs a new message.
+     *
+     * @param topic   Message topic.
+     * @param payload Message payload.
+     * @param qos     {@link QualityOfService}. When sending, the
+     *                {@link QualityOfService} to use for delivery. When receiving,
+     *                the {@link QualityOfService} used for delivery.
+     * @param retain  Retain flag. When sending, whether the message should be
+     *                retained by the broker and delivered to future subscribers.
+     *                When receiving, whether the message was sent as a result of a
+     *                new subscription being made.
+     */
+    public MqttMessage(String topic, byte[] payload, QualityOfService qos, boolean retain) {
+        this(topic, payload, qos, retain, false);
+    }
+
+    /**
+     * Constructs a new message.
+     *
+     * @param topic   Message topic.
+     * @param payload Message payload.
+     * @param qos     {@link QualityOfService}. When sending, the
+     *                {@link QualityOfService} to use for delivery. When receiving,
+     *                the {@link QualityOfService} used for delivery.
+     */
+    public MqttMessage(String topic, byte[] payload, QualityOfService qos) {
+        this(topic, payload, qos, false, false);
+    }
+
+    @Deprecated
+    public MqttMessage(String topic, byte[] payload) {
+        this(topic, payload, QualityOfService.AT_LEAST_ONCE, false, false);
     }
 
     /**
@@ -36,4 +88,37 @@ public final class MqttMessage {
     public byte[] getPayload() {
         return payload;
     }
+
+    /**
+     * Gets the {@link QualityOfService}. When sending, the {@link QualityOfService}
+     * to use for delivery. When receiving, the {@link QualityOfService} used for
+     * delivery.
+     *
+     * @return The {@link QualityOfService}
+     */
+    public QualityOfService getQos() {
+        return qos;
+    }
+
+    /**
+     * Gets the retain flag. When sending, whether the message should be retained by
+     * the broker and delivered to future subscribers. When receiving, whether the
+     * message was sent as a result of a new subscription being made.
+     *
+     * @return Retain flag
+     */
+    public boolean getRetain() {
+        return retain;
+    }
+
+    /**
+     * Gets the DUP flag. Ignored when sending. When receiving, indicates whether
+     * this might be re-delivery of an earlier attempt to send the message.
+     *
+     * @return DUP flag
+     */
+    public boolean getDup() {
+        return dup;
+    }
+
 }

--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttMessage.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttMessage.java
@@ -68,6 +68,9 @@ public final class MqttMessage {
         this(topic, payload, qos, false, false);
     }
 
+    /**
+     * @deprecated Use alternate constructor.
+     */
     @Deprecated
     public MqttMessage(String topic, byte[] payload) {
         this(topic, payload, QualityOfService.AT_LEAST_ONCE, false, false);

--- a/src/main/java/software/amazon/awssdk/crt/mqtt/QualityOfService.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/QualityOfService.java
@@ -5,6 +5,11 @@
 
 package software.amazon.awssdk.crt.mqtt;
 
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * Quality of Service associated with a publish action or subscription [MQTT-4.3].
   */
@@ -37,4 +42,19 @@ public enum QualityOfService {
     public int getValue() {
         return qos;
     }
+
+    public static QualityOfService getEnumValueFromInteger(int value) {
+        QualityOfService enumValue = enumMapping.get(value);
+        if (enumValue != null) {
+            return enumValue;
+        }
+        throw new RuntimeException("Illegal QualityOfService");
+    }
+
+    private static Map<Integer, QualityOfService> buildEnumMapping() {
+        return Stream.of(QualityOfService.values())
+            .collect(Collectors.toMap(QualityOfService::getValue, Function.identity()));
+    }
+
+    private static Map<Integer, QualityOfService> enumMapping = buildEnumMapping();
 }

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -169,7 +169,7 @@ static void s_cache_message_handler(JNIEnv *env) {
     jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/mqtt/MqttClientConnection$MessageHandler");
     AWS_FATAL_ASSERT(cls);
 
-    message_handler_properties.deliver = (*env)->GetMethodID(env, cls, "deliver", "(Ljava/lang/String;[B)V");
+    message_handler_properties.deliver = (*env)->GetMethodID(env, cls, "deliver", "(Ljava/lang/String;[BZIZ)V");
     AWS_FATAL_ASSERT(message_handler_properties.deliver);
 }
 

--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -566,7 +566,11 @@ static void s_on_subscription_delivered(
     struct aws_mqtt_client_connection *connection,
     const struct aws_byte_cursor *topic,
     const struct aws_byte_cursor *payload,
+    bool dup,
+    enum aws_mqtt_qos qos,
+    bool retain,
     void *user_data) {
+
     AWS_FATAL_ASSERT(connection);
     AWS_FATAL_ASSERT(topic);
     AWS_FATAL_ASSERT(payload);
@@ -583,7 +587,8 @@ static void s_on_subscription_delivered(
 
     jstring jni_topic = aws_jni_string_from_cursor(env, topic);
 
-    (*env)->CallVoidMethod(env, callback->async_callback, message_handler_properties.deliver, jni_topic, jni_payload);
+    (*env)->CallVoidMethod(
+        env, callback->async_callback, message_handler_properties.deliver, jni_topic, jni_payload, dup, qos, retain);
 
     (*env)->DeleteLocalRef(env, jni_payload);
     (*env)->DeleteLocalRef(env, jni_topic);

--- a/src/test/java/software/amazon/awssdk/crt/test/ProcessTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/ProcessTest.java
@@ -15,7 +15,7 @@ import software.amazon.awssdk.crt.Process;
 
 public class ProcessTest extends CrtTestFixture  {
     public ProcessTest() {}
-    
+
     @Test
     public void testGetPid() {
         int pid = Process.getPid();
@@ -43,7 +43,7 @@ public class ProcessTest extends CrtTestFixture  {
             Process.setMaxIOHandlesSoftLimit(softLimit - 1);
         } catch (CrtRuntimeException ex) {
             // make sure it's the not-implemented exception if it was thrown.
-            assertEquals(36, ex.errorCode);
+            assertEquals("AWS_ERROR_UNIMPLEMENTED", ex.errorName);
         }
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/PublishTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/PublishTest.java
@@ -33,8 +33,8 @@ public class PublishTest extends MqttClientConnectionFixture {
         connect();
 
         try {
-            MqttMessage message = new MqttMessage(TEST_TOPIC, TEST_PAYLOAD.getBytes());
-            CompletableFuture<Integer> published = connection.publish(message, QualityOfService.AT_LEAST_ONCE, false);
+            MqttMessage message = new MqttMessage(TEST_TOPIC, TEST_PAYLOAD.getBytes(), QualityOfService.AT_LEAST_ONCE);
+            CompletableFuture<Integer> published = connection.publish(message);
             published.thenApply(packetId -> pubsAcked++);
             published.get();
 

--- a/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.fail;
 public class WillTest extends MqttClientConnectionFixture {
     @Rule
     public Timeout testTimeout = Timeout.seconds(15);
-    
+
     public WillTest() {
     }
 
@@ -29,11 +29,9 @@ public class WillTest extends MqttClientConnectionFixture {
 
     @Override
     protected void modifyConnectionConfiguration(MqttConnectionConfig config) {
-        MqttMessage will = new MqttMessage(TEST_TOPIC, TEST_WILL.getBytes());
+        MqttMessage will = new MqttMessage(TEST_TOPIC, TEST_WILL.getBytes(), QualityOfService.AT_LEAST_ONCE);
 
         config.setWillMessage(will);
-        config.setWillQos(QualityOfService.AT_LEAST_ONCE);
-        config.setWillRetain(false);
     }
 
     @Test


### PR DESCRIPTION
This allows users to know the `qos`, `retain`, and `dup` of received messages.

Functions that took `MqttMessage`, `qos`, and `retain` as separate parameters have been deprecated in favor of functions that just take an `MqttMessage`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
