### PR TITLE
PackageInfo: Prefer implementation version to specification version

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/utils/PackageInfo.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/PackageInfo.java
@@ -18,7 +18,7 @@ public final class PackageInfo {
 
         public Version(String v) {
             version = v != null ? v : "UNKNOWN";
-            
+
             int dashIdx = version.indexOf('-');
             if (dashIdx != -1) {
                 tag = version.substring(dashIdx + 1);
@@ -48,7 +48,7 @@ public final class PackageInfo {
             return 0;
         }
     }
-    
+
     public Version version;
 
     public PackageInfo() {
@@ -59,9 +59,9 @@ public final class PackageInfo {
         }
 
         Package pkg = CRT.class.getPackage();
-        String pkgVersion = pkg.getSpecificationVersion();
+        String pkgVersion = pkg.getImplementationVersion();
         if (pkgVersion == null) {
-            pkgVersion = pkg.getImplementationVersion();
+            pkgVersion = pkg.getSpecificationVersion();
         }
         // There is no JAR/manifest during internal tests
         if (pkgVersion == null) {
@@ -69,5 +69,5 @@ public final class PackageInfo {
         }
         version = new Version(pkgVersion);
     }
-    
+
 }


### PR DESCRIPTION
The implementation version is finer grained than the specification
version (e.g. "0.10.6" versus "0.10"), so it seems that the
specification version should only be used as a backup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
