### PR TITLE
Add architecture detection for riscv. Submodule s2n remains untouched.

### DIFF
--- a/cmake/archdetect.c
+++ b/cmake/archdetect.c
@@ -12,6 +12,12 @@
 #    elif defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__)
 #        error ARCH armv6
 #    endif
+#elif defined(__riscv)
+#    if __riscv_xlen==64
+#        error ARCH riscv64
+#    else
+#        error ARCH riscv32
+#    endif
 #else
 #    error ARCH unknown
 #endif

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -113,6 +113,12 @@ public final class CRT {
             return (getOSIdentifier() == "android") ? "arm64-v8a": "armv8";
         } else if (arch.equals("arm")) {
            return "armv6";
+        } else if (arch.startsWith("riscv")) {
+           if (arch.contains("64")) {
+               return "riscv64";
+           } else {
+               return "riscv32";
+           }
         }
 
         throw new UnknownPlatformException("AWS CRT: architecture not supported: " + arch);


### PR DESCRIPTION
Initial commit for RISC-V support

Added architecture detection.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
