### PR TITLE
Gentle shutdown by default

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -38,7 +38,8 @@ public final class CRT {
             memoryTracingLevel = Integer.parseInt(System.getProperty("aws.crt.memory.tracing"));
         } catch (Exception ex) {}
         boolean debugWait = System.getProperty("aws.crt.debugwait") != null;
-        awsCrtInit(memoryTracingLevel, debugWait);
+        boolean strictShutdown = System.getProperty("aws.crt.strictshutdown") != null;
+        awsCrtInit(memoryTracingLevel, debugWait, strictShutdown);
 
         try {
             Log.initLoggingFromSystemProperties();
@@ -225,7 +226,7 @@ public final class CRT {
     }
 
     // Called internally when bootstrapping the CRT, allows native code to do any static initialization it needs
-    private static native void awsCrtInit(int memoryTracingLevel, boolean debugWait) throws CrtRuntimeException;
+    private static native void awsCrtInit(int memoryTracingLevel, boolean debugWait, boolean strictShutdown) throws CrtRuntimeException;
 
     /**
      * Returns the last error on the current thread.

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -213,7 +213,7 @@ JNIEnv *aws_jni_get_thread_env(JavaVM *jvm) {
     return env;
 }
 
-static void s_jni_atexit(void) {
+static void s_jni_atexit_strict(void) {
     aws_s3_library_clean_up();
     aws_event_stream_library_clean_up();
     aws_auth_library_clean_up();
@@ -233,6 +233,38 @@ static void s_jni_atexit(void) {
     }
 }
 
+#define DEFAULT_MANAGED_SHUTDOWN_WAIT_IN_SECONDS 1
+
+static void s_jni_atexit_gentle(void) {
+
+    /* If not doing strict shutdown, wait only a short time before shutting down */
+    aws_thread_set_managed_join_timeout_ns(
+        aws_timestamp_convert(DEFAULT_MANAGED_SHUTDOWN_WAIT_IN_SECONDS, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL));
+
+    if (aws_thread_join_all_managed() == AWS_OP_SUCCESS) {
+        /* a successful managed join means it should be safe to do a full, strict clean up */
+        s_jni_atexit_strict();
+    } else {
+        /*
+         * We didn't successfully join all our threads so it's not really safe to clean up the libraries.
+         * Just dump memory if applicable and exit.
+         */
+        AWS_LOGF_WARN(
+            AWS_LS_JAVA_CRT_GENERAL,
+            "Not all native threads were successfully joined during gentle shutdown.  Memory may be leaked.");
+
+        if (g_memory_tracing) {
+            AWS_LOGF_DEBUG(
+                AWS_LS_JAVA_CRT_GENERAL,
+                "At shutdown, %u bytes remaining",
+                (uint32_t)aws_mem_tracer_bytes(aws_jni_get_allocator()));
+            if (g_memory_tracing > 1) {
+                aws_mem_tracer_dump(aws_jni_get_allocator());
+            }
+        }
+    }
+}
+
 #define KB_256 (256 * 1024)
 
 /* Called as the entry point, immediately after the shared lib is loaded the first time by JNI */
@@ -241,7 +273,8 @@ void JNICALL Java_software_amazon_awssdk_crt_CRT_awsCrtInit(
     JNIEnv *env,
     jclass jni_crt_class,
     jint jni_memtrace,
-    jboolean jni_debug_wait) {
+    jboolean jni_debug_wait,
+    jboolean jni_strict_shutdown) {
     (void)jni_crt_class;
 
     if (jni_debug_wait) {
@@ -273,7 +306,12 @@ void JNICALL Java_software_amazon_awssdk_crt_CRT_awsCrtInit(
     aws_s3_library_init(allocator);
 
     cache_java_class_ids(env);
-    atexit(s_jni_atexit);
+
+    if (jni_strict_shutdown) {
+        atexit(s_jni_atexit_strict);
+    } else {
+        atexit(s_jni_atexit_gentle);
+    }
 }
 
 JNIEXPORT

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -8,7 +8,17 @@
 
 #include <aws/common/byte_buf.h>
 #include <aws/common/common.h>
+#include <aws/common/logging.h>
+
 #include <jni.h>
+
+#define AWS_CRT_JAVA_PACKAGE_ID 9
+
+enum aws_java_crt_log_subject {
+    AWS_LS_JAVA_CRT_GENERAL = AWS_LOG_SUBJECT_BEGIN_RANGE(AWS_CRT_JAVA_PACKAGE_ID),
+
+    AWS_LS_JAVA_CRT_LAST = AWS_LOG_SUBJECT_END_RANGE(AWS_CRT_JAVA_PACKAGE_ID)
+};
 
 struct aws_allocator *aws_jni_get_allocator(void);
 


### PR DESCRIPTION
* By default, do a gentle shutdown that does not require all native threads to be joined before jni exit
* https://github.com/aws/aws-iot-device-sdk-java-v2/issues/139

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
