### PR TITLE
fix:Release payload and header jni byte arrays during read/write from/…

### DIFF
--- a/src/native/event_stream_rpc_client.c
+++ b/src/native/event_stream_rpc_client.c
@@ -110,6 +110,9 @@ static void s_connection_protocol_message(
         payload_byte_array,
         (jint)message_args->message_type,
         (jint)message_args->message_flags);
+
+    (*env)->DeleteLocalRef(env, payload_byte_array);
+    (*env)->DeleteLocalRef(env, headers_array);
     aws_jni_check_and_clear_exception(env);
 }
 
@@ -382,6 +385,9 @@ static void s_stream_continuation(
         payload_byte_array,
         (jint)message_args->message_type,
         (jint)message_args->message_flags);
+
+    (*env)->DeleteLocalRef(env, payload_byte_array);
+    (*env)->DeleteLocalRef(env, headers_array);
     /* don't really care if they threw here, but we want to make the jvm happy that we checked */
     aws_jni_check_and_clear_exception(env);
 }


### PR DESCRIPTION
…to continuation

*Issue #, if available:*
Local reference for payload jByteArray is not being released which is causing heap memory increase as the client continues to send/receive messages over event stream.

*Description of changes:*
Releasing the local reference to jByteArrays 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
