### PR TITLE
Add onResponse to ResponseDataConsumer 

### DIFF
--- a/s3-native-client/src/main/java/com/amazonaws/s3/ResponseDataConsumer.java
+++ b/s3-native-client/src/main/java/com/amazonaws/s3/ResponseDataConsumer.java
@@ -1,20 +1,25 @@
 package com.amazonaws.s3;
 
-import java.util.function.Consumer;
+import java.nio.ByteBuffer;
 
 /**
  * Produces events for response streaming data to be handled without holding everything in memory
+ * @param <T> POJO response type.
  */
-public interface ResponseDataConsumer extends Consumer<byte[]>, OperationHandler {
-    default void accept(byte[] bodyBytesIn) {
-        onResponseData(bodyBytesIn);
-    }
+public interface ResponseDataConsumer<T> extends OperationHandler {
+
+    /**
+     * Called when the unmarshalled response object is ready.
+     *
+     * @param response The unmarshalled response.
+     */
+    public void onResponse(T response);
     
     /**
      * Called multiple times in sequence until there are no more response body bytes. 
      * @param bodyBytesIn the next sequence of bytes representing the data requested through the operation
      */
-    public void onResponseData(byte[] bodyBytesIn);
+    public void onResponseData(ByteBuffer bodyBytesIn);
 
     /**
      * Invoked when the transfer has completed normally

--- a/s3-native-client/src/main/java/com/amazonaws/s3/S3NativeClient.java
+++ b/s3-native-client/src/main/java/com/amazonaws/s3/S3NativeClient.java
@@ -38,10 +38,11 @@ public class S3NativeClient implements  AutoCloseable {
     }
 
     public CompletableFuture<GetObjectOutput> getObject(GetObjectRequest request,
-                                                        final ResponseDataConsumer dataHandler) {
+                                                        final ResponseDataConsumer<GetObjectOutput> dataHandler) {
         final CompletableFuture<GetObjectOutput> resultFuture = new CompletableFuture<>();
         final GetObjectOutput.Builder resultBuilder = GetObjectOutput.builder();
         final S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
+            private GetObjectOutput getObjectOutput;
             @Override
             public void onResponseHeaders(final int statusCode, final HttpHeader[] headers) {
                 for (int headerIndex = 0; headerIndex < headers.length; ++headerIndex) {
@@ -54,10 +55,12 @@ public class S3NativeClient implements  AutoCloseable {
                     }
                 }
                 dataHandler.onResponseHeaders(statusCode, headers);
+                getObjectOutput = resultBuilder.build();
+                dataHandler.onResponse(getObjectOutput);
             }
 
             @Override
-            public int onResponseBody(byte[] bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+            public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
                 dataHandler.onResponseData(bodyBytesIn);
                 return 0;
             }
@@ -78,7 +81,7 @@ public class S3NativeClient implements  AutoCloseable {
                         resultFuture.completeExceptionally(ex);
                     }
                     else {
-                        resultFuture.complete(resultBuilder.build());
+                        resultFuture.complete(getObjectOutput);
                     }
                 }
             }
@@ -168,7 +171,7 @@ public class S3NativeClient implements  AutoCloseable {
             }
 
             @Override
-            public int onResponseBody(byte[] bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+            public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
                 return 0;
             }
 

--- a/s3-native-client/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
+++ b/s3-native-client/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
@@ -1,8 +1,12 @@
 package com.amazonaws.s3;
 
+import static org.junit.Assert.assertNotNull;
+
+import com.amazonaws.s3.model.GetObjectOutput;
 import com.amazonaws.s3.model.GetObjectRequest;
 import com.amazonaws.s3.model.PutObjectRequest;
 import com.amazonaws.test.AwsClientTestFixture;
+import java.nio.ByteBuffer;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CrtRuntimeException;
@@ -37,11 +41,16 @@ public class S3NativeClientTest extends AwsClientTestFixture {
             nativeClient.getObject(GetObjectRequest.builder()
                     .bucket(BUCKET)
                     .key(GET_OBJECT_KEY)
-                    .build(), new ResponseDataConsumer() {
-                
+                    .build(), new ResponseDataConsumer<GetObjectOutput>() {
+
                 @Override
-                public void onResponseData(byte[] bodyBytesIn) {
-                    length[0] += bodyBytesIn.length;
+                public void onResponse(GetObjectOutput response) {
+                    assertNotNull(response);
+                }
+
+                @Override
+                public void onResponseData(ByteBuffer bodyBytesIn) {
+                    length[0] += bodyBytesIn.remaining();
                 }
 
                 @Override
@@ -49,7 +58,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
 
                 @Override
                 public void onException(final CrtRuntimeException e) { }
-            });
+            }).join();
         }
     }
     
@@ -75,7 +84,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
                         }
                         lengthWritten[0] += buffer.length;
                         return lengthWritten[0] == contentLength;
-                    });
+                    }).join();
 
         }
     }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandler.java
@@ -1,11 +1,12 @@
 package software.amazon.awssdk.crt.s3;
 
+import java.nio.ByteBuffer;
 import software.amazon.awssdk.crt.http.HttpHeader;
 
 public interface S3MetaRequestResponseHandler {
     default void onResponseHeaders(final int statusCode, final HttpHeader[] headers) { }
     
-    default int onResponseBody(byte[] bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+    default int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
         return 0;
     }
 

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandlerNativeAdapter.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandlerNativeAdapter.java
@@ -12,9 +12,7 @@ class S3MetaRequestResponseHandlerNativeAdapter {
     }
 
     int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
-        byte[] payload = new byte[bodyBytesIn.limit()];
-        bodyBytesIn.get(payload);
-        return this.responseHandler.onResponseBody(payload, objectRangeStart, objectRangeEnd);
+        return this.responseHandler.onResponseBody(bodyBytesIn, objectRangeStart, objectRangeEnd);
     }
 
     void onFinished(int errorCode) {

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
@@ -108,9 +108,11 @@ public class S3ClientTest extends CrtTestFixture {
             S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
 
                 @Override
-                public int onResponseBody(byte[] bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+                public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+                    byte[] bytes = new byte[bodyBytesIn.remaining()];
+                    bodyBytesIn.get(bytes);
                     Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3,
-                            "Body Response: " + bodyBytesIn.toString());
+                            "Body Response: " + Arrays.toString(bytes));
                     return 0;
                 }
 
@@ -174,7 +176,7 @@ public class S3ClientTest extends CrtTestFixture {
             S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
 
                 @Override
-                public int onResponseBody(byte[] bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+                public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
                     Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3, "Body Response: " + bodyBytesIn.toString());
                     return 0;
                 }
@@ -378,8 +380,8 @@ public class S3ClientTest extends CrtTestFixture {
                         TransferStats stats = new TransferStats();
 
                         @Override
-                        public int onResponseBody(byte[] bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
-                            stats.recordRead(bodyBytesIn.length);
+                        public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+                            stats.recordRead(bodyBytesIn.remaining());
                             return 0;
                         }
 


### PR DESCRIPTION
*Description of changes:*

- Add `onResponse` to `ResponseDataConsumer` which is called when the unmarshalled response object is ready. 
- Use `ByteBuffer` in onResponse
- Update `ResponseDataConsumer` to not extend `Consumer` because `onResponseData` can be called multiple times


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
