### PR TITLE
Add changes to RequestDataSupplier

### DIFF
--- a/s3-native-client/src/main/java/com/amazonaws/s3/RequestDataSupplier.java
+++ b/s3-native-client/src/main/java/com/amazonaws/s3/RequestDataSupplier.java
@@ -1,22 +1,19 @@
 package com.amazonaws.s3;
 
-import java.util.function.Function;
+import java.nio.ByteBuffer;
 
-public interface RequestDataSupplier extends Function<byte[], Boolean>, OperationHandler{
-    default Boolean apply(byte[] buffer) {
-        return getRequestBytes(buffer);
-    }
-
+@FunctionalInterface
+public interface RequestDataSupplier extends OperationHandler{
     /**
-     * Gives the supplier implement an array that must be fully populated with sequences of bytes, representing
-     * the data to be sent with the operation's request
+     * Called to retrieve data from this supplier. The supplier must write the
+     * available bytes to the given {@code ByteBuffer}.
      * 
      * Return true if all of the request data has been supplied
      * 
      * @param buffer byte array to populate with data.
      * @return true if and only if all of the data has been supplied and the transfer can complete 
      */
-    boolean getRequestBytes(byte[] buffer);
+    boolean getRequestBytes(ByteBuffer buffer);
 
     /**
      * Called when the processing needs the stream to rewind itself back to its beginning.

--- a/s3-native-client/src/main/java/com/amazonaws/s3/S3NativeClient.java
+++ b/s3-native-client/src/main/java/com/amazonaws/s3/S3NativeClient.java
@@ -115,14 +115,7 @@ public class S3NativeClient implements  AutoCloseable {
             @Override
             public boolean sendRequestBody(final ByteBuffer outBuffer) {
                 try {
-                    if (outBuffer.hasArray()) {
-                        return requestDataSupplier.getRequestBytes(outBuffer.array());
-                    } else {
-                        byte[] buffer = new byte[outBuffer.capacity()];
-                        boolean returnFlag = requestDataSupplier.getRequestBytes(buffer);
-                        outBuffer.put(buffer);  //assert outBuffer.remaining() == 0
-                        return returnFlag;
-                    }
+                    return requestDataSupplier.getRequestBytes(outBuffer);
                 } catch (Exception e) {
                     resultFuture.completeExceptionally(e);
                     return true;

--- a/s3-native-client/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
+++ b/s3-native-client/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
@@ -3,6 +3,7 @@ package com.amazonaws.s3;
 import com.amazonaws.s3.model.GetObjectRequest;
 import com.amazonaws.s3.model.PutObjectRequest;
 import com.amazonaws.test.AwsClientTestFixture;
+import java.nio.ByteBuffer;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CrtRuntimeException;
@@ -70,10 +71,11 @@ public class S3NativeClientTest extends AwsClientTestFixture {
                     .key(PUT_OBJECT_KEY)
                     .contentLength(contentLength)
                     .build(), buffer -> {
-                        for (int index = 0; index < buffer.length; ++index) {
-                            buffer[index] = 42;
+                        while (buffer.hasRemaining()) {
+                            buffer.put((byte) 42);
+                            ++lengthWritten[0];
                         }
-                        lengthWritten[0] += buffer.length;
+                        buffer.flip();
                         return lengthWritten[0] == contentLength;
                     });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 - Remove unneeded extension of Function; replace with
   @FunctionalInterface annotation

 - Change getRequestBytes to accept ByteBuffer for more flexibility in
   how the callee supplies data (no need to fill buffer entirely)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


Opened in favor of #293.