### PR TITLE
Update resource wait API to wait long enough for s2n tls alerts to go out

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CrtResource.java
+++ b/src/main/java/software/amazon/awssdk/crt/CrtResource.java
@@ -25,7 +25,7 @@ import java.util.function.Consumer;
  */
 public abstract class CrtResource implements AutoCloseable {
     private static final String NATIVE_DEBUG_PROPERTY_NAME = "aws.crt.debugnative";
-    private static final long DEBUG_CLEANUP_WAIT_TIME_IN_SECONDS = 10;
+    private static final int DEBUG_CLEANUP_WAIT_TIME_IN_SECONDS = 60;
     private static final long NULL = 0;
 
     public class ResourceInstance {
@@ -407,7 +407,7 @@ public abstract class CrtResource implements AutoCloseable {
             }
         }
 
-        waitForGlobalResourceDestruction(10);
+        waitForGlobalResourceDestruction(DEBUG_CLEANUP_WAIT_TIME_IN_SECONDS);
     }
 
     private static native void waitForGlobalResourceDestruction(int timeoutInSeconds);


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
