### PR TITLE
Updating aws-c-http to v0.6.2 

### DIFF
--- a/src/native/credentials_provider.c
+++ b/src/native/credentials_provider.c
@@ -14,6 +14,7 @@
 #include <aws/common/clock.h>
 #include <aws/common/string.h>
 #include <aws/http/connection.h>
+#include <aws/http/proxy.h>
 #include <aws/io/tls_channel_handler.h>
 
 /* on 32-bit platforms, casting pointers to longs throws a warning we don't need */

--- a/src/native/http_connection_manager.c
+++ b/src/native/http_connection_manager.c
@@ -21,6 +21,7 @@
 #include <aws/http/connection.h>
 #include <aws/http/connection_manager.h>
 #include <aws/http/http.h>
+#include <aws/http/proxy.h>
 
 /* on 32-bit platforms, casting pointers to longs throws a warning we don't need */
 #if UINTPTR_MAX == 0xffffffff

--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -11,6 +11,7 @@
 #include <aws/common/string.h>
 #include <aws/common/thread.h>
 #include <aws/http/connection.h>
+#include <aws/http/proxy.h>
 #include <aws/http/request_response.h>
 #include <aws/io/channel.h>
 #include <aws/io/channel_bootstrap.h>


### PR DESCRIPTION
*Description of changes:*
Updating aws-c-http submodule to v0.6.2, which requires some additional includes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
