### PR TITLE
Adding usage of coming build flag to ensure CI uses warnings and erro…

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -4,7 +4,7 @@
         "maven"
     ],
     "build_steps": [
-        "mvn -B compile"
+        "mvn -P continuous-integration -B compile"
     ],
     "test_steps": [
         "mvn -B test -DredirectTestOutputToFile=true -DforkCount=0 -DrerunFailingTestsCount=5"
@@ -35,7 +35,7 @@
         "linux": {
             "!build_steps": [
                 "{source_dir}/gradlew :s3-native-client:build -x test",
-                "mvn -B compile"
+                "mvn -P continuous-integration -B compile"
             ],
             "!test_steps": [
                 "mvn -B test -DforkCount=0 -DrerunFailingTestsCount=5"
@@ -124,7 +124,7 @@
                 "JAVA_HOME": "/usr/local/openjdk8"
             },
             "!build_steps": [
-                "mvn -B compile"
+                "mvn -P continuous-integration -B compile"
             ],
             "!test_steps": [
                 "mvn -B test -DrerunFailingTestsCount=5"

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,16 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cmake.warningsareerrors>OFF</cmake.warningsareerrors>
     </properties>
 
     <profiles>
+        <profile>
+            <id>continuous-integration</id>
+            <properties>
+                <cmake.warningsareerrors>ON</cmake.warningsareerrors>
+            </properties>
+        </profile>
         <profile>
             <!-- Windows profile: find cmake generators and use ALL_BUILD target
                 NOTE: CMake generator will be cached to target/cmake-build/cmake.properties, delete or edit this
@@ -141,6 +148,7 @@
                                         <argument>-DCMAKE_BUILD_TYPE=${cmake.buildtype}</argument>
                                         <argument>-DCMAKE_EXPORT_COMPILE_COMMANDS=ON</argument>
                                         <argument>-DBUILD_DEPS=ON</argument>
+                                        <argument>-DAWS_WARNINGS_ARE_ERRORS=${cmake.warningsareerrors}</argument>
                                         <argument>-DCMAKE_PREFIX_PATH=${cmake.binaries}/install</argument>
                                         <argument>-DCMAKE_INSTALL_PREFIX=${cmake.binaries}/install</argument>
                                         <argument>-DCMAKE_C_FLAGS=${cmake.cflags}</argument>


### PR DESCRIPTION
…rs, but no where else by default.

*Description of changes:*
* enable CI builds to fail on compiler warnings by default. Anticipating future default value change of this flag for non CI builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
