### PR TITLE
Submodule update to pull in SNI fix on Windows when overriding the root CA

### DIFF
--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     commands:
-      #- sudo add-apt-repository ppa:openjdk-r/ppa
+      - sudo add-apt-repository ppa:openjdk-r/ppa
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     commands:
-      - sudo add-apt-repository ppa:openjdk-r/ppa
+      #- sudo add-apt-repository ppa:openjdk-r/ppa
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y


### PR DESCRIPTION
* Properly validate SNI and server cert chain on Windows when using a root CA override

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
