### PR TITLE
Keep alive timeout MS -> Secs

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttClientConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttClientConnection.java
@@ -187,7 +187,7 @@ public class MqttClientConnection extends CrtResource {
             mqttClientConnectionConnect(getNativeHandle(), config.getEndpoint(), port,
                     socketOptions != null ? socketOptions.getNativeHandle() : 0,
                     tls != null ? tls.getNativeHandle() : 0, config.getClientId(), config.getCleanSession(),
-                    config.getKeepAliveMs(), pingTimeout, config.getProtocolOperationTimeoutMs());
+                    config.getKeepAliveSecs(), pingTimeout, config.getProtocolOperationTimeoutMs());
 
         } catch (CrtRuntimeException ex) {
             future.completeExceptionally(ex);

--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnectionConfig.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnectionConfig.java
@@ -195,7 +195,8 @@ public final class MqttConnectionConfig extends CrtResource {
 
     /**
      * Configures MQTT keep-alive via PING messages. Note that this is not TCP
-     * keepalive.
+     * keepalive. Note: AWS IoT Core only allows 30-1200 Secs. Anything larger than 
+     * 65535 will be capped.
      *
      * @param keepAliveSecs How often in seconds to send an MQTT PING message to the
      *                   service to keep a connection alive

--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnectionConfig.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttConnectionConfig.java
@@ -24,7 +24,7 @@ public final class MqttConnectionConfig extends CrtResource {
     private String username;
     private String password;
     private MqttClientConnectionEvents connectionCallbacks;
-    private int keepAliveMs = 0;
+    private int keepAliveSecs = 0;
     private int pingTimeoutMs = 0;
     private int protocolOperationTimeoutMs = 0;
     private boolean cleanSession = true;
@@ -169,24 +169,50 @@ public final class MqttConnectionConfig extends CrtResource {
     }
 
     /**
-     * Configures MQTT keep-alive via PING messages. Note that this is not TCP
-     * keepalive.
+     * @deprecated Configures MQTT keep-alive via PING messages. Note that this is not TCP
+     * keepalive. Please use setKeepAliveSecs instead.
      *
      * @param keepAliveMs How often in milliseconds to send an MQTT PING message to the
      *                   service to keep a connection alive
+     * 
      */
+    @Deprecated
     public void setKeepAliveMs(int keepAliveMs) {
-        this.keepAliveMs = keepAliveMs;
+        this.keepAliveSecs = keepAliveMs/1000;
+    }
+
+    /**
+     * @deprecated Queries the MQTT keep-alive via PING messages. Please use 
+     * getKeepAliveSecs instead.
+     *
+     * @return How often in milliseconds to send an MQTT PING message to the
+     *                   service to keep a connection alive
+     */
+    @Deprecated
+    public int getKeepAliveMs() {
+        return keepAliveSecs*1000;
+    }
+
+    /**
+     * Configures MQTT keep-alive via PING messages. Note that this is not TCP
+     * keepalive.
+     *
+     * @param keepAliveSecs How often in seconds to send an MQTT PING message to the
+     *                   service to keep a connection alive
+     * 
+     */
+    public void setKeepAliveSecs(int keepAliveSecs) {
+        this.keepAliveSecs = keepAliveSecs;
     }
 
     /**
      * Queries the MQTT keep-alive via PING messages.
      *
-     * @return How often in milliseconds to send an MQTT PING message to the
+     * @return How often in seconds to send an MQTT PING message to the
      *                   service to keep a connection alive
      */
-    public int getKeepAliveMs() {
-        return keepAliveMs;
+    public int getKeepAliveSecs() {
+        return keepAliveSecs;
     }
 
     /**
@@ -465,7 +491,7 @@ public final class MqttConnectionConfig extends CrtResource {
             clone.setUsername(getUsername());
             clone.setPassword(getPassword());
             clone.setConnectionCallbacks(getConnectionCallbacks());
-            clone.setKeepAliveMs(getKeepAliveMs());
+            clone.setKeepAliveSecs(getKeepAliveSecs());
             clone.setPingTimeoutMs(getPingTimeoutMs());
             clone.setProtocolOperationTimeoutMs(getProtocolOperationTimeoutMs());
             clone.setCleanSession(getCleanSession());

--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -379,7 +379,7 @@ void JNICALL Java_software_amazon_awssdk_crt_mqtt_MqttClientConnection_mqttClien
     jlong jni_tls_ctx,
     jstring jni_client_id,
     jboolean jni_clean_session,
-    jint keep_alive_ms,
+    jint keep_alive_secs,
     jshort ping_timeout_ms,
     jint protocol_operation_timeout_ms) {
     (void)jni_class;
@@ -438,7 +438,7 @@ void JNICALL Java_software_amazon_awssdk_crt_mqtt_MqttClientConnection_mqttClien
     connect_options.socket_options = &connection->socket_options;
     connect_options.tls_options = tls_options;
     connect_options.client_id = client_id;
-    connect_options.keep_alive_time_secs = (uint16_t)(keep_alive_ms / 1000);
+    connect_options.keep_alive_time_secs = (uint16_t)keep_alive_secs;
     connect_options.ping_timeout_ms = ping_timeout_ms;
     connect_options.protocol_operation_timeout_ms = protocol_operation_timeout_ms;
     connect_options.clean_session = clean_session;

--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -438,7 +438,7 @@ void JNICALL Java_software_amazon_awssdk_crt_mqtt_MqttClientConnection_mqttClien
     connect_options.socket_options = &connection->socket_options;
     connect_options.tls_options = tls_options;
     connect_options.client_id = client_id;
-    connect_options.keep_alive_time_secs = (uint16_t)keep_alive_ms / 1000;
+    connect_options.keep_alive_time_secs = (uint16_t)(keep_alive_ms / 1000);
     connect_options.ping_timeout_ms = ping_timeout_ms;
     connect_options.protocol_operation_timeout_ms = protocol_operation_timeout_ms;
     connect_options.clean_session = clean_session;

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
@@ -134,11 +134,11 @@ public class MqttClientConnectionFixture extends CrtTestFixture {
         return connect(false, 0, 0, anyMessageHandler);
     }
 
-    boolean connect(boolean cleanSession, int keepAliveMs, int protocolOperationTimeout) {
-        return connect(cleanSession, keepAliveMs, protocolOperationTimeout, null);
+    boolean connect(boolean cleanSession, int keepAliveSecs, int protocolOperationTimeout) {
+        return connect(cleanSession, keepAliveSecs, protocolOperationTimeout, null);
     }
 
-    boolean connect(boolean cleanSession, int keepAliveMs, int protocolOperationTimeout, Consumer<MqttMessage> anyMessageHandler) {
+    boolean connect(boolean cleanSession, int keepAliveSecs, int protocolOperationTimeout, Consumer<MqttMessage> anyMessageHandler) {
         Assume.assumeTrue(findCredentials());
 
         MqttClientConnectionEvents events = new MqttClientConnectionEvents() {
@@ -181,7 +181,7 @@ public class MqttClientConnectionFixture extends CrtTestFixture {
                 config.setEndpoint(iotEndpoint);
                 config.setPort(port);
                 config.setCleanSession(cleanSession);
-                config.setKeepAliveMs(keepAliveMs);
+                config.setKeepAliveSecs(keepAliveSecs);
                 config.setProtocolOperationTimeoutMs(protocolOperationTimeout);
 
                 modifyConnectionConfiguration(config);


### PR DESCRIPTION
Or, we should just set it to Sec instead Ms. Since it makes not sense to use Ms as it will be cast to uint_16

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
