### PR TITLE
Use byte[] for data delivery, do not require upstream copies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ endif()
 
 include(UseJava)
 include(AwsPlatformDetect)
+include(AwsSharedLibSetup)
 
 file(GLOB AWS_CRT_JAVA_HEADERS
         "include/aws/jni/*.h"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 
 dependencies {
     testImplementation("junit:junit:4.12")
+    testImplementation("org.mockito:mockito-core:3.+")
 }
 
 group = "software.amazon.awssdk.crt"

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandlerNativeAdapter.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandlerNativeAdapter.java
@@ -11,8 +11,8 @@ class S3MetaRequestResponseHandlerNativeAdapter {
         this.responseHandler = responseHandler;
     }
 
-    int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
-        return this.responseHandler.onResponseBody(bodyBytesIn, objectRangeStart, objectRangeEnd);
+    int onResponseBody(byte[] bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+        return this.responseHandler.onResponseBody(ByteBuffer.wrap(bodyBytesIn), objectRangeStart, objectRangeEnd);
     }
 
     void onFinished(int errorCode, int responseStatus, byte[] errorPayload) {

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -534,7 +534,7 @@ static void s_cache_s3_meta_request_response_handler_native_adapter_properties(J
     AWS_FATAL_ASSERT(cls);
 
     s3_meta_request_response_handler_native_adapter_properties.onResponseBody =
-        (*env)->GetMethodID(env, cls, "onResponseBody", "(Ljava/nio/ByteBuffer;JJ)I");
+        (*env)->GetMethodID(env, cls, "onResponseBody", "([BJJ)I");
     AWS_FATAL_ASSERT(s3_meta_request_response_handler_native_adapter_properties.onResponseBody);
 
     s3_meta_request_response_handler_native_adapter_properties.onFinished =

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -196,7 +196,7 @@ static int s_on_s3_meta_request_body_callback(
 
     JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
 
-    jobject jni_payload = aws_jni_direct_byte_buffer_from_raw_ptr(env, body->ptr, body->len);
+    jobject jni_payload = aws_jni_byte_array_from_cursor(env, body);
     jint body_response_result = 0;
 
     if (callback_data->java_s3_meta_request_response_handler_native_adapter != NULL) {

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
@@ -1,48 +1,34 @@
 package software.amazon.awssdk.crt.test;
 
-import software.amazon.awssdk.crt.CRT;
-import software.amazon.awssdk.crt.io.ClientBootstrap;
-import software.amazon.awssdk.crt.io.EventLoopGroup;
-import software.amazon.awssdk.crt.io.HostResolver;
-import software.amazon.awssdk.crt.io.TlsContext;
-import software.amazon.awssdk.crt.s3.*;
-import software.amazon.awssdk.crt.s3.S3MetaRequestOptions.MetaRequestType;
-import software.amazon.awssdk.crt.utils.ByteBufferUtils;
-import software.amazon.awssdk.crt.auth.credentials.DefaultChainCredentialsProvider;
-import software.amazon.awssdk.crt.http.HttpRequest;
-import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
-import software.amazon.awssdk.crt.http.HttpHeader;
-import software.amazon.awssdk.crt.Log;
-import software.amazon.awssdk.crt.CrtRuntimeException;
-import software.amazon.awssdk.crt.s3.CrtS3RuntimeException;
-
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import software.amazon.awssdk.crt.Log;
+import software.amazon.awssdk.crt.auth.credentials.DefaultChainCredentialsProvider;
+import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
+import software.amazon.awssdk.crt.io.*;
+import software.amazon.awssdk.crt.s3.*;
+import software.amazon.awssdk.crt.s3.S3MetaRequestOptions.MetaRequestType;
+import software.amazon.awssdk.crt.utils.ByteBufferUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
-import java.time.Instant;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.DoubleStream;
-import java.util.LinkedList;
-import java.util.List;
-
-import software.amazon.awssdk.crt.io.StandardRetryOptions;
-import software.amazon.awssdk.crt.io.ExponentialBackoffRetryOptions;
 
 public class S3ClientTest extends CrtTestFixture {
 


### PR DESCRIPTION
Also fixed gradle build, mockito dependency was missing from test configuration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
