### PR TITLE
Fix Android support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,19 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
+  android:
+    name: Android
+    # ubuntu-20.04 comes with Android tooling, see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#android
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Build ${{ env.PACKAGE_NAME }}
+        run: |
+          ./gradlew :android:crt:build
+
   check-submodules:
     runs-on: ubuntu-latest
     steps:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:7.0.0'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,23 +1,17 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
-//    ext.kotlin_version = '1.3.71'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
-//        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }
 
 allprojects {
     repositories {
         google()
+        mavenCentral()
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.71'
+//    ext.kotlin_version = '1.3.71'
     repositories {
         google()
-        jcenter()
-        
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.android.tools.build:gradle:4.2.0'
+//        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -19,8 +18,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+}
+
 allprojects {
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,6 +12,24 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
 }
 
+group = 'software.amazon.awssdk.crt'
+version = '1.0.0-dev'
+
+
+if (project.hasProperty("sonatypeUsername") && project.hasProperty("sonatypePassword")) {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+    nexusPublishing {
+        repositories {
+            create("awsNexus") {
+                nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
+                snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
+                username.set(project.property("sonatypeUsername") as String)
+                password.set(project.property("sonatypePassword") as String)
+            }
+        }
+    }
+}
+
 allprojects {
     repositories {
         google()

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -1,8 +1,6 @@
 import java.util.regex.Pattern
 
 apply plugin: 'com.android.library'
-//apply plugin: 'kotlin-android'
-//apply plugin: 'kotlin-android-extensions'
 
 // Before configuring, make sure libcrypto is installed
 preBuild {
@@ -96,11 +94,13 @@ android {
     buildTypes {
         debug {
             versionNameSuffix = gitVersionTag()
+            buildConfigField("String", "VERSION_NAME", "\"" + gitVersionName() + "\"")
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             versionNameSuffix ""
+            buildConfigField("String", "VERSION_NAME", "\"" + gitVersionName() + "\"")
         }
     }
 
@@ -122,7 +122,6 @@ build.dependsOn preBuild
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:monitor:1.2.0@aar'
@@ -162,7 +161,7 @@ afterEvaluate {
                 from components.release
 
                 groupId = 'software.amazon.awssdk.crt'
-                artifactId = 'android'
+                artifactId = 'aws-crt-android'
                 version = android.defaultConfig.versionName
             }
 
@@ -170,7 +169,7 @@ afterEvaluate {
                 from components.debug
 
                 groupId = 'software.amazon.awssdk.crt'
-                artifactId = 'android'
+                artifactId = 'aws-crt-android'
                 version = android.defaultConfig.versionName + '-SNAPSHOT'
             }
         }

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -58,7 +58,7 @@ android {
     useLibrary 'android.test.mock'
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 29
         versionCode = gitVersionCode()
         versionName = gitVersionName()

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -155,6 +155,10 @@ task androidDocsJar(type: Jar) {
 
 afterEvaluate {
     publishing {
+        repositories {
+            maven { name = "testLocal"; url = "$rootProject.buildDir/m2" }
+        }
+
         publications {
             release(MavenPublication) {
                 from components.release

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -50,7 +50,7 @@ ext {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "30.0.2"
+    buildToolsVersion "30.0.3"
     ndkVersion "21.4.7075529" // LTS version
 
     useLibrary 'android.test.runner'
@@ -121,11 +121,10 @@ android {
 build.dependsOn preBuild
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:monitor:1.2.0@aar'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test:monitor:1.4.0@aar'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
 }
 
 // Publishing

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -1,8 +1,8 @@
 import java.util.regex.Pattern
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+//apply plugin: 'kotlin-android'
+//apply plugin: 'kotlin-android-extensions'
 
 // Before configuring, make sure libcrypto is installed
 preBuild {
@@ -52,15 +52,15 @@ ext {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.3"
-    ndkVersion "21.0.6113669"
+    buildToolsVersion "30.0.2"
+    ndkVersion "21.4.7075529" // LTS version
 
     useLibrary 'android.test.runner'
     useLibrary 'android.test.base'
     useLibrary 'android.test.mock'
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 24
         targetSdkVersion 29
         versionCode = gitVersionCode()
         versionName = gitVersionName()

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -59,7 +59,7 @@ android {
     useLibrary 'android.test.mock'
 
     defaultConfig {
-        minSdkVersion 26  // TODO - dictated by CompletableFuture which is API 24+ and CRT::loadLibraryFromJar java.nio.File/Path usage
+        minSdkVersion 24  // TODO - dictated by CompletableFuture which is API 24+
         targetSdkVersion 30
         versionCode = gitVersionCode()
         versionName = gitVersionName()
@@ -116,12 +116,15 @@ android {
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
+        coreLibraryDesugaringEnabled true
     }
 }
 
 build.dependsOn preBuild
 
 dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+
     androidTestImplementation 'org.mockito:mockito-core:3.11.2'
     androidTestImplementation 'androidx.appcompat:appcompat:1.3.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -160,22 +160,6 @@ task androidDocsJar(type: Jar) {
 }
 
 
-if (project.hasProperty("sonatypeUsername") && project.hasProperty("sonatypePassword")) {
-    apply plugin: 'io.github.gradle-nexus.publish-plugin'
-
-    nexusPublishing {
-        repositories {
-            create("awsNexus") {
-                nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
-                snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
-                username.set(project.property("sonatypeUsername") as String)
-                password.set(project.property("sonatypePassword") as String)
-            }
-        }
-    }
-}
-
-
 afterEvaluate {
     publishing {
         repositories {
@@ -188,15 +172,30 @@ afterEvaluate {
 
                 groupId = 'software.amazon.awssdk.crt'
                 artifactId = 'aws-crt-android'
+                pom {
+                    name.set("software.amazon.awssdk.crt:aws-crt-android")
+                    description.set("Java Android bindings for the AWS SDK Common Runtime")
+                    url.set("https://github.com/awslabs/aws-crt-java")
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("aws-sdk-common-runtime")
+                            name.set("AWS SDK Common Runtime Team")
+                            email.set("aws-sdk-common-runtime@amazon.com")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:git://github.com/awslabs/aws-crt-java.git")
+                        developerConnection.set("scm:git:ssh://github.com/awslabs/aws-crt-java.git")
+                        url.set("https://github.com/awslabs/aws-crt-java")
+                    }
+                }
                 version = android.defaultConfig.versionName
-            }
-
-            debug(MavenPublication) {
-                from components.debug
-
-                groupId = 'software.amazon.awssdk.crt'
-                artifactId = 'aws-crt-android'
-                version = android.defaultConfig.versionName + '-SNAPSHOT'
             }
         }
         repositories {

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -50,7 +50,7 @@ ext {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion "30.0.3"
     ndkVersion "21.4.7075529" // LTS version
 
@@ -59,8 +59,8 @@ android {
     useLibrary 'android.test.mock'
 
     defaultConfig {
-        minSdkVersion 26
-        targetSdkVersion 29
+        minSdkVersion 26  // TODO - dictated by CompletableFuture which is API 24+ and CRT::loadLibraryFromJar java.nio.File/Path usage
+        targetSdkVersion 30
         versionCode = gitVersionCode()
         versionName = gitVersionName()
 

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -116,6 +116,9 @@ android {
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
+        // Enable desugaring so that Android lint doesn't flag `java.time` usage. Downstream
+        // consumers will need to enable desugaring to use this library.
+        // See: https://developer.android.com/studio/write/java8-support#library-desugaring
         coreLibraryDesugaringEnabled true
     }
 }

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -122,6 +122,8 @@ android {
 build.dependsOn preBuild
 
 dependencies {
+    androidTestImplementation 'org.mockito:mockito-core:3.11.2'
+    androidTestImplementation 'androidx.appcompat:appcompat:1.3.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:monitor:1.4.0@aar'

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -1,6 +1,7 @@
 import java.util.regex.Pattern
 
 apply plugin: 'com.android.library'
+apply plugin: 'signing'
 
 // Before configuring, make sure libcrypto is installed
 preBuild {
@@ -153,6 +154,23 @@ task androidDocsJar(type: Jar) {
     from androidDocs.destinationDir
 }
 
+
+if (project.hasProperty("sonatypeUsername") && project.hasProperty("sonatypePassword")) {
+    apply plugin: 'io.github.gradle-nexus.publish-plugin'
+
+    nexusPublishing {
+        repositories {
+            create("awsNexus") {
+                nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
+                snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
+                username.set(project.property("sonatypeUsername") as String)
+                password.set(project.property("sonatypePassword") as String)
+            }
+        }
+    }
+}
+
+
 afterEvaluate {
     publishing {
         repositories {
@@ -181,6 +199,17 @@ afterEvaluate {
                 def snapshotRepo = "https://aws.oss.sonatype.org/content/repositories/snapshots"
                 def releaseRepo = "https://aws.oss.sonatype.org/"
                 url = version.endsWith('SNAPSHOT') ? snapshotRepo : releaseRepo
+            }
+        }
+
+        if (project.hasProperty("signingKey") && project.hasProperty("signingPassword")) {
+            signing {
+                useInMemoryPgpKeys(
+                        (String) project.property("signingKey"),
+                        (String) project.property("signingPassword")
+                )
+                println("key=" + project.property("signingKey"))
+                sign(publications)
             }
         }
     }

--- a/android/crt/src/androidTest/assets/README.md
+++ b/android/crt/src/androidTest/assets/README.md
@@ -1,4 +1,4 @@
-Files required to make tests pass:
+Files required to make MQTT/IoT tests pass:
 ca-certificates.crt - Taken from any recent Linux /etc/ssl
 certificate.pem - IoT Thing Certificate
 privatekey.pem - IoT Thing Private Key

--- a/android/crt/src/androidTest/java/software/amazon/awssdk/crt/test/android/CrtPlatformImpl.java
+++ b/android/crt/src/androidTest/java/software/amazon/awssdk/crt/test/android/CrtPlatformImpl.java
@@ -5,7 +5,6 @@
 
 package software.amazon.awssdk.crt.test.android;
 
-import android.Manifest;
 import android.content.res.AssetManager;
 import android.os.Bundle;
 
@@ -16,7 +15,6 @@ import java.io.InputStream;
 import java.util.Set;
 
 import software.amazon.awssdk.crt.test.CrtTestContext;
-import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.utils.PackageInfo;
 
 // Overrides just for testing
@@ -45,7 +43,7 @@ public class CrtPlatformImpl extends software.amazon.awssdk.crt.android.CrtPlatf
             assetStream.read(contents);
             return contents;
         } catch (IOException ex) {
-            throw new CrtRuntimeException(ex.toString());
+            return null;
         }
     }
 
@@ -54,7 +52,10 @@ public class CrtPlatformImpl extends software.amazon.awssdk.crt.android.CrtPlatf
         ctx.trustStore = assetContents("ca-certificates.crt");
         ctx.iotClientCertificate = assetContents("certificate.pem");
         ctx.iotClientPrivateKey = assetContents("privatekey.pem");
-        ctx.iotEndpoint = new String(assetContents("endpoint.txt")).trim();
+        byte[] endpoint = assetContents("endpoint.txt");
+        if (endpoint != null) {
+            ctx.iotEndpoint = new String(endpoint).trim();
+        }
         ctx.iotCARoot = assetContents("AmazonRootCA1.pem");
     }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name='CRT'
+rootProject.name='aws-crt-android'
 include ':crt'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation("junit:junit:4.12")
-    testImplementation("org.mockito:mockito-core:3.+")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:3.11.2")
 }
 
 group = "software.amazon.awssdk.crt"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,11 @@ tasks.compileTestJava {
 }
 
 publishing {
+
+    repositories {
+        maven { name = "testLocal"; url = file("${rootProject.buildDir}/m2").toURI() }
+    }
+
     publications {
         create<MavenPublication>("maven") {
             artifactId = project.name

--- a/codebuild/cd/deploy-snapshot-android.sh
+++ b/codebuild/cd/deploy-snapshot-android.sh
@@ -1,0 +1,8 @@
+git submodule update --init
+cd ./android
+
+GPG_KEY=$(cat /tmp/aws-sdk-common-runtime.key.asc)
+# Publish to nexus
+./gradlew -PsigningKey=$"$GPG_KEY" -PsigningPassword=$GPG_PASSPHRASE -PsonatypeUsername='aws-sdk-common-runtime' -PsonatypePassword=$ST_PASSWORD publishToAwsNexus closeAwsNexusStagingRepository | tee /tmp/android_deploy.log
+# Get the staging repository id and save it
+cat /tmp/android_deploy.log | grep "Created staging repository" | cut -d\' -f2 | tee /tmp/android_repositoryId.txt

--- a/codebuild/cd/deploy-snapshot.yml
+++ b/codebuild/cd/deploy-snapshot.yml
@@ -7,7 +7,16 @@ phases:
     commands:
       - sudo add-apt-repository ppa:openjdk-r/ppa
       - sudo apt-get update -y
-      - sudo apt-get install openjdk-8-jdk-headless maven -y -f
+      - sudo apt-get install openjdk-11-jdk-headless maven wget unzip -y -f
+      # install android sdk
+      - wget --quiet https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip
+      - export ANDROID_SDK_ROOT=$CODEBUILD_SRC_DIR/android-sdk
+      - mkdir -p $ANDROID_SDK_ROOT/cmdline-tools
+      - unzip commandlinetools-linux-7583922_latest.zip -d $ANDROID_SDK_ROOT/cmdline-tools
+      # This weird path needed for cmd tool to work
+      - mv $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+      # install android build tools
+      - echo y | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "build-tools;30.0.3" "platforms;android-30" "ndk;21.4.7075529"
 
   pre_build:
     commands:
@@ -26,6 +35,7 @@ phases:
       - aws s3 cp s3://code-sharing-aws-crt/aws-sdk-common-runtime.key.asc /tmp/aws-sdk-common-runtime.key.asc
       - gpg --import /tmp/aws-sdk-common-runtime.key.asc
       - export GPG_PASSPHRASE=$(aws --query "SecretString" secretsmanager get-secret-value --secret-id aws-sdk-common-runtime.key.asc/password | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
+      - export ST_PASSWORD=$(aws --query "SecretString" secretsmanager get-secret-value --secret-id Sonatype/JIRA/Password | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
   build:
     commands:
       - cd $CODEBUILD_SRC_DIR/aws-crt-java
@@ -37,6 +47,8 @@ phases:
       - mvn -B versions:set -DnewVersion=${PKG_VERSION}
       - mvn -B deploy -Prelease -Dshared-lib.skip=true -Dmaven.test.skip=true -Dgpg.passphrase=$GPG_PASSPHRASE | tee /tmp/deploy.log
       - cat /tmp/deploy.log | grep "Created staging repository with ID" | cut -d\" -f2 | tee /tmp/repositoryId.txt
+      # deploy android
+      - bash ./codebuild/cd/deploy-snapshot-android.sh
   post_build:
     commands:
 
@@ -46,7 +58,8 @@ artifacts:
     - $CODEBUILD_SRC_DIR/aws-crt-java/target/aws-crt-*.jar
     - $CODEBUILD_SRC_DIR/aws-crt-java/target/aws-crt-*.asc
     - /tmp/repositoryId.txt
+    - /tmp/android_repositoryId.txt
 
 cache:
   paths:
-    - '/root/.m2/**/*'
+    - "/root/.m2/**/*"

--- a/codebuild/cd/promote-release.yml
+++ b/codebuild/cd/promote-release.yml
@@ -8,7 +8,7 @@ phases:
       - sudo add-apt-repository ppa:openjdk-r/ppa
       - sudo apt-get update -y
       - sudo apt-get install openjdk-8-jdk-headless maven -y -f
-  
+
   pre_build:
     commands:
       - cd $CODEBUILD_SRC_DIR/aws-crt-java
@@ -22,14 +22,16 @@ phases:
       - gpg --import /tmp/aws-sdk-common-runtime.key.asc
       - export GPG_PASSPHRASE=$(aws --query "SecretString" secretsmanager get-secret-value --secret-id aws-sdk-common-runtime.key.asc/password | cut -f2 -d":" | sed -e 's/[\\\"\}]//g')
       - export REPOSITORY_ID=$(cat $CODEBUILD_SRC_DIR_aws_crt/repositoryId.txt)
+      - export ANDROID_REPOSITORY_ID=$(cat $CODEBUILD_SRC_DIR_aws_crt/android_repositoryId.txt)
   build:
     commands:
       - cd $CODEBUILD_SRC_DIR/aws-crt-java
       # Trigger the release of the last staged package in the staging repository
       - mvn -B nexus-staging:release -Prelease -DstagingRepositoryId=$REPOSITORY_ID
+      - mvn -B nexus-staging:release -Prelease -DstagingRepositoryId=$ANDROID_REPOSITORY_ID
   post_build:
     commands:
 
 cache:
   paths:
-    - '/root/.m2/**/*'
+    - "/root/.m2/**/*"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,4 +9,19 @@ project(":native").projectDir = File("${settingsDir}/src/native")
 
 include(":smithy-crt")
 include(":s3-native-client")
-includeBuild("./android")
+
+
+val localPropertiesFile = File(rootProject.projectDir, "local.properties")
+val localProperties = java.util.Properties()
+if (localPropertiesFile.exists()) {
+    localProperties.load(localPropertiesFile.inputStream())
+}
+
+val androidHomeSet = System.getenv().containsKey("ANDROID_HOME") || localProperties.containsKey("sdk.dir")
+if (androidHomeSet) {
+    val androidHome = System.getenv()["ANDROID_HOME"] ?: localProperties.getProperty("sdk.dir")
+    println("Android home: $androidHome")
+    includeBuild("./android")
+}else {
+    logger.warn("Android SDK dir not set, android build disabled. Define location with `sdk.dir` in local.properties file or with `ANDROID_HOME` environment variable ")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,3 +9,4 @@ project(":native").projectDir = File("${settingsDir}/src/native")
 
 include(":smithy-crt")
 include(":s3-native-client")
+includeBuild("./android")

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -153,7 +153,6 @@ public final class CRT {
             String libraryPath = "/" + getOSIdentifier() + "/" + getArchIdentifier() + "/" + libraryName;
 
             File tempSharedLib = File.createTempFile(prefix, libraryName, tmpdirFile);
-            System.out.println(tempSharedLib.getAbsolutePath());
 
             // open a stream to read the shared lib contents from this JAR
             try (InputStream in = CRT.class.getResourceAsStream(libraryPath)) {

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -11,6 +11,7 @@ import java.util.List;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.utils.PemUtils;
+import software.amazon.awssdk.crt.utils.StringUtils;
 
 /**
  * This class wraps the aws_tls_connection_options from aws-c-io to provide
@@ -105,7 +106,7 @@ public final class TlsContextOptions extends CrtResource {
             acquireNativeHandle(tlsContextOptionsNew(
                 minTlsVersion.getValue(),
                 tlsCipherPreference.getValue(),
-                alpnList.size() > 0 ? String.join(";", alpnList) : null,
+                alpnList.size() > 0 ? StringUtils.join(";", alpnList) : null,
                 certificate,
                 privateKey,
                 certificatePath,

--- a/src/main/java/software/amazon/awssdk/crt/s3/CrtS3RuntimeException.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/CrtS3RuntimeException.java
@@ -49,10 +49,10 @@ public class CrtS3RuntimeException extends CrtRuntimeException {
     }
 
     /**
-     * Returns the aws error code from S3 response. The <Code> element in xml
+     * Returns the aws error code from S3 response. The {@code Code} element in xml
      * response.
      *
-     * @return errorCode, if no <Code> element in the response, empty string will be
+     * @return errorCode, if no {@code Code} element in the response, empty string will be
      *         returned
      */
     public String getAwsErrorCode() {
@@ -60,10 +60,10 @@ public class CrtS3RuntimeException extends CrtRuntimeException {
     }
 
     /**
-     * Returns the error message from S3 response. The detail among <Message>
+     * Returns the error message from S3 response. The detail among {@code Message}
      * element in xml response.
      *
-     * @return error message, if no <Message> element in the response, empty string
+     * @return error message, if no {@code Message} element in the response, empty string
      *         will be returned
      */
     public String getAwsErrorMessage() {

--- a/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
@@ -1,0 +1,26 @@
+package software.amazon.awssdk.crt.utils;
+
+public class StringUtils {
+    /**
+     * Returns a new String composed of copies of the CharSequence elements joined together with a copy of the specified delimiter.
+     * Like `Strings.join()` but works on Android < 26.
+     *
+     * @param delimiter a sequence of characters that is used to separate each of the elements in the resulting String
+     * @param elements an Iterable that will have its elements joined together
+     * @return a new String that is composed from the elements argument
+     */
+    public static String join(CharSequence delimiter, Iterable<? extends CharSequence> elements) {
+        if (delimiter == null || elements == null) throw new NullPointerException("delimiter and elements must not be null");
+        StringBuilder sb = new StringBuilder();
+
+        boolean first = true;
+        for(CharSequence cs : elements) {
+            if (!first) {
+                sb.append(delimiter);
+            }
+            sb.append(cs);
+            first = false;
+        }
+        return sb.toString();
+    }
+}

--- a/src/native/credentials_provider.c
+++ b/src/native/credentials_provider.c
@@ -367,7 +367,7 @@ static int s_credentials_provider_delegate_get_credentials(
         callback_data->jni_delegate_credential_handler,
         credentials_handler_properties.on_handler_get_credentials_method_id);
     if (aws_jni_check_and_clear_exception(env)) {
-        goto call_failed;
+        goto fetch_credentials_failed;
     }
 
     jbyteArray java_access_key_id =
@@ -380,7 +380,7 @@ static int s_credentials_provider_delegate_get_credentials(
     if (java_access_key_id == NULL || java_secret_access_key == NULL) {
         aws_jni_throw_runtime_exception(
             env, "DelegateCredentialProvider - accessKeyId and secretAccessKey must be non null");
-        goto call_failed;
+        goto empty_credentials;
     }
 
     struct aws_byte_cursor access_key_id = aws_jni_byte_cursor_from_jbyteArray_acquire(env, java_access_key_id);
@@ -407,7 +407,11 @@ done:
     if (java_session_token != NULL) {
         aws_jni_byte_cursor_from_jbyteArray_release(env, java_session_token, session_token);
     }
-call_failed:
+empty_credentials:
+    (*env)->DeleteLocalRef(env, java_access_key_id);
+    (*env)->DeleteLocalRef(env, java_secret_access_key);
+    (*env)->DeleteLocalRef(env, java_session_token);
+fetch_credentials_failed:
     (*env)->DeleteLocalRef(env, java_credentials);
     return return_value;
 }

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -402,9 +402,8 @@ void JNICALL Java_software_amazon_awssdk_crt_CRT_nativeCheckJniExceptionContract
 
     if (clear_exception) {
         (*env)->ExceptionClear(env);
+        (*env)->CallStaticVoidMethod(env, jni_crt_class, crt_properties.test_jni_exception_method_id, false);
     } else {
         (*env)->ExceptionCheck(env);
     }
-
-    (*env)->CallStaticVoidMethod(env, jni_crt_class, crt_properties.test_jni_exception_method_id, false);
 }

--- a/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
+++ b/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
@@ -41,7 +41,6 @@ import software.amazon.awssdk.crt.io.*;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.http.HttpRequest;
 
-import javax.annotation.processing.Completion;
 
 public class S3NativeClientTest extends AwsClientTestFixture {
     private static final String BUCKET = System.getProperty("crt.test_s3_bucket", "aws-crt-canary-bucket");

--- a/src/test/java/software/amazon/awssdk/crt/test/CredentialsProviderTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CredentialsProviderTest.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 
 import org.junit.Assume;
 import org.junit.Test;
-import org.mockito.internal.matchers.Null;
 
 import static org.junit.Assert.*;
 import software.amazon.awssdk.crt.*;

--- a/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
@@ -1,0 +1,23 @@
+package software.amazon.awssdk.crt.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import software.amazon.awssdk.crt.utils.StringUtils;
+
+
+public class StringUtilsTest {
+
+    @Test
+    public void testJoin() {
+        List<String> alpns = new ArrayList<>();
+        alpns.add("one");
+        assertEquals("one", StringUtils.join(";", alpns));
+        alpns.add("two");
+        assertEquals("one;two", StringUtils.join(";", alpns));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
#334 

*Description of changes:*

* Fix Android build
    * Update Gradle and Android plugin to latest
    * Update to LTS version of NDK
    * Drop the Android API requirement from 26 -> 24 which required removing `java.nio.File/Path` APIs and few other minor API changes.
* Add an `android` job to CI which builds the Android project. This will also run the lint checks to verify API compatibility with the declared `minSdk` version.  
    * This runs directly on Ubuntu runner for now. I created an Android docker image in [aws-crt-builder:corretto](https://github.com/awslabs/aws-crt-builder/tree/corretto). When we figure out the issues with Docker and GitHub we can integrate those changes.
* (conditionally) enables the Android build based on if you have configured the Android SDK. This means most developers (and CI) will not need to configure Android to contribute to `aws-crt-java`. CI will handle the rest.
* Publish the Android `.aar` as a separate publication (it will get it's own maven coordinates at `software.amazon.awssdk.crt:aws-crt-android`
    * This uses Gradle to do the publication which has some complications with the Nexus publishing plugin. Currently we use maven to build and release. The maven nexus plugin has support to do separate publish/closeAndRelease tasks. This is currently a missing feature in the Gradle plugin. Instead we publish and close the staged nexus repo from Gradle and then use maven to do the release of both publications.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
