### PR TITLE
Fix build on 32bit machine

### DIFF
--- a/src/native/checksums.c
+++ b/src/native/checksums.c
@@ -17,7 +17,7 @@ jint crc_common(
     uint32_t (*checksum_fn)(const uint8_t *, int, uint32_t)) {
     struct aws_byte_cursor cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, input);
     aws_byte_cursor_advance(&cursor, start);
-    cursor.len = aws_min_i64(length, cursor.len);
+    cursor.len = (size_t)aws_min_i64(length, cursor.len);
     uint32_t res = (uint32_t)previous;
     while (cursor.len > INT_MAX) {
         res = checksum_fn(cursor.ptr, INT_MAX, res);

--- a/src/native/checksums.c
+++ b/src/native/checksums.c
@@ -17,7 +17,7 @@ jint crc_common(
     uint32_t (*checksum_fn)(const uint8_t *, int, uint32_t)) {
     struct aws_byte_cursor cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, input);
     aws_byte_cursor_advance(&cursor, start);
-    cursor.len = (size_t)aws_min_i64(length, cursor.len);
+    cursor.len = aws_min_size(length, cursor.len);
     uint32_t res = (uint32_t)previous;
     while (cursor.len > INT_MAX) {
         res = checksum_fn(cursor.ptr, INT_MAX, res);


### PR DESCRIPTION
*Issue #, if available:*
- Fix build on 32bit machine 

*Description of changes:*
- The comparing treats size_t as int64 and return a int64to a size_t and causing build issue for 32 bit machine

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
