### PR TITLE
Allow user to change Windows Named Pipe open flags via SocketOptions

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/SocketOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/SocketOptions.java
@@ -5,7 +5,6 @@
 package software.amazon.awssdk.crt.io;
 
 import software.amazon.awssdk.crt.CrtResource;
-import software.amazon.awssdk.crt.CrtRuntimeException;
 
 /**
  * This class wraps the aws_socket_options from aws-c-io to provide
@@ -89,22 +88,30 @@ public final class SocketOptions extends CrtResource {
     public int keepAliveTimeoutSecs = 0;
 
     /**
+     * If running on Windows and this socket is a LOCAL type, this option sets the flags used for the
+     * open pipe options when calling CreateNamedPipe.
+     * 0 is the default which means that no additional flags are added.
+     */
+    public int windowsNamedPipeOpenFlags = 0;
+
+    /**
      * Creates a new set of socket options
      */
     public SocketOptions() {
-        
+
     }
 
     @Override
     public long getNativeHandle() {
         if (super.getNativeHandle() == 0) {
             acquireNativeHandle(socketOptionsNew(
-                domain.getValue(),
-                type.getValue(),
-                connectTimeoutMs,
-                keepAliveIntervalSecs,
-                keepAliveTimeoutSecs
-            ));   
+                    domain.getValue(),
+                    type.getValue(),
+                    connectTimeoutMs,
+                    keepAliveIntervalSecs,
+                    keepAliveTimeoutSecs,
+                    windowsNamedPipeOpenFlags
+            ));
         }
         return super.getNativeHandle();
     }
@@ -129,7 +136,7 @@ public final class SocketOptions extends CrtResource {
     /*******************************************************************************
      * native methods
      ******************************************************************************/
-    private static native long socketOptionsNew(int domain, int type, int connectTimeoutMs, int keepAliveIntervalSecs, int keepAliveTimeoutSecs);
+    private static native long socketOptionsNew(int domain, int type, int connectTimeoutMs, int keepAliveIntervalSecs, int keepAliveTimeoutSecs, int windowsNamedPipeOpenFlags);
 
     private static native void socketOptionsDestroy(long elg);
 };

--- a/src/native/socket_options.c
+++ b/src/native/socket_options.c
@@ -29,7 +29,8 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_SocketOptions_socketOptionsNew(
     jint type,
     jint connect_timeout_ms,
     jint keep_alive_interval_secs,
-    jint keep_alive_timeout_secs) {
+    jint keep_alive_timeout_secs,
+    jint windows_named_pipe_open_flags) {
     (void)env;
     (void)jni_class;
     struct aws_allocator *allocator = aws_jni_get_allocator();
@@ -42,6 +43,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_SocketOptions_socketOptionsNew(
     options->connect_timeout_ms = connect_timeout_ms;
     options->keep_alive_interval_sec = (short)keep_alive_interval_secs;
     options->keep_alive_timeout_sec = (short)keep_alive_timeout_secs;
+    options->windows_named_pipe_open_flags = windows_named_pipe_open_flags;
 
     return (jlong)options;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Requires: https://github.com/awslabs/aws-c-io/pull/422

This implements the Java-side change for https://github.com/awslabs/aws-c-io/pull/422


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
