### PR TITLE
PKCS#11 public API

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/Pkcs11Lib.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/Pkcs11Lib.java
@@ -1,9 +1,17 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 package software.amazon.awssdk.crt.io;
 
 import software.amazon.awssdk.crt.CrtResource;
 
 /**
  * Handle to a loaded PKCS#11 library.
+ * <p>
+ * For most use cases, a single instance of Pkcs11Lib should be used for the
+ * lifetime of your application.
  * <p>
  * <b>Notes on initialization:</b> By default, {@code C_Initialize()} and
  * {@code C_Finalize()} are called when the PKCS#11 library is loaded and
@@ -16,6 +24,7 @@ public class Pkcs11Lib extends CrtResource {
 
     /**
      * Load and initialize a PKCS#11 library.
+     *
      * @param path path to PKCS#11 library.
      */
     public Pkcs11Lib(String path) {
@@ -24,6 +33,7 @@ public class Pkcs11Lib extends CrtResource {
 
     /**
      * Load a PKCS#11 library, with explicit control over initialization.
+     *
      * @param path           path to PKCS#11 library.
      * @param omitInitialize if true, {@code C_Initialize()} and
      *                       {@code C_Finalize()} will not be called on the PKCS#11

--- a/src/main/java/software/amazon/awssdk/crt/io/Pkcs11Lib.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/Pkcs11Lib.java
@@ -1,7 +1,6 @@
 package software.amazon.awssdk.crt.io;
 
 import software.amazon.awssdk.crt.CrtResource;
-import software.amazon.awssdk.crt.CrtRuntimeException;
 
 /**
  * Handle to a loaded PKCS#11 library.
@@ -17,22 +16,20 @@ public class Pkcs11Lib extends CrtResource {
 
     /**
      * Load and initialize a PKCS#11 library.
-     *
      * @param path path to PKCS#11 library.
      */
-    public Pkcs11Lib(String path) throws CrtRuntimeException {
+    public Pkcs11Lib(String path) {
         this(path, false);
     }
 
     /**
      * Load a PKCS#11 library, with explicit control over initialization.
-     *
      * @param path           path to PKCS#11 library.
      * @param omitInitialize if true, {@code C_Initialize()} and
      *                       {@code C_Finalize()} will not be called on the PKCS#11
      *                       library. See {@link Pkcs11Lib Notes on initialization}
      */
-    public Pkcs11Lib(String path, boolean omitInitialize) throws CrtRuntimeException {
+    public Pkcs11Lib(String path, boolean omitInitialize) {
         acquireNativeHandle(pkcs11LibNew(path, omitInitialize));
     }
 

--- a/src/main/java/software/amazon/awssdk/crt/io/Pkcs11Lib.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/Pkcs11Lib.java
@@ -1,0 +1,57 @@
+package software.amazon.awssdk.crt.io;
+
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.CrtRuntimeException;
+
+/**
+ * Handle to a loaded PKCS#11 library.
+ * <p>
+ * <b>Notes on initialization:</b> By default, {@code C_Initialize()} and
+ * {@code C_Finalize()} are called when the PKCS#11 library is loaded and
+ * unloaded. Call a constructor with {@link Pkcs11Lib(String, boolean)
+ * omitInitialization} set to skip these calls if your application has already
+ * initialized the PKCS#11 library (ex: by using the {@code SunPKCS11}
+ * cryptographic provider)
+ */
+public class Pkcs11Lib extends CrtResource {
+
+    /**
+     * Load and initialize a PKCS#11 library.
+     *
+     * @param path path to PKCS#11 library.
+     */
+    public Pkcs11Lib(String path) throws CrtRuntimeException {
+        this(path, false);
+    }
+
+    /**
+     * Load a PKCS#11 library, with explicit control over initialization.
+     *
+     * @param path           path to PKCS#11 library.
+     * @param omitInitialize if true, {@code C_Initialize()} and
+     *                       {@code C_Finalize()} will not be called on the PKCS#11
+     *                       library. See {@link Pkcs11Lib Notes on initialization}
+     */
+    public Pkcs11Lib(String path, boolean omitInitialize) throws CrtRuntimeException {
+        acquireNativeHandle(pkcs11LibNew(path, omitInitialize));
+    }
+
+    @Override
+    protected boolean canReleaseReferencesImmediately() {
+        return true;
+    }
+
+    @Override
+    protected void releaseNativeHandle() {
+        if (!isNull()) {
+            pkcs11LibRelease(getNativeHandle());
+        }
+    }
+
+    /*******************************************************************************
+     * native methods
+     ******************************************************************************/
+    private static native long pkcs11LibNew(String path, boolean omitInitialize);
+
+    private static native void pkcs11LibRelease(long nativeHandle);
+}

--- a/src/main/java/software/amazon/awssdk/crt/io/Pkcs11TlsOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/Pkcs11TlsOptions.java
@@ -99,32 +99,4 @@ public class Pkcs11TlsOptions {
         this.certificateFileContents = contents;
         return this;
     }
-
-    public Pkcs11Lib pkcs11Lib() {
-        return pkcs11Lib;
-    }
-
-    public String userPin() {
-        return userPin;
-    }
-
-    public Integer slotId() {
-        return slotId;
-    }
-
-    public String tokenLabel() {
-        return tokenLabel;
-    }
-
-    public String privateKeyObjectLabel() {
-        return privateKeyObjectLabel;
-    }
-
-    public String certificateFilePath() {
-        return certificateFilePath;
-    }
-
-    public String certificateFileContents() {
-        return certificateFileContents;
-    }
 }

--- a/src/main/java/software/amazon/awssdk/crt/io/Pkcs11TlsOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/Pkcs11TlsOptions.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.awssdk.crt.io;
+
+/**
+ * Options for TLS using a PKCS#11 library for private key operations.
+ *
+ * @see TlsContextOptions#withMtlsPkcs11(Pkcs11TlsOptions)
+ */
+public class Pkcs11TlsOptions {
+    Pkcs11Lib pkcs11Lib;
+    String userPin;
+    Integer slotId;
+    String tokenLabel;
+    String privateKeyObjectLabel;
+    String certificateFilePath;
+    String certificateFileContents;
+
+    /**
+     * Constructor
+     *
+     * @param pkcs11Lib use this PKCS#11 library
+     */
+    public Pkcs11TlsOptions(Pkcs11Lib pkcs11Lib) {
+        this.pkcs11Lib = pkcs11Lib;
+    }
+
+    /**
+     * Use this PIN to log the user into the token. Leave unspecified to log into a
+     * token with a "protected authentication path".
+     *
+     * @param pin PIN
+     * @return this
+     */
+    public Pkcs11TlsOptions withUserPin(String pin) {
+        this.userPin = pin;
+        return this;
+    }
+
+    /**
+     * Use the token in this slot ID. If not specified, the token will be chosen
+     * based on other criteria (such as token label).
+     *
+     * @param slotId slot ID
+     * @return this
+     */
+    public Pkcs11TlsOptions withSlotId(int slotId) {
+        this.slotId = slotId;
+        return this;
+    }
+
+    /**
+     * Use the token with this label. If not specified, the token will be chosen
+     * based on other criteria (such as slot ID).
+     *
+     * @param label label of token
+     * @return this
+     */
+    public Pkcs11TlsOptions withTokenLabel(String label) {
+        this.tokenLabel = label;
+        return this;
+    }
+
+    /**
+     * Use the private key object with this label. If not specified, the key will be
+     * chosen based on other criteria (such as being the only available key).
+     *
+     * @param label label of private key object
+     * @return this
+     */
+    public Pkcs11TlsOptions withPrivateKeyObjectLabel(String label) {
+        this.privateKeyObjectLabel = label;
+        return this;
+    }
+
+    /**
+     * Use this X.509 certificate (file on disk). The certificate may be specified
+     * by other means instead (ex: {@link withCertificateFileContents})
+     *
+     * @param path path to PEM-formatted certificate file on disk.
+     * @return this
+     */
+    public Pkcs11TlsOptions withCertificateFilePath(String path) {
+        this.certificateFilePath = path;
+        return this;
+    }
+
+    /**
+     * Use this X.509 certificate (contents in memory). The certificate may be
+     * specified by other means instead (ex: {@link withCertificateFilePath})
+     *
+     * @param contents contents of PEM-formatted certificate file.
+     * @return this
+     */
+    public Pkcs11TlsOptions withCertificateFileContents(String contents) {
+        this.certificateFileContents = contents;
+        return this;
+    }
+
+    public Pkcs11Lib pkcs11Lib() {
+        return pkcs11Lib;
+    }
+
+    public String userPin() {
+        return userPin;
+    }
+
+    public Integer slotId() {
+        return slotId;
+    }
+
+    public String tokenLabel() {
+        return tokenLabel;
+    }
+
+    public String privateKeyObjectLabel() {
+        return privateKeyObjectLabel;
+    }
+
+    public String certificateFilePath() {
+        return certificateFilePath;
+    }
+
+    public String certificateFileContents() {
+        return certificateFileContents;
+    }
+}

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -88,11 +88,7 @@ public final class TlsContextOptions extends CrtResource {
     private String caDir;
     private String pkcs12Path;
     private String pkcs12Password;
-    private Pkcs11Lib pkcs11Lib;
-    private Integer pkcs11SlotId;
-    private String pkcs11TokenLabel;
-    private String pkcs11Pin;
-    private String pkcs11PrivateKeyLabel;
+    private Pkcs11TlsOptions pkcs11Options;
 
     /**
      * Creates a new set of options that can be used to create a {@link TlsContext}
@@ -367,28 +363,6 @@ public final class TlsContextOptions extends CrtResource {
     }
 
     /**
-     * Enables mutual TLS (mTLS), using this certificate.
-     * Use other methods to set the associated private key.
-     * @param contents contents of PEM-formatted certificate
-     * @return this
-     */
-    public TlsContextOptions withMtlsCertificate(String contents) {
-        this.certificate = contents;
-        return this;
-    }
-
-    /**
-     * Enables mutual TLS (mTLS), using this certificate.
-     * Use other methods to set the associated private key.
-     * @param path path to PEM-formatted certificate
-     * @return this
-     */
-    public TlsContextOptions withMtlsCertificatePath(String path) {
-        this.certificatePath = path;
-        return this;
-    }
-
-    /**
      * Specifies the certificate authority to use. By default, the OS CA repository will be used.
      * @param caRoot Certificate Authority, in PEM format
      * @return this
@@ -422,58 +396,11 @@ public final class TlsContextOptions extends CrtResource {
 
     /**
      * Unix platforms only, specifies mTLS using a PKCS#11 library for private key operations.
-     * Use other methods to specify the mTLS certificate and private key
-     * (ex: {@link withMtlsCertificate}, {@link withPkcs11PrivateKeyLabel}).
-     * Consult the "withPkcs11" methods for further options.
-     * @param pkcs11Lib PKCS#11 library handle to use.
+     * @param pkcs11Options PKCS#11 options
      * @return this
      */
-    public TlsContextOptions withMtlsPkcs11(Pkcs11Lib pkcs11Lib) {
-        this.pkcs11Lib = pkcs11Lib;
-        return this;
-    }
-
-    /**
-     * (PKCS#11 only) Use the token in this slot ID.
-     * If not specified, the token will be chosen based on other criteria (such as token label).
-     * @return this
-     * @see withMtlsPkcs11
-     */
-    public TlsContextOptions withPkcs11SlotId(int slotId) {
-        this.pkcs11SlotId = slotId;
-        return this;
-    }
-
-    /**
-     * (PKCS#11 only) Use the token with this label.
-     * If not specified, the token will be chosen based on other criteria (such as slot ID).
-     * @return this
-     * @see withMtlsPkcs11
-     */
-    public TlsContextOptions withPkcs11TokenLabel(String label) {
-        this.pkcs11TokenLabel = label;
-        return this;
-    }
-
-    /**
-     * (PKCS#11 only) Use this PIN to log the user into the token.
-     * Leave unspecified to log into a token with a "protected authentication path".
-     * @return this
-     * @see withMtlsPkcs11
-     */
-    public TlsContextOptions withPkcs11Pin(String pin) {
-        this.pkcs11Pin = pin;
-        return this;
-    }
-
-    /**
-     * (PKCS#11 only) Use the private key with this label.
-     * If not specified, the key will be chosen based on other criteria (such as being the only available key).
-     * @return this
-     * @see withMtlsPkcs11
-     */
-    public TlsContextOptions withPkcs11PrivateKeyLabel(String label) {
-        this.pkcs11PrivateKeyLabel = label;
+    public TlsContextOptions withMtlsPkcs11(Pkcs11TlsOptions pkcs11Options) {
+        this.pkcs11Options = pkcs11Options;
         return this;
     }
 

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -367,8 +367,8 @@ public final class TlsContextOptions extends CrtResource {
     }
 
     /**
-     * Set the certificate for mutual TLS (mTLS).
-     * A private key must also be set.
+     * Enables mutual TLS (mTLS), using this certificate.
+     * Use other methods to set the associated private key.
      * @param contents contents of PEM-formatted certificate
      * @return this
      */
@@ -378,8 +378,8 @@ public final class TlsContextOptions extends CrtResource {
     }
 
     /**
-     * Set the certificate for mutual TLS (mTLS).
-     * A private key must also be set.
+     * Enables mutual TLS (mTLS), using this certificate.
+     * Use other methods to set the associated private key.
      * @param path path to PEM-formatted certificate
      * @return this
      */

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -55,7 +55,7 @@ public final class TlsContextOptions extends CrtResource {
      * Sets the minimum acceptable TLS version that the {@link TlsContext} will
      * allow. Not compatible with setCipherPreference() API.
      *
-     * Select from TlsVersions, a good default is TlsVersions.TLS_VER_SYS_DEFAULTS 
+     * Select from TlsVersions, a good default is TlsVersions.TLS_VER_SYS_DEFAULTS
      * as this will update if the OS TLS is updated
      */
     public TlsVersions minTlsVersion = TlsVersions.TLS_VER_SYS_DEFAULTS;
@@ -88,12 +88,17 @@ public final class TlsContextOptions extends CrtResource {
     private String caDir;
     private String pkcs12Path;
     private String pkcs12Password;
+    private Pkcs11Lib pkcs11Lib;
+    private Integer pkcs11SlotId;
+    private String pkcs11TokenLabel;
+    private String pkcs11Pin;
+    private String pkcs11PrivateKeyLabel;
 
     /**
      * Creates a new set of options that can be used to create a {@link TlsContext}
      */
     private TlsContextOptions() {
-        
+
     }
 
     @Override
@@ -165,7 +170,7 @@ public final class TlsContextOptions extends CrtResource {
     /**
      * Sets the certificate/key pair that identifies this TLS host. Must be in
      * PEM format.
-     * 
+     *
      * @param certificate PEM armored certificate
      * @param privateKey  PEM armored private key
      * @throws IllegalArgumentException If the certificate or privateKey are not in PEM format or if they contain chains
@@ -225,7 +230,7 @@ public final class TlsContextOptions extends CrtResource {
 
     /**
      * Helper function to provide a TlsContext-local trust store
-     * 
+     *
      * @param caRoot Buffer containing the root certificate chain. Must be in PEM format.
      * @throws IllegalArgumentException if the CA Root PEM file is malformed
      */
@@ -250,7 +255,7 @@ public final class TlsContextOptions extends CrtResource {
 
     /**
      * Helper which creates a default set of TLS options for the current platform
-     * 
+     *
      * @return A default configured set of options for a TLS server connection
      */
     public static TlsContextOptions createDefaultServer() {
@@ -274,7 +279,7 @@ public final class TlsContextOptions extends CrtResource {
 
     /**
      * Helper which creates TLS options using a certificate and private key
-     * 
+     *
      * @param certificate String containing a PEM format certificate
      * @param privateKey  String containing a PEM format private key
      * @return A set of options for setting up an MTLS connection
@@ -362,6 +367,28 @@ public final class TlsContextOptions extends CrtResource {
     }
 
     /**
+     * Set the certificate for mutual TLS (mTLS).
+     * A private key must also be set.
+     * @param contents contents of PEM-formatted certificate
+     * @return this
+     */
+    public TlsContextOptions withMtlsCertificate(String contents) {
+        this.certificate = contents;
+        return this;
+    }
+
+    /**
+     * Set the certificate for mutual TLS (mTLS).
+     * A private key must also be set.
+     * @param path path to PEM-formatted certificate
+     * @return this
+     */
+    public TlsContextOptions withMtlsCertificatePath(String path) {
+        this.certificatePath = path;
+        return this;
+    }
+
+    /**
      * Specifies the certificate authority to use. By default, the OS CA repository will be used.
      * @param caRoot Certificate Authority, in PEM format
      * @return this
@@ -390,6 +417,63 @@ public final class TlsContextOptions extends CrtResource {
      */
     public TlsContextOptions withMtlsPkcs12(String pkcs12Path, String pkcs12Password) {
         this.initMtlsPkcs12(pkcs12Path, pkcs12Password);
+        return this;
+    }
+
+    /**
+     * Unix platforms only, specifies mTLS using a PKCS#11 library for private key operations.
+     * Use other methods to specify the mTLS certificate and private key
+     * (ex: {@link withMtlsCertificate}, {@link withPkcs11PrivateKeyLabel}).
+     * Consult the "withPkcs11" methods for further options.
+     * @param pkcs11Lib PKCS#11 library handle to use.
+     * @return this
+     */
+    public TlsContextOptions withMtlsPkcs11(Pkcs11Lib pkcs11Lib) {
+        this.pkcs11Lib = pkcs11Lib;
+        return this;
+    }
+
+    /**
+     * (PKCS#11 only) Use the token in this slot ID.
+     * If not specified, the token will be chosen based on other criteria (such as token label).
+     * @return this
+     * @see withMtlsPkcs11
+     */
+    public TlsContextOptions withPkcs11SlotId(int slotId) {
+        this.pkcs11SlotId = slotId;
+        return this;
+    }
+
+    /**
+     * (PKCS#11 only) Use the token with this label.
+     * If not specified, the token will be chosen based on other criteria (such as slot ID).
+     * @return this
+     * @see withMtlsPkcs11
+     */
+    public TlsContextOptions withPkcs11TokenLabel(String label) {
+        this.pkcs11TokenLabel = label;
+        return this;
+    }
+
+    /**
+     * (PKCS#11 only) Use this PIN to log the user into the token.
+     * Leave unspecified to log into a token with a "protected authentication path".
+     * @return this
+     * @see withMtlsPkcs11
+     */
+    public TlsContextOptions withPkcs11Pin(String pin) {
+        this.pkcs11Pin = pin;
+        return this;
+    }
+
+    /**
+     * (PKCS#11 only) Use the private key with this label.
+     * If not specified, the key will be chosen based on other criteria (such as being the only available key).
+     * @return this
+     * @see withMtlsPkcs11
+     */
+    public TlsContextOptions withPkcs11PrivateKeyLabel(String label) {
+        this.pkcs11PrivateKeyLabel = label;
         return this;
     }
 

--- a/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.crt.utils;
 public class StringUtils {
     /**
      * Returns a new String composed of copies of the CharSequence elements joined together with a copy of the specified delimiter.
-     * Like `Strings.join()` but works on Android < 26.
+     * Like `Strings.join()` but works on Android prior to 26.
      *
      * @param delimiter a sequence of characters that is used to separate each of the elements in the resulting String
      * @param elements an Iterable that will have its elements joined together

--- a/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
@@ -3,7 +3,7 @@ package software.amazon.awssdk.crt.utils;
 public class StringUtils {
     /**
      * Returns a new String composed of copies of the CharSequence elements joined together with a copy of the specified delimiter.
-     * Like `Strings.join()` but works on Android prior to 26.
+     * Like `Strings.join()` but works on Android before API 26.
      *
      * @param delimiter a sequence of characters that is used to separate each of the elements in the resulting String
      * @param elements an Iterable that will have its elements joined together


### PR DESCRIPTION
This is just an API review. The implementation is not here yet. This is set to merge to the `pkcs11` feature branch.

I was happy to find that `TlsContextOptions` already has a builder pattern on it. Using the builder pattern so user can set PKCS#11 options one at a time. I think this is important because I'm convinced that many of the params we think are required now, will turn out to be optional in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
