### PR TITLE
Added aws.crt.lib.dir as an override for java.io.tmpdir on secured hosts

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -8,8 +8,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Date;
-import java.util.Locale;
+import java.util.*;
 
 /**
  * This class is responsible for loading the aws-crt-jni shared lib for the
@@ -122,14 +121,13 @@ public final class CRT {
         throw new UnknownPlatformException("AWS CRT: architecture not supported: " + arch);
     }
 
-    private static void loadLibraryFromJar() {
+    private static void extractAndLoadLibrary(String path) {
         try {
             // Check java.io.tmpdir
-            String tmpdir = System.getProperty("java.io.tmpdir");
             String tmpdirPath;
             File tmpdirFile;
             try {
-                tmpdirFile = new File(tmpdir).getAbsoluteFile();
+                tmpdirFile = new File(path).getAbsoluteFile();
                 tmpdirPath = tmpdirFile.getAbsolutePath();
                 if (tmpdirFile.exists()) {
                     if (!tmpdirFile.isDirectory()) {
@@ -143,7 +141,7 @@ public final class CRT {
                     throw new IOException("access denied: " + tmpdirPath);
                 }
             } catch (Exception ex) {
-                String msg = "java.io.tmpdir=\"" + tmpdir + "\": Invalid directory";
+                String msg = "Invalid directory: " + path;
                 throw new IOException(msg, ex);
             }
 
@@ -190,15 +188,49 @@ public final class CRT {
             // load the shared lib from the temp path
             System.load(tempSharedLib.getAbsolutePath());
         } catch (CrtRuntimeException crtex) {
-            System.err.println("Unable to initialize AWS CRT: " + crtex.toString());
+            System.err.println("Unable to initialize AWS CRT: " + crtex);
             crtex.printStackTrace();
+            throw crtex;
         } catch (UnknownPlatformException upe) {
-            System.err.println("Unable to determine platform for AWS CRT: " + upe.toString());
+            System.err.println("Unable to determine platform for AWS CRT: " + upe);
             upe.printStackTrace();
+            CrtRuntimeException rex = new CrtRuntimeException("Unable to determine platform for AWS CRT");
+            rex.initCause(upe);
+            throw rex;
         } catch (Exception ex) {
-            System.err.println("Unable to unpack AWS CRT lib: " + ex.toString());
+            System.err.println("Unable to unpack AWS CRT lib: " + ex);
             ex.printStackTrace();
+            CrtRuntimeException rex = new CrtRuntimeException("Unable to unpack AWS CRT library");
+            rex.initCause(ex);
+            throw rex;
         }
+    }
+
+    private static void loadLibraryFromJar() {
+        // By default, just try java.io.tmpdir
+        List<String> pathsToTry = new LinkedList<>();
+        pathsToTry.add(System.getProperty("java.io.tmpdir"));
+
+        // If aws.crt.lib.dir is specified, try that first
+        String overrideLibDir = System.getProperty("aws.crt.lib.dir");
+        if (overrideLibDir != null) {
+            pathsToTry.add(0, overrideLibDir);
+        }
+
+        List<Exception> exceptions = new LinkedList<>();
+        for (String path : pathsToTry) {
+            try {
+                extractAndLoadLibrary(path);
+                return;
+            } catch (CrtRuntimeException ex) {
+                exceptions.add(ex);
+            }
+        }
+
+        // Aggregate the exceptions in order and throw a single failure exception
+        StringBuilder failureMessage = new StringBuilder();
+        exceptions.stream().map(Exception::toString).forEach(failureMessage::append);
+        throw new CrtRuntimeException(failureMessage.toString());
     }
 
     private static CrtPlatform findPlatformImpl() {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
