### PR TITLE
Bind PKCS#11 TLS options to C

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CrtRuntimeException.java
+++ b/src/main/java/software/amazon/awssdk/crt/CrtRuntimeException.java
@@ -28,7 +28,7 @@ public class CrtRuntimeException extends RuntimeException {
         super(msg);
 
         Matcher matcher = crtExFormat.matcher(msg);
-        if (matcher.matches()) {
+        if (matcher.find()) {
             errorName = matcher.group(1);
             errorCode = Integer.parseInt(matcher.group(2));
         } else {

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -303,6 +303,18 @@ public final class TlsContextOptions extends CrtResource {
         return options;
     }
 
+    /**
+     * Unix platforms only - Helper which creates TLS options using a PKCS#11 library for private key operations.
+     * @param pkcs11Options PKCS#11 options
+     * @return A set of options for creating a PKCS#11 TLS connection
+     */
+    public static TlsContextOptions createWithMtlsPkcs11(TlsContextPkcs11Options pkcs11Options) {
+        TlsContextOptions options = new TlsContextOptions();
+        options.withMtlsPkcs11(pkcs11Options);
+        options.verifyPeer = true;
+        return options;
+    }
+
     /*******************************************************************************
      * .with() methods
      ******************************************************************************/
@@ -401,6 +413,7 @@ public final class TlsContextOptions extends CrtResource {
      * @return this
      */
     public TlsContextOptions withMtlsPkcs11(TlsContextPkcs11Options pkcs11Options) {
+        addReferenceTo(pkcs11Options);
         this.pkcs11Options = pkcs11Options;
         return this;
     }

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -88,7 +88,7 @@ public final class TlsContextOptions extends CrtResource {
     private String caDir;
     private String pkcs12Path;
     private String pkcs12Password;
-    private Pkcs11TlsOptions pkcs11Options;
+    private TlsContextPkcs11Options pkcs11Options;
 
     /**
      * Creates a new set of options that can be used to create a {@link TlsContext}
@@ -117,7 +117,8 @@ public final class TlsContextOptions extends CrtResource {
                 caDir,
                 verifyPeer,
                 pkcs12Path,
-                pkcs12Password
+                pkcs12Password,
+                pkcs11Options
             ));
         }
         return super.getNativeHandle();
@@ -399,7 +400,7 @@ public final class TlsContextOptions extends CrtResource {
      * @param pkcs11Options PKCS#11 options
      * @return this
      */
-    public TlsContextOptions withMtlsPkcs11(Pkcs11TlsOptions pkcs11Options) {
+    public TlsContextOptions withMtlsPkcs11(TlsContextPkcs11Options pkcs11Options) {
         this.pkcs11Options = pkcs11Options;
         return this;
     }
@@ -440,7 +441,8 @@ public final class TlsContextOptions extends CrtResource {
                 String caDir,
                 boolean verifyPeer,
                 String pkcs12Path,
-                String pkcs12Password
+                String pkcs12Password,
+                TlsContextPkcs11Options pkcs11Options
             );
 
     private static native void tlsContextOptionsDestroy(long elg);

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextPkcs11Options.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextPkcs11Options.java
@@ -5,12 +5,14 @@
 
 package software.amazon.awssdk.crt.io;
 
+import software.amazon.awssdk.crt.CrtResource;
+
 /**
  * Options for TLS using a PKCS#11 library for private key operations.
  *
  * @see TlsContextOptions#withMtlsPkcs11(TlsContextPkcs11Options)
  */
-public class TlsContextPkcs11Options {
+public class TlsContextPkcs11Options extends CrtResource {
     Pkcs11Lib pkcs11Lib;
     String userPin;
     Integer slotId;
@@ -25,6 +27,7 @@ public class TlsContextPkcs11Options {
      * @param pkcs11Lib use this PKCS#11 library
      */
     public TlsContextPkcs11Options(Pkcs11Lib pkcs11Lib) {
+        addReferenceTo(pkcs11Lib);
         this.pkcs11Lib = pkcs11Lib;
     }
 
@@ -99,5 +102,22 @@ public class TlsContextPkcs11Options {
     public TlsContextPkcs11Options withCertificateFileContents(String contents) {
         this.certificateFileContents = contents;
         return this;
+    }
+
+    /*
+     * Doesn't actually have a native handle. This class is just a CrtResource
+     * because it references one
+     */
+    @Override
+    protected void releaseNativeHandle() {
+    }
+
+    /*
+     * Doesn't actually have a native handle. This class is just a CrtResource
+     * because it references one
+     */
+    @Override
+    protected boolean canReleaseReferencesImmediately() {
+        return true;
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextPkcs11Options.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextPkcs11Options.java
@@ -8,9 +8,9 @@ package software.amazon.awssdk.crt.io;
 /**
  * Options for TLS using a PKCS#11 library for private key operations.
  *
- * @see TlsContextOptions#withMtlsPkcs11(Pkcs11TlsOptions)
+ * @see TlsContextOptions#withMtlsPkcs11(TlsContextPkcs11Options)
  */
-public class Pkcs11TlsOptions {
+public class TlsContextPkcs11Options {
     Pkcs11Lib pkcs11Lib;
     String userPin;
     Integer slotId;
@@ -24,54 +24,55 @@ public class Pkcs11TlsOptions {
      *
      * @param pkcs11Lib use this PKCS#11 library
      */
-    public Pkcs11TlsOptions(Pkcs11Lib pkcs11Lib) {
+    public TlsContextPkcs11Options(Pkcs11Lib pkcs11Lib) {
         this.pkcs11Lib = pkcs11Lib;
     }
 
     /**
-     * Use this PIN to log the user into the token. Leave unspecified to log into a
-     * token with a "protected authentication path".
+     * Use this PIN to log the user into the PKCS#11 token. Leave unspecified to log
+     * into a token with a "protected authentication path".
      *
      * @param pin PIN
      * @return this
      */
-    public Pkcs11TlsOptions withUserPin(String pin) {
+    public TlsContextPkcs11Options withUserPin(String pin) {
         this.userPin = pin;
         return this;
     }
 
     /**
-     * Use the token in this slot ID. If not specified, the token will be chosen
-     * based on other criteria (such as token label).
+     * Specify the slot ID containing a PKCS#11 token. If not specified, the token
+     * will be chosen based on other criteria (such as token label).
      *
      * @param slotId slot ID
      * @return this
      */
-    public Pkcs11TlsOptions withSlotId(int slotId) {
+    public TlsContextPkcs11Options withSlotId(int slotId) {
         this.slotId = slotId;
         return this;
     }
 
     /**
-     * Use the token with this label. If not specified, the token will be chosen
-     * based on other criteria (such as slot ID).
+     * Specify the label of the PKCS#11 token to use. If not specified, the token
+     * will be chosen based on other criteria (such as slot ID).
      *
      * @param label label of token
      * @return this
      */
-    public Pkcs11TlsOptions withTokenLabel(String label) {
+    public TlsContextPkcs11Options withTokenLabel(String label) {
         this.tokenLabel = label;
         return this;
     }
 
     /**
-     * Use the private key object with this label. If not specified, the key will be
-     * chosen based on other criteria (such as being the only available key).
+     * Specify the label of the private key object on the PKCS#11 token. If not
+     * specified, the key will be chosen based on other criteria (such as being the
+     * only available private key on the token).
      *
      * @param label label of private key object
      * @return this
      */
-    public Pkcs11TlsOptions withPrivateKeyObjectLabel(String label) {
+    public TlsContextPkcs11Options withPrivateKeyObjectLabel(String label) {
         this.privateKeyObjectLabel = label;
         return this;
     }
@@ -83,7 +84,7 @@ public class Pkcs11TlsOptions {
      * @param path path to PEM-formatted certificate file on disk.
      * @return this
      */
-    public Pkcs11TlsOptions withCertificateFilePath(String path) {
+    public TlsContextPkcs11Options withCertificateFilePath(String path) {
         this.certificateFilePath = path;
         return this;
     }
@@ -95,7 +96,7 @@ public class Pkcs11TlsOptions {
      * @param contents contents of PEM-formatted certificate file.
      * @return this
      */
-    public Pkcs11TlsOptions withCertificateFileContents(String contents) {
+    public TlsContextPkcs11Options withCertificateFileContents(String contents) {
         this.certificateFileContents = contents;
         return this;
     }

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -68,6 +68,24 @@ void aws_jni_throw_runtime_exception(JNIEnv *env, const char *msg, ...) {
     (*env)->ThrowNew(env, runtime_exception, exception);
 }
 
+void aws_jni_throw_null_pointer_exception(JNIEnv *env, const char *msg, ...) {
+    va_list args;
+    va_start(args, msg);
+    char buf[1024];
+    vsnprintf(buf, sizeof(buf), msg, args);
+    va_end(args);
+    (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/NullPointerException"), buf);
+}
+
+void aws_jni_throw_illegal_argument_exception(JNIEnv *env, const char *msg, ...) {
+    va_list args;
+    va_start(args, msg);
+    char buf[1024];
+    vsnprintf(buf, sizeof(buf), msg, args);
+    va_end(args);
+    (*env)->ThrowNew(env, (*env)->FindClass(env, "java/lang/IllegalArgumentException"), buf);
+}
+
 bool aws_jni_check_and_clear_exception(JNIEnv *env) {
     bool exception_pending = (*env)->ExceptionCheck(env);
     if (exception_pending) {
@@ -139,8 +157,7 @@ jobject aws_jni_direct_byte_buffer_from_raw_ptr(JNIEnv *env, const void *dst, si
 
 struct aws_byte_cursor aws_jni_byte_cursor_from_jstring_acquire(JNIEnv *env, jstring str) {
     if (str == NULL) {
-        jclass null_ptr_exception = (*env)->FindClass(env, "java/lang/NullPointerException");
-        (*env)->ThrowNew(env, null_ptr_exception, "string is null");
+        aws_jni_throw_null_pointer_exception(env, "string is null");
         return aws_byte_cursor_from_array(NULL, 0);
     }
 

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -31,6 +31,16 @@ struct aws_allocator *aws_jni_get_allocator(void);
 void aws_jni_throw_runtime_exception(JNIEnv *env, const char *msg, ...);
 
 /*******************************************************************************
+ * Throws java NullPointerException
+ ******************************************************************************/
+void aws_jni_throw_null_pointer_exception(JNIEnv *env, const char *msg, ...);
+
+/*******************************************************************************
+ * Throws java IllegalArgumentException
+ ******************************************************************************/
+void aws_jni_throw_illegal_argument_exception(JNIEnv *env, const char *msg, ...);
+
+/*******************************************************************************
  * Checks whether or not an exception is pending on the stack and clears it.
  * If an exception was pending, it is cleared.
  *

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -102,6 +102,16 @@ static void s_cache_predicate(JNIEnv *env) {
     AWS_FATAL_ASSERT(predicate_properties.test_method_id);
 }
 
+struct java_integer_properties integer_properties;
+
+static void s_cache_integer(JNIEnv *env) {
+    jclass integer_class = (*env)->FindClass(env, "java/lang/Integer");
+    AWS_FATAL_ASSERT(integer_class);
+
+    integer_properties.int_value_method_id = (*env)->GetMethodID(env, integer_class, "intValue", "()I");
+    AWS_FATAL_ASSERT(integer_properties.int_value_method_id);
+}
+
 struct java_http_request_properties http_request_properties;
 
 static void s_cache_http_request(JNIEnv *env) {
@@ -303,6 +313,38 @@ static void s_cache_client_bootstrap(JNIEnv *env) {
 
     client_bootstrap_properties.onShutdownComplete = (*env)->GetMethodID(env, cls, "onShutdownComplete", "()V");
     AWS_FATAL_ASSERT(client_bootstrap_properties.onShutdownComplete);
+}
+
+struct java_tls_context_pkcs11_options_properties tls_context_pkcs11_options_properties;
+
+static void s_cache_tls_context_pkcs11_options(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/io/TlsContextPkcs11Options");
+    AWS_FATAL_ASSERT(cls);
+
+    tls_context_pkcs11_options_properties.pkcs11Lib =
+        (*env)->GetFieldID(env, cls, "pkcs11Lib", "Lsoftware/amazon/awssdk/crt/io/Pkcs11Lib;");
+    AWS_FATAL_ASSERT(tls_context_pkcs11_options_properties.pkcs11Lib);
+
+    tls_context_pkcs11_options_properties.userPin = (*env)->GetFieldID(env, cls, "userPin", "Ljava/lang/String;");
+    AWS_FATAL_ASSERT(tls_context_pkcs11_options_properties.userPin);
+
+    tls_context_pkcs11_options_properties.slotId = (*env)->GetFieldID(env, cls, "slotId", "Ljava/lang/Integer;");
+    AWS_FATAL_ASSERT(tls_context_pkcs11_options_properties.slotId);
+
+    tls_context_pkcs11_options_properties.tokenLabel = (*env)->GetFieldID(env, cls, "tokenLabel", "Ljava/lang/String;");
+    AWS_FATAL_ASSERT(tls_context_pkcs11_options_properties.tokenLabel);
+
+    tls_context_pkcs11_options_properties.privateKeyObjectLabel =
+        (*env)->GetFieldID(env, cls, "privateKeyObjectLabel", "Ljava/lang/String;");
+    AWS_FATAL_ASSERT(tls_context_pkcs11_options_properties.privateKeyObjectLabel);
+
+    tls_context_pkcs11_options_properties.certificateFilePath =
+        (*env)->GetFieldID(env, cls, "certificateFilePath", "Ljava/lang/String;");
+    AWS_FATAL_ASSERT(tls_context_pkcs11_options_properties.certificateFilePath);
+
+    tls_context_pkcs11_options_properties.certificateFileContents =
+        (*env)->GetFieldID(env, cls, "certificateFileContents", "Ljava/lang/String;");
+    AWS_FATAL_ASSERT(tls_context_pkcs11_options_properties.certificateFileContents);
 }
 
 struct java_http_client_connection_manager_properties http_client_connection_manager_properties;
@@ -694,6 +736,7 @@ void cache_java_class_ids(JNIEnv *env) {
     s_cache_http_request_body_stream(env);
     s_cache_aws_signing_config(env);
     s_cache_predicate(env);
+    s_cache_integer(env);
     s_cache_http_request(env);
     s_cache_crt_resource(env);
     s_cache_mqtt_connection(env);
@@ -706,6 +749,7 @@ void cache_java_class_ids(JNIEnv *env) {
     s_cache_async_callback(env);
     s_cache_event_loop_group(env);
     s_cache_client_bootstrap(env);
+    s_cache_tls_context_pkcs11_options(env);
     s_cache_http_client_connection_manager(env);
     s_cache_http_client_connection(env);
     s_cache_http_stream(env);

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -43,6 +43,12 @@ struct java_predicate_properties {
 };
 extern struct java_predicate_properties predicate_properties;
 
+/* java/lang/Integer */
+struct java_integer_properties {
+    jmethodID int_value_method_id;
+};
+extern struct java_integer_properties integer_properties;
+
 /* HttpRequest */
 struct java_http_request_properties {
     jclass http_request_class;
@@ -136,6 +142,18 @@ struct java_client_bootstrap_properties {
     jmethodID onShutdownComplete;
 };
 extern struct java_client_bootstrap_properties client_bootstrap_properties;
+
+/* TlsContextPkcs11Options */
+struct java_tls_context_pkcs11_options_properties {
+    jfieldID pkcs11Lib;
+    jfieldID userPin;
+    jfieldID slotId;
+    jfieldID tokenLabel;
+    jfieldID privateKeyObjectLabel;
+    jfieldID certificateFilePath;
+    jfieldID certificateFileContents;
+};
+extern struct java_tls_context_pkcs11_options_properties tls_context_pkcs11_options_properties;
 
 /* HttpClientConnectionManager */
 struct java_http_client_connection_manager_properties {

--- a/src/native/pkcs11_lib.c
+++ b/src/native/pkcs11_lib.c
@@ -32,18 +32,16 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_io_Pkcs11Lib_pkcs11LibNe
     struct aws_pkcs11_lib *pkcs11_lib = NULL;
     struct aws_pkcs11_lib_options options;
     AWS_ZERO_STRUCT(options);
-    struct aws_byte_cursor filename = {.ptr = NULL};
 
     /* read jni args into C options */
 
     /* filename is required in Java binding
      * (it's optional in C because user could link their PKCS#11 lib statically,
      * but that's not happening in Java) */
-    filename = aws_jni_byte_cursor_from_jstring_acquire(env, jni_filename);
-    if (filename.ptr == NULL) {
+    options.filename = aws_jni_byte_cursor_from_jstring_acquire(env, jni_filename);
+    if (options.filename.ptr == NULL) {
         goto cleanup;
     }
-    options.filename = &filename;
 
     options.omit_initialize = jni_omit_initialize != 0;
 
@@ -56,7 +54,7 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_io_Pkcs11Lib_pkcs11LibNe
 
 cleanup:
     /* clean up, whether or not we were successful */
-    aws_jni_byte_cursor_from_jstring_release(env, jni_filename, filename);
+    aws_jni_byte_cursor_from_jstring_release(env, jni_filename, options.filename);
 
     return (jlong)pkcs11_lib;
 }

--- a/src/native/tls_context_options.c
+++ b/src/native/tls_context_options.c
@@ -91,8 +91,6 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     AWS_FATAL_ASSERT(tls);
     aws_tls_ctx_options_init_default_client(&tls->options, allocator);
 
-    /* TODO: rewrite this function so that it's an error we ignore any settings. */
-
     /* Certs or paths will cause an init, which overwrites other fields, so do those first */
     if (jni_certificate && jni_private_key) {
         tls->certificate = aws_jni_new_string_from_jstring(env, jni_certificate);

--- a/src/native/tls_context_options.c
+++ b/src/native/tls_context_options.c
@@ -139,7 +139,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
         }
 
         if (aws_tls_ctx_options_init_client_mtls_with_pkcs11(&tls->options, allocator, tls->pkcs11_options)) {
-            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_init_client_mtls_with_pkcs11 failedn");
+            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_init_client_mtls_with_pkcs11 failed");
             goto on_error;
         }
     }

--- a/src/native/tls_context_pkcs11_options.c
+++ b/src/native/tls_context_pkcs11_options.c
@@ -12,6 +12,18 @@
 #include <aws/io/pkcs11.h>
 #include <aws/io/tls_channel_handler.h>
 
+/* on 32-bit platforms, casting pointers to longs throws a warning we don't need */
+#if UINTPTR_MAX == 0xffffffff
+#    if defined(_MSC_VER)
+#        pragma warning(push)
+#        pragma warning(disable : 4305) /* 'type cast': truncation from 'jlong' to pointer */
+#    else
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
+#        pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
+#    endif
+#endif
+
 /* Contains aws_tls_ctx_pkcs11_options, plus values copied from
  * the TlsContextPkcs11Options java object */
 struct aws_tls_ctx_pkcs11_options_binding {

--- a/src/native/tls_context_pkcs11_options.c
+++ b/src/native/tls_context_pkcs11_options.c
@@ -11,12 +11,11 @@
 #include <aws/common/string.h>
 #include <aws/io/tls_channel_handler.h>
 
-/* aws_tls_ctx_pkcs11_options, plus values copied out of the originating TlsContextPkcs11Options java object */
+/* Contains aws_tls_ctx_pkcs11_options, plus values copied from
+ * the TlsContextPkcs11Options java object */
 struct aws_tls_ctx_pkcs11_options_binding {
-    /* Must be first thing in the structure so casts to aws_tls_ctx_pkcs11_options work */
     struct aws_tls_ctx_pkcs11_options options;
 
-    /* these strings get copied from java, so we don't have to pin and track references */
     struct aws_string *user_pin;
     struct aws_string *token_label;
     struct aws_string *private_key_object_label;
@@ -43,7 +42,7 @@ void aws_tls_ctx_pkcs11_options_from_java_destroy(struct aws_tls_ctx_pkcs11_opti
     aws_mem_release(aws_jni_get_allocator(), binding);
 }
 
-/* Helper for processing optional byte-cursors in the options.
+/* Helper for processing optional strings.
  * If false is returned then a java exception has occurred */
 static bool s_read_optional_string(
     JNIEnv *env,
@@ -59,12 +58,13 @@ static bool s_read_optional_string(
         return true;
     }
 
-    *out_string = aws_jni_new_string_from_jstring(env, field);
-    if (*out_string == NULL) {
+    struct aws_string *value = aws_jni_new_string_from_jstring(env, field);
+    if (value == NULL) {
         return false;
     }
 
-    *out_cursor = aws_byte_cursor_from_string(*out_string);
+    *out_string = value;
+    *out_cursor = aws_byte_cursor_from_string(value);
     return true;
 }
 

--- a/src/native/tls_context_pkcs11_options.c
+++ b/src/native/tls_context_pkcs11_options.c
@@ -1,0 +1,159 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include "tls_context_pkcs11_options.h"
+
+#include "crt.h"
+#include "java_class_ids.h"
+
+#include <aws/common/string.h>
+#include <aws/io/tls_channel_handler.h>
+
+/* aws_tls_ctx_pkcs11_options, plus values copied out of the originating TlsContextPkcs11Options java object */
+struct aws_tls_ctx_pkcs11_options_binding {
+    /* Must be first thing in the structure so casts to aws_tls_ctx_pkcs11_options work */
+    struct aws_tls_ctx_pkcs11_options options;
+
+    /* these strings get copied from java, so we don't have to pin and track references */
+    struct aws_string *user_pin;
+    struct aws_string *token_label;
+    struct aws_string *private_key_object_label;
+    struct aws_string *cert_file_path;
+    struct aws_string *cert_file_contents;
+
+    uint32_t slot_id;
+};
+
+void aws_tls_ctx_pkcs11_options_from_java_destroy(struct aws_tls_ctx_pkcs11_options *options) {
+    if (options == NULL) {
+        return;
+    }
+
+    struct aws_tls_ctx_pkcs11_options_binding *binding =
+        AWS_CONTAINER_OF(options, struct aws_tls_ctx_pkcs11_options_binding, options);
+
+    aws_string_destroy_secure(binding->user_pin);
+    aws_string_destroy(binding->token_label);
+    aws_string_destroy(binding->private_key_object_label);
+    aws_string_destroy(binding->cert_file_path);
+    aws_string_destroy(binding->cert_file_contents);
+
+    aws_mem_release(aws_jni_get_allocator(), binding);
+}
+
+/* Helper for processing optional byte-cursors in the options.
+ * If false is returned then a java exception has occurred */
+static bool s_read_optional_string(
+    JNIEnv *env,
+    jobject options_jni,
+    jfieldID jstring_field_id,
+    struct aws_string **out_string,
+    struct aws_byte_cursor *out_cursor) {
+
+    /* Check the field in TlsContextPkcs11Options.
+     * If it's NULL then we're all done, the user didn't set that optional string */
+    jstring field = (*env)->GetObjectField(env, options_jni, jstring_field_id);
+    if (field == NULL) {
+        return true;
+    }
+
+    *out_string = aws_jni_new_string_from_jstring(env, field);
+    if (*out_string == NULL) {
+        return false;
+    }
+
+    *out_cursor = aws_byte_cursor_from_string(*out_string);
+    return true;
+}
+
+struct aws_tls_ctx_pkcs11_options *aws_tls_ctx_pkcs11_options_from_java_new(JNIEnv *env, jobject options_jni) {
+    struct aws_tls_ctx_pkcs11_options_binding *binding =
+        aws_mem_calloc(aws_jni_get_allocator(), 1, sizeof(struct aws_tls_ctx_pkcs11_options_binding));
+
+    /* pkcs11_lib is required */
+    jobject pkcs11_lib_jni = (*env)->GetObjectField(env, options_jni, tls_context_pkcs11_options_properties.pkcs11Lib);
+    if (pkcs11_lib_jni == NULL) {
+        aws_jni_throw_null_pointer_exception(env, "Pkcs11Lib is null");
+        goto error;
+    }
+    binding->options.pkcs11_lib =
+        (void *)(*env)->CallLongMethod(env, pkcs11_lib_jni, crt_resource_properties.get_native_handle_method_id);
+    if (binding->options.pkcs11_lib == NULL) {
+        aws_jni_throw_null_pointer_exception(env, "Pkcs11Lib.getNativeHandle() returned null");
+        goto error;
+    }
+
+    /* user_pin is optional String */
+    if (!s_read_optional_string(
+            env,
+            options_jni,
+            tls_context_pkcs11_options_properties.userPin,
+            &binding->user_pin,
+            &binding->options.user_pin)) {
+        goto error;
+    }
+
+    /* slot_id is optional Integer */
+    jobject slot_id_jni = (*env)->GetObjectField(env, options_jni, tls_context_pkcs11_options_properties.slotId);
+    if (slot_id_jni != NULL) {
+        jint slot_id_value = (*env)->CallIntMethod(env, slot_id_jni, integer_properties.int_value_method_id);
+        if ((*env)->ExceptionCheck(env)) {
+            goto error;
+        }
+        if (slot_id_value < 0) {
+            aws_jni_throw_illegal_argument_exception(env, "PKCS#11 slot ID cannot be negative");
+            goto error;
+        }
+        binding->slot_id = (uint32_t)slot_id_value;
+        binding->options.slot_id = &binding->slot_id;
+    }
+
+    /* token_label is optional String */
+    if (!s_read_optional_string(
+            env,
+            options_jni,
+            tls_context_pkcs11_options_properties.tokenLabel,
+            &binding->token_label,
+            &binding->options.token_label)) {
+        goto error;
+    }
+
+    /* private_key_object_label is optional String */
+    if (!s_read_optional_string(
+            env,
+            options_jni,
+            tls_context_pkcs11_options_properties.privateKeyObjectLabel,
+            &binding->private_key_object_label,
+            &binding->options.private_key_object_label)) {
+        goto error;
+    }
+
+    /* cert_file_path is optional String */
+    if (!s_read_optional_string(
+            env,
+            options_jni,
+            tls_context_pkcs11_options_properties.certificateFilePath,
+            &binding->cert_file_path,
+            &binding->options.cert_file_path)) {
+        goto error;
+    }
+
+    /* binding->cert_file_contents is optional String */
+    if (!s_read_optional_string(
+            env,
+            options_jni,
+            tls_context_pkcs11_options_properties.certificateFileContents,
+            &binding->cert_file_contents,
+            &binding->options.cert_file_contents)) {
+        goto error;
+    }
+
+    /* success! */
+    return &binding->options;
+
+error:
+    aws_tls_ctx_pkcs11_options_from_java_destroy(&binding->options);
+    return NULL;
+}

--- a/src/native/tls_context_pkcs11_options.h
+++ b/src/native/tls_context_pkcs11_options.h
@@ -1,0 +1,21 @@
+#ifndef AWS_JNI_CRT_TLS_CONTEXT_PKCS11_OPTIONS_H
+#define AWS_JNI_CRT_TLS_CONTEXT_PKCS11_OPTIONS_H
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <jni.h>
+
+struct aws_tls_ctx_pkcs11_options;
+
+/* Create a aws_tls_ctx_pkcs11_options from a TlsContextPkcs11Options java object.
+ * All values are copied out of the Java object and stored in this allocation,
+ * there's no need to keep the java object around.
+ * This MUST be destroyed via aws_pkcs11_tls_options_from_java_destroy().
+ * Returns NULL and throws a java exception if something goes wrong. */
+struct aws_tls_ctx_pkcs11_options *aws_tls_ctx_pkcs11_options_from_java_new(JNIEnv *env, jobject options_jni);
+
+void aws_tls_ctx_pkcs11_options_from_java_destroy(struct aws_tls_ctx_pkcs11_options *options);
+
+#endif /* AWS_JNI_CRT_TLS_CONTEXT_PKCS11_OPTIONS_H */

--- a/src/test/java/software/amazon/awssdk/crt/test/Pkcs11LibTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Pkcs11LibTest.java
@@ -10,9 +10,9 @@ import software.amazon.awssdk.crt.io.Pkcs11Lib;
 public class Pkcs11LibTest extends CrtTestFixture {
 
     // The PKCS#11 tests are skipped unless the following env variables are set:
-    String TEST_PKCS11_LIB = System.getenv("TEST_PKCS11_LIB");
+    static String TEST_PKCS11_LIB = System.getenv("TEST_PKCS11_LIB");
 
-    void assumeEnvironmentSetUpForPkcs11Tests() {
+    static void assumeEnvironmentSetUpForPkcs11Tests() {
         Assume.assumeNotNull(TEST_PKCS11_LIB);
     }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
@@ -11,8 +11,10 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.is;
 import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.io.Pkcs11Lib;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
+import software.amazon.awssdk.crt.io.TlsContextPkcs11Options;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.utils.PemUtils;
 
@@ -213,6 +215,31 @@ public class TlsContextOptionsTest extends CrtTestFixture {
         }
 
         assertFalse(successfullyCreatedTlsContext);
+    }
+
+    @Test
+    public void testMtlsPkcs11() {
+        Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
+        Pkcs11LibTest.assumeEnvironmentSetUpForPkcs11Tests();
+
+        try (Pkcs11Lib pkcs11Lib = new Pkcs11Lib(Pkcs11LibTest.TEST_PKCS11_LIB);
+                TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
+
+            TlsContextPkcs11Options pkcs11Options = new TlsContextPkcs11Options(pkcs11Lib)
+                    .withUserPin("1234")
+                    .withSlotId(1)
+                    .withTokenLabel("my-token")
+                    .withPrivateKeyObjectLabel("my-key")
+                    .withCertificateFileContents("asdf")
+                    .withCertificateFilePath("qwer");
+
+            tlsOptions.withMtlsPkcs11(pkcs11Options);
+
+            try (TlsContext tls = new TlsContext(tlsOptions)) {
+            } catch (Exception ex) {
+                // TODO: remove this catch-block.
+            }
+        }
     }
 
     @Test

--- a/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.is;
 import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.Pkcs11Lib;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
@@ -223,22 +224,20 @@ public class TlsContextOptionsTest extends CrtTestFixture {
         Pkcs11LibTest.assumeEnvironmentSetUpForPkcs11Tests();
 
         try (Pkcs11Lib pkcs11Lib = new Pkcs11Lib(Pkcs11LibTest.TEST_PKCS11_LIB);
-                TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
+                TlsContextPkcs11Options pkcs11Options = new TlsContextPkcs11Options(pkcs11Lib)
+                        .withUserPin("1234")
+                        .withSlotId(1)
+                        .withTokenLabel("my-token")
+                        .withPrivateKeyObjectLabel("my-key")
+                        .withCertificateFileContents("asdf")
+                        .withCertificateFilePath("qwer");
+                TlsContextOptions tlsOptions = TlsContextOptions.createWithMtlsPkcs11(pkcs11Options);
+                TlsContext tls = new TlsContext(tlsOptions)) {
 
-            TlsContextPkcs11Options pkcs11Options = new TlsContextPkcs11Options(pkcs11Lib)
-                    .withUserPin("1234")
-                    .withSlotId(1)
-                    .withTokenLabel("my-token")
-                    .withPrivateKeyObjectLabel("my-key")
-                    .withCertificateFileContents("asdf")
-                    .withCertificateFilePath("qwer");
-
-            tlsOptions.withMtlsPkcs11(pkcs11Options);
-
-            try (TlsContext tls = new TlsContext(tlsOptions)) {
-            } catch (Exception ex) {
-                // TODO: remove this catch-block.
-            }
+        }
+        // TODO: remove this catch block once aws-c-io has actual implementation
+        catch (CrtRuntimeException ex) {
+            assertEquals("AWS_ERROR_UNIMPLEMENTED", ex.errorName);
         }
     }
 


### PR DESCRIPTION
Design decisions:
- rename ~Pkcs11TlsOptions~ -> `TlsContextPkcs11Options` for consistency with C
- `TlsContextPkcs11Options` is a `CrtResource`, but doesn't actually "carry around" its own native resource.
    - There's no real benefit in tying the lifetime of the native object to the java object, so don't
    - But being a `CrtResource`, lets it fit nicely into the rest of our `CrtResource` "ecosystem":
      - It can properly reference other resources.
      - It can be declared in the same try-blocks as other resources. etc

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
