### PR TITLE
Set release target version to JDK 8, when building with JDK > 8.

### DIFF
--- a/.builder/actions/aws_crt_java_test.py
+++ b/.builder/actions/aws_crt_java_test.py
@@ -11,7 +11,7 @@ class AWSCrtJavaTest(Builder.Action):
         actions = []
 
         if os.system("mvn -B test -DredirectTestOutputToFile=true -DforkCount=0 \
-            -DrerunFailingTestsCount=5 -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true -DskipAfterFailureCount=1"):
+            -DrerunFailingTestsCount=5 -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true"):
             # Failed
             actions.append("exit 1")
         os.system("cat log.txt")

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,15 @@
 
     <profiles>
         <profile>
+            <id>compile-for-java-8</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
+        <profile>
             <id>continuous-integration</id>
             <properties>
                 <cmake.warningsareerrors>ON</cmake.warningsareerrors>
@@ -288,6 +297,11 @@
             </testResource>
         </testResources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
@@ -41,7 +41,7 @@ public class HttpClientConnectionTest extends HttpClientTestFixture {
 
         try (HttpClientConnectionManager connectionPool = HttpClientConnectionManager.create(options)) {
             resp.shutdownComplete = connectionPool.getShutdownCompleteFuture();
-            try (HttpClientConnection conn = connectionPool.acquireConnection().get(120, TimeUnit.SECONDS)) {
+            try (HttpClientConnection conn = connectionPool.acquireConnection().get(60, TimeUnit.SECONDS)) {
                 resp.actuallyConnected = true;
             }
         } catch (Exception e) {
@@ -69,7 +69,7 @@ public class HttpClientConnectionTest extends HttpClientTestFixture {
                         SocketOptions socketOptions = new SocketOptions();
                         TlsContext tlsCtx = new TlsContext(tlsOpts)) {
 
-                    socketOptions.connectTimeoutMs = 10000;
+                    socketOptions.connectTimeoutMs = 100000;
                     resp = testConnection(uri, bootstrap, socketOptions, tlsCtx);
                 }
             }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
@@ -41,7 +41,7 @@ public class HttpClientConnectionTest extends HttpClientTestFixture {
 
         try (HttpClientConnectionManager connectionPool = HttpClientConnectionManager.create(options)) {
             resp.shutdownComplete = connectionPool.getShutdownCompleteFuture();
-            try (HttpClientConnection conn = connectionPool.acquireConnection().get(60, TimeUnit.SECONDS)) {
+            try (HttpClientConnection conn = connectionPool.acquireConnection().get(120, TimeUnit.SECONDS)) {
                 resp.actuallyConnected = true;
             }
         } catch (Exception e) {


### PR DESCRIPTION
This fixes an issue where customers on JDK 8 would get a NoSuchMethodException for ByteBuffer.position.