### PR TITLE
PKCS#11 - expose InitializeFinalizeBehavior enum

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/Pkcs11Lib.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/Pkcs11Lib.java
@@ -9,38 +9,74 @@ import software.amazon.awssdk.crt.CrtResource;
 
 /**
  * Handle to a loaded PKCS#11 library.
- * <p>
+ *
  * For most use cases, a single instance of Pkcs11Lib should be used for the
  * lifetime of your application.
- * <p>
- * <b>Notes on initialization:</b> By default, {@code C_Initialize()} and
- * {@code C_Finalize()} are called when the PKCS#11 library is loaded and
- * unloaded. Call a constructor with {@link Pkcs11Lib(String, boolean)
- * omitInitialization} set to skip these calls if your application has already
- * initialized the PKCS#11 library (ex: by using the {@code SunPKCS11}
- * cryptographic provider)
  */
 public class Pkcs11Lib extends CrtResource {
 
     /**
+     * Controls how Pkcs11Lib calls {@code C_Initialize()} and {@code C_Finalize()}
+     * on the PKCS#11 library.
+     */
+    public enum InitializeFinalizeBehavior {
+        /**
+         * Default behavior that accommodates most use cases.
+         *
+         * {@code C_Initialize()} is called on creation, and "already-initialized"
+         * errors are ignored. {@code C_Finalize()} is never called, just in case
+         * another part of your application is still using the PKCS#11 library.
+         */
+        DEFAULT(0),
+
+        /**
+         * Skip calling {@code C_Initialize()} and {@code C_Finalize()}.
+         *
+         * Use this if your application has already initialized the PKCS#11 library, and
+         * you do not want {@code C_Initialize()} called again.
+         */
+        OMIT(1),
+
+        /**
+         * {@code C_Initialize()} is called on creation and {@code C_Finalize()} is
+         * called on cleanup.
+         *
+         * If {@code C_Initialize()} reports that's it's already initialized, this is
+         * treated as an error. Use this if you need perfect cleanup (ex: running
+         * valgrind with --leak-check).
+         */
+        STRICT(2);
+
+        InitializeFinalizeBehavior(int nativeValue) {
+            this.nativeValue = nativeValue;
+        }
+
+        int nativeValue;
+    }
+
+    /**
      * Load and initialize a PKCS#11 library.
+     *
+     * {@code C_Initialize()} and {@code C_Finalize()} are called on the PKCS#11
+     * library in the {@link InitializeFinalizeBehavior#DEFAULT DEFAULT} way.
      *
      * @param path path to PKCS#11 library.
      */
     public Pkcs11Lib(String path) {
-        this(path, false);
+        this(path, InitializeFinalizeBehavior.DEFAULT);
     }
 
     /**
-     * Load a PKCS#11 library, with explicit control over initialization.
+     * Load a PKCS#11 library, specifying how {@code C_Initialize()} and
+     * {@code C_Finalize()} will be called.
      *
-     * @param path           path to PKCS#11 library.
-     * @param omitInitialize if true, {@code C_Initialize()} and
-     *                       {@code C_Finalize()} will not be called on the PKCS#11
-     *                       library. See {@link Pkcs11Lib Notes on initialization}
+     * @param path                       path to PKCS#11 library.
+     * @param initializeFinalizeBehavior specifies how {@code C_Initialize()} and
+     *                                   {@code C_Finalize()} will be called on the
+     *                                   PKCS#11 library.
      */
-    public Pkcs11Lib(String path, boolean omitInitialize) {
-        acquireNativeHandle(pkcs11LibNew(path, omitInitialize));
+    public Pkcs11Lib(String path, InitializeFinalizeBehavior initializeFinalizeBehavior) {
+        acquireNativeHandle(pkcs11LibNew(path, initializeFinalizeBehavior.nativeValue));
     }
 
     @Override
@@ -58,7 +94,7 @@ public class Pkcs11Lib extends CrtResource {
     /*******************************************************************************
      * native methods
      ******************************************************************************/
-    private static native long pkcs11LibNew(String path, boolean omitInitialize);
+    private static native long pkcs11LibNew(String path, int initializeFinalizeBehavior);
 
     private static native void pkcs11LibRelease(long nativeHandle);
 }

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -413,7 +413,7 @@ public final class TlsContextOptions extends CrtResource {
      * @return this
      */
     public TlsContextOptions withMtlsPkcs11(TlsContextPkcs11Options pkcs11Options) {
-        addReferenceTo(pkcs11Options);
+        swapReferenceTo(this.pkcs11Options, pkcs11Options);
         this.pkcs11Options = pkcs11Options;
         return this;
     }

--- a/src/native/pkcs11_lib.c
+++ b/src/native/pkcs11_lib.c
@@ -25,7 +25,7 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_io_Pkcs11Lib_pkcs11LibNe
     JNIEnv *env,
     jclass jni_class,
     jstring jni_filename,
-    jboolean jni_omit_initialize) {
+    jint jni_initialize_finalize_behavior) {
 
     (void)jni_class;
 
@@ -43,9 +43,7 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_io_Pkcs11Lib_pkcs11LibNe
         goto cleanup;
     }
 
-    if (jni_omit_initialize) {
-        options.initialize_finalize_behavior = AWS_PKCS11_LIB_OMIT_INITIALIZE;
-    }
+    options.initialize_finalize_behavior = jni_initialize_finalize_behavior;
 
     /* create aws_pkcs11_lib */
     pkcs11_lib = aws_pkcs11_lib_new(aws_jni_get_allocator(), &options);

--- a/src/test/java/software/amazon/awssdk/crt/test/Pkcs11LibTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Pkcs11LibTest.java
@@ -1,26 +1,40 @@
 package software.amazon.awssdk.crt.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Assume;
 import org.junit.Test;
 
+import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.Pkcs11Lib;
 
 public class Pkcs11LibTest extends CrtTestFixture {
 
     // The PKCS#11 tests are skipped unless the following env variables are set:
     static String TEST_PKCS11_LIB = System.getenv("TEST_PKCS11_LIB");
+    static String TEST_PKCS11_TOKEN_LABEL = System.getenv("TEST_PKCS11_TOKEN_LABEL");
+    static String TEST_PKCS11_PIN = System.getenv("TEST_PKCS11_PIN");
+    static String TEST_PKCS11_PKEY_LABEL = System.getenv("TEST_PKCS11_PKEY_LABEL");
+    static String TEST_PKCS11_CERT_FILE = System.getenv("TEST_PKCS11_CERT_FILE");
+    static String TEST_PKCS11_CA_FILE = System.getenv("TEST_PKCS11_CA_FILE");
 
     static void assumeEnvironmentSetUpForPkcs11Tests() {
         Assume.assumeNotNull(TEST_PKCS11_LIB);
+        Assume.assumeNotNull(TEST_PKCS11_TOKEN_LABEL);
+        Assume.assumeNotNull(TEST_PKCS11_PIN);
+        Assume.assumeNotNull(TEST_PKCS11_PKEY_LABEL);
+        Assume.assumeNotNull(TEST_PKCS11_CERT_FILE);
+        Assume.assumeNotNull(TEST_PKCS11_CA_FILE);
     }
 
     public Pkcs11LibTest() {
     }
 
     @Test
-    public void testPkcs11LibWithInitialize() {
+    public void testPkcs11Lib() {
         assumeEnvironmentSetUpForPkcs11Tests();
 
         try (Pkcs11Lib pkcs11Lib = new Pkcs11Lib(TEST_PKCS11_LIB)) {
@@ -38,15 +52,19 @@ public class Pkcs11LibTest extends CrtTestFixture {
     }
 
     @Test
-    public void testPkcs11LibWithOmitInitialize() {
+    public void testPkcs11LibInitializeFinalizeBehavior() {
         assumeEnvironmentSetUpForPkcs11Tests();
 
-        // Check that omitInitialize constructor param can be used to skip C_Initialize.
-        // To test this, we need to create 2 Pkcs11Lib instances,
-        // where the 1st calls C_Initialize and the 2nd omits C_Initialize
-        try (Pkcs11Lib firstLibInstance = new Pkcs11Lib(TEST_PKCS11_LIB, false /* omitInitialize */);
-                Pkcs11Lib secondLibInstance = new Pkcs11Lib(TEST_PKCS11_LIB, true /* omitInitialize */)) {
+        // check that the behavior enum is passed to native.
+        // we expect OMIT behavior to cause failure here because no one else
+        // has called C_Initialize.
+        CrtRuntimeException crtException = null;
+        try (Pkcs11Lib pkcs11Lib = new Pkcs11Lib(TEST_PKCS11_LIB, Pkcs11Lib.InitializeFinalizeBehavior.OMIT)) {
+        } catch (Exception ex) {
+            crtException = (CrtRuntimeException) ex;
         }
+        assertNotNull(crtException);
+        assertTrue(crtException.errorName.contains("CKR_CRYPTOKI_NOT_INITIALIZED"));
     }
 
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
@@ -219,7 +219,6 @@ public class TlsContextOptionsTest extends CrtTestFixture {
         assertFalse(successfullyCreatedTlsContext);
     }
 
-    @Ignore // TODO: figure out how to test this
     @Test
     public void testMtlsPkcs11() {
         Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
@@ -227,17 +226,15 @@ public class TlsContextOptionsTest extends CrtTestFixture {
 
         try (Pkcs11Lib pkcs11Lib = new Pkcs11Lib(Pkcs11LibTest.TEST_PKCS11_LIB);
                 TlsContextPkcs11Options pkcs11Options = new TlsContextPkcs11Options(pkcs11Lib)
-                        .withUserPin("1234")
-                        .withSlotId(1)
-                        .withTokenLabel("my-token")
-                        .withPrivateKeyObjectLabel("my-key")
-                        .withCertificateFileContents("asdf")
-                        .withCertificateFilePath("qwer");
+                        .withUserPin(Pkcs11LibTest.TEST_PKCS11_PIN)
+                        .withTokenLabel(Pkcs11LibTest.TEST_PKCS11_TOKEN_LABEL)
+                        .withPrivateKeyObjectLabel(Pkcs11LibTest.TEST_PKCS11_PKEY_LABEL)
+                        .withCertificateFilePath(Pkcs11LibTest.TEST_PKCS11_CERT_FILE);
                 TlsContextOptions tlsOptions = TlsContextOptions.createWithMtlsPkcs11(pkcs11Options);
                 TlsContext tls = new TlsContext(tlsOptions)) {
-
         }
         catch (CrtRuntimeException ex) {
+            // This is expected to fail on platforms where we don't yet support mTLS with PKCS#11
             assertEquals("AWS_ERROR_UNIMPLEMENTED", ex.errorName);
         }
     }


### PR DESCRIPTION
Expose enum that controls how C_Initialize() and C_Finalize() are called on the underlying PKCS#11 library.

This is related to the following changes from C:  https://github.com/awslabs/aws-c-io/pull/442

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
