### PR TITLE
HTTP/2 Request (HTTP/2 Phase3)

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/http/Http2ClientConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2ClientConnection.java
@@ -29,9 +29,19 @@ public class Http2ClientConnection extends HttpClientConnection {
      * (RFC-7540 7).
      */
     public enum Http2ErrorCode {
-        PROTOCOL_ERROR(1), INTERNAL_ERROR(2), FLOW_CONTROL_ERROR(3), SETTINGS_TIMEOUT(4), STREAM_CLOSED(5),
-        FRAME_SIZE_ERROR(6), REFUSED_STREAM(7), CANCEL(8), COMPRESSION_ERROR(9), CONNECT_ERROR(10),
-        ENHANCE_YOUR_CALM(11), INADEQUATE_SECURITY(12), HTTP_1_1_REQUIRED(13);
+        PROTOCOL_ERROR(1),
+        INTERNAL_ERROR(2),
+        FLOW_CONTROL_ERROR(3),
+        SETTINGS_TIMEOUT(4),
+        STREAM_CLOSED(5),
+        FRAME_SIZE_ERROR(6),
+        REFUSED_STREAM(7),
+        CANCEL(8),
+        COMPRESSION_ERROR(9),
+        CONNECT_ERROR(10),
+        ENHANCE_YOUR_CALM(11),
+        INADEQUATE_SECURITY(12),
+        HTTP_1_1_REQUIRED(13);
 
         private int errorCode;
 

--- a/src/main/java/software/amazon/awssdk/crt/http/Http2ClientConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2ClientConnection.java
@@ -29,19 +29,9 @@ public class Http2ClientConnection extends HttpClientConnection {
      * (RFC-7540 7).
      */
     public enum Http2ErrorCode {
-        PROTOCOL_ERROR(1),
-        INTERNAL_ERROR(2),
-        FLOW_CONTROL_ERROR(3),
-        SETTINGS_TIMEOUT(4),
-        STREAM_CLOSED(5),
-        FRAME_SIZE_ERROR(6),
-        REFUSED_STREAM(7),
-        CANCEL(8),
-        COMPRESSION_ERROR(9),
-        CONNECT_ERROR(10),
-        ENHANCE_YOUR_CALM(11),
-        INADEQUATE_SECURITY(12),
-        HTTP_1_1_REQUIRED(13);
+        PROTOCOL_ERROR(1), INTERNAL_ERROR(2), FLOW_CONTROL_ERROR(3), SETTINGS_TIMEOUT(4), STREAM_CLOSED(5),
+        FRAME_SIZE_ERROR(6), REFUSED_STREAM(7), CANCEL(8), COMPRESSION_ERROR(9), CONNECT_ERROR(10),
+        ENHANCE_YOUR_CALM(11), INADEQUATE_SECURITY(12), HTTP_1_1_REQUIRED(13);
 
         private int errorCode;
 
@@ -163,7 +153,8 @@ public class Http2ClientConnection extends HttpClientConnection {
 
     /**
      * Schedules an HttpRequest on the Native EventLoop for this
-     * HttpClientConnection.
+     * HttpClientConnection. The HTTP/1.1 request will be transformed to HTTP/2
+     * request under the hood.
      *
      * @param request       The Request to make to the Server.
      * @param streamHandler The Stream Handler to be called from the Native
@@ -174,7 +165,7 @@ public class Http2ClientConnection extends HttpClientConnection {
      *         the user thread making this request when it's done.
      */
     @Override
-    public Http2Stream makeRequest(HttpRequest request, HttpStreamResponseHandler streamHandler)
+    public Http2Stream makeRequest(HttpRequestBase request, HttpStreamResponseHandler streamHandler)
             throws CrtRuntimeException {
         if (isNull()) {
             throw new IllegalStateException("Http2ClientConnection has been closed, can't make requests on it.");

--- a/src/main/java/software/amazon/awssdk/crt/http/Http2Request.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2Request.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.awssdk.crt.http;
+
+import software.amazon.awssdk.crt.http.HttpClientConnection.ProtocolVersion;
+
+/**
+ * Represents a single Client Request to be sent on a HTTP connection
+ */
+public class Http2Request extends HttpRequestBase {
+    /**
+     *
+     */
+    public Http2Request() {
+        this(new HttpHeader[] {}, null);
+    }
+
+    public Http2Request(HttpHeader[] headers, HttpRequestBodyStream bodyStream) {
+        super(headers, bodyStream);
+        this.version = ProtocolVersion.HTTP_2;
+    }
+
+}

--- a/src/main/java/software/amazon/awssdk/crt/http/Http2Request.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2Request.java
@@ -12,12 +12,20 @@ import software.amazon.awssdk.crt.http.HttpClientConnection.ProtocolVersion;
  */
 public class Http2Request extends HttpRequestBase {
     /**
-     *
+     * An empty HTTP/2 Request.
      */
     public Http2Request() {
         this(new HttpHeader[] {}, null);
     }
 
+    /**
+     * An empty HTTP/2 Request with headers and body stream.
+     *
+     * @param headers    set of http request headers to include, note: pseudo
+     *                   headers should be set to make a good HTTP/2 request.
+     * @param bodyStream (optional) interface to an object that will stream out the
+     *                   request body
+     */
     public Http2Request(HttpHeader[] headers, HttpRequestBodyStream bodyStream) {
         super(headers, bodyStream);
         this.version = ProtocolVersion.HTTP_2;

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnection.java
@@ -76,7 +76,7 @@ public class HttpClientConnection extends CrtResource {
      * @return The HttpStream that represents this Request/Response Pair. It can be closed at any time during the
      *          request/response, but must be closed by the user thread making this request when it's done.
      */
-    public HttpStream makeRequest(HttpRequest request, HttpStreamResponseHandler streamHandler) throws CrtRuntimeException {
+    public HttpStream makeRequest(HttpRequestBase request, HttpStreamResponseHandler streamHandler) throws CrtRuntimeException {
         if (isNull()) {
             throw new IllegalStateException("HttpClientConnection has been closed, can't make requests on it.");
         }

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpRequest.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpRequest.java
@@ -4,73 +4,63 @@
  */
 
 package software.amazon.awssdk.crt.http;
+
 import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.http.HttpClientConnection.ProtocolVersion;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Represents a single Client Request to be sent on a HTTP connection
  */
-public class HttpRequest {
-    private final static Charset UTF8 = java.nio.charset.StandardCharsets.UTF_8;
-    private final static int BUFFER_INT_SIZE = 4;
-    private final String method;
-    private String encodedPath;
-    private List<HttpHeader> headers;
-    private HttpRequestBodyStream bodyStream;
+public class HttpRequest extends HttpRequestBase {
 
     /**
      *
-     * @param method http verb to use
+     * @param method      http verb to use
      * @param encodedPath path of the http request
      */
     public HttpRequest(String method, String encodedPath) {
-        this(method, encodedPath, new HttpHeader[]{}, null);
+        this(method, encodedPath, new HttpHeader[] {}, null);
     }
 
     /**
      *
-     * @param method http verb to use
+     * @param method      http verb to use
      * @param encodedPath path of the http request
-     * @param headers set of http request headers to include
-     * @param bodyStream (optional) interface to an object that will stream out the request body
+     * @param headers     set of http request headers to include
+     * @param bodyStream  (optional) interface to an object that will stream out the
+     *                    request body
      */
     public HttpRequest(String method, String encodedPath, HttpHeader[] headers, HttpRequestBodyStream bodyStream) {
-        if (headers == null) { throw new IllegalArgumentException("Headers can be empty, but can't be null"); }
+        super(headers, bodyStream);
         this.method = method;
         this.encodedPath = encodedPath;
-        this.headers = Arrays.asList(headers);
-        this.bodyStream = bodyStream;
     }
 
     /**
-     * Package private. Used by JNI to convert native http representation to a Java object, because accessing this
-     * struct from JNI is too slow.
+     * Package private. Used by JNI to convert native http representation to a Java
+     * object, because accessing this struct from JNI is too slow.
      *
-     *  Requests are marshalled as follows:
+     * Requests are marshalled as follows:
      *
-     *  each string field is:
-     *  [4-bytes BE] [variable length bytes specified by the previous field]
-     *  Each request is then:
-     *  [method][path][header name-value pairs]
+     * each string field is: [4-bytes BE] [variable length bytes specified by the
+     * previous field] Each request is then: [method][path][header name-value pairs]
      *
      * @param marshalledRequest serialized http request to be parsed.
-     * @param bodyStream body stream for the http request.
+     * @param bodyStream        body stream for the http request.
      */
     HttpRequest(ByteBuffer marshalledRequest, HttpRequestBodyStream bodyStream) {
-        if (marshalledRequest.remaining() < BUFFER_INT_SIZE * 2) {
+        if (marshalledRequest.remaining() < BUFFER_INT_SIZE * 3) {
             throw new CrtRuntimeException("Invalid marshalled request object.");
         }
+        this.version = ProtocolVersion.getEnumValueFromInteger(marshalledRequest.getInt());
 
         int methodLength = marshalledRequest.getInt();
         byte[] methodBlob = new byte[methodLength];
         marshalledRequest.get(methodBlob);
         this.method = new String(methodBlob, UTF8);
-        if  (marshalledRequest.remaining() < BUFFER_INT_SIZE) {
+        if (marshalledRequest.remaining() < BUFFER_INT_SIZE) {
             throw new CrtRuntimeException("Invalid marshalled request object.");
         }
 
@@ -93,69 +83,5 @@ public class HttpRequest {
 
     public void setEncodedPath(final String encodedPath) {
         this.encodedPath = encodedPath;
-    }
-
-    public List<HttpHeader> getHeaders() {
-        return headers;
-    }
-
-    public HttpHeader[] getHeadersAsArray() {
-        return headers.toArray(new HttpHeader[] {});
-    }
-
-    public void addHeader(final HttpHeader header) {
-        headers.add(header);
-    }
-
-    public void addHeader(final String headerName, final String headerValue) {
-        headers.add(new HttpHeader(headerName, headerValue));
-    }
-
-    public void addHeaders(final HttpHeader[] headers) {
-        Collections.addAll(this.headers, headers);
-
-    }
-
-    public HttpRequestBodyStream getBodyStream() {
-        return bodyStream;
-    }
-
-    /**
-     * @exclude Requests are marshalled as follows:
-     *
-     *          each string field is: [4-bytes BE] [variable length bytes specified
-     *          by the previous field]
-     *
-     *          Each request is then: [method][path][header name-value pairs]
-     * @return encoded blob of headers
-     */
-    public byte[] marshalForJni() {
-        int size = 0;
-        size += BUFFER_INT_SIZE + method.length();
-        size += BUFFER_INT_SIZE + encodedPath.length();
-        size += (BUFFER_INT_SIZE * 2) * headers.size();
-
-        for(HttpHeader header : headers) {
-            if (header.getNameBytes().length > 0) {
-                size += header.getNameBytes().length + header.getValueBytes().length;
-            }
-        }
-
-        ByteBuffer buffer = ByteBuffer.allocate(size);
-        buffer.putInt(method.length());
-        buffer.put(method.getBytes(UTF8));
-        buffer.putInt(encodedPath.length());
-        buffer.put(encodedPath.getBytes(UTF8));
-
-        for(HttpHeader header : headers) {
-            if (header.getNameBytes().length > 0) {
-                buffer.putInt(header.getNameBytes().length);
-                buffer.put(header.getNameBytes());
-                buffer.putInt(header.getValueBytes().length);
-                buffer.put(header.getValueBytes());
-            }
-        }
-
-        return buffer.array();
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpRequestBase.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpRequestBase.java
@@ -1,0 +1,100 @@
+package software.amazon.awssdk.crt.http;
+
+import java.util.Arrays;
+import java.util.List;
+
+import software.amazon.awssdk.crt.http.HttpClientConnection.ProtocolVersion;
+import java.util.Arrays;
+import java.nio.charset.Charset;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+
+public class HttpRequestBase {
+    protected final static Charset UTF8 = java.nio.charset.StandardCharsets.UTF_8;
+    protected final static int BUFFER_INT_SIZE = 4;
+    protected List<HttpHeader> headers;
+    protected HttpRequestBodyStream bodyStream;
+    protected ProtocolVersion version = ProtocolVersion.HTTP_1_1;
+    protected String method;
+    protected String encodedPath;
+
+    protected HttpRequestBase() {
+    }
+
+    protected HttpRequestBase(HttpHeader[] headers, HttpRequestBodyStream bodyStream) {
+        if (headers == null) {
+            throw new IllegalArgumentException("Headers can be empty, but can't be null");
+        }
+        this.headers = Arrays.asList(headers);
+        this.bodyStream = bodyStream;
+    }
+
+    /**
+     * @exclude Requests are marshalled as follows:
+     *
+     *          version is as int: [4-bytes BE]
+     *
+     *          each string field is: [4-bytes BE] [variable length bytes specified
+     *          by the previous field]
+     *
+     *          Each request is then: [version][method][path][header name-value
+     *          pairs]
+     * @return encoded blob of headers
+     */
+    public byte[] marshalForJni() {
+        int size = 0;
+        size += BUFFER_INT_SIZE; /* version */
+        size += BUFFER_INT_SIZE + method.length();
+        size += BUFFER_INT_SIZE + encodedPath.length();
+        size += (BUFFER_INT_SIZE * 2) * headers.size();
+
+        for (HttpHeader header : headers) {
+            if (header.getNameBytes().length > 0) {
+                size += header.getNameBytes().length + header.getValueBytes().length;
+            }
+        }
+
+        ByteBuffer buffer = ByteBuffer.allocate(size);
+        buffer.putInt(version.getValue());
+        buffer.putInt(method.length());
+        buffer.put(method.getBytes(UTF8));
+        buffer.putInt(encodedPath.length());
+        buffer.put(encodedPath.getBytes(UTF8));
+
+        for (HttpHeader header : headers) {
+            if (header.getNameBytes().length > 0) {
+                buffer.putInt(header.getNameBytes().length);
+                buffer.put(header.getNameBytes());
+                buffer.putInt(header.getValueBytes().length);
+                buffer.put(header.getValueBytes());
+            }
+        }
+
+        return buffer.array();
+    }
+
+    public HttpRequestBodyStream getBodyStream() {
+        return bodyStream;
+    }
+
+    public List<HttpHeader> getHeaders() {
+        return headers;
+    }
+
+    public HttpHeader[] getHeadersAsArray() {
+        return headers.toArray(new HttpHeader[] {});
+    }
+
+    public void addHeader(final HttpHeader header) {
+        headers.add(header);
+    }
+
+    public void addHeader(final String headerName, final String headerValue) {
+        headers.add(new HttpHeader(headerName, headerValue));
+    }
+
+    public void addHeaders(final HttpHeader[] headers) {
+        Collections.addAll(this.headers, headers);
+
+    }
+}

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpRequestBase.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpRequestBase.java
@@ -1,10 +1,10 @@
 package software.amazon.awssdk.crt.http;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 import software.amazon.awssdk.crt.http.HttpClientConnection.ProtocolVersion;
-import java.util.Arrays;
 import java.nio.charset.Charset;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -18,6 +18,9 @@ public class HttpRequestBase {
     protected String method;
     protected String encodedPath;
 
+    /**
+     * Only used for create request from native side.
+     */
     protected HttpRequestBase() {
     }
 
@@ -25,7 +28,9 @@ public class HttpRequestBase {
         if (headers == null) {
             throw new IllegalArgumentException("Headers can be empty, but can't be null");
         }
-        this.headers = Arrays.asList(headers);
+        method = "";
+        encodedPath = "";
+        this.headers = new ArrayList<HttpHeader>(Arrays.asList(headers));
         this.bodyStream = bodyStream;
     }
 

--- a/src/native/http_request_utils.c
+++ b/src/native/http_request_utils.c
@@ -214,6 +214,14 @@ int aws_marshal_http_headers_to_dynamic_buffer(
     return AWS_OP_SUCCESS;
 }
 
+static inline enum aws_http_version s_unmarshal_http_request_to_get_version(struct aws_byte_cursor *request_blob) {
+    uint32_t version = 0;
+    if (!aws_byte_cursor_read_be32(request_blob, &version)) {
+        aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    }
+    return version;
+}
+
 static inline int s_unmarshal_http_request(struct aws_http_message *message, struct aws_byte_cursor *request_blob) {
     uint32_t field_len = 0;
 
@@ -282,7 +290,12 @@ int aws_apply_java_http_request_changes_to_native_request(
     struct aws_byte_cursor marshalled_cur =
         aws_byte_cursor_from_array((uint8_t *)marshalled_request_data, marshalled_request_length);
 
-    result = s_unmarshal_http_request(message, &marshalled_cur);
+    enum aws_http_version version = s_unmarshal_http_request_to_get_version(&marshalled_cur);
+    if (version != aws_http_message_get_protocol_version(message)) {
+        result = aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    } else {
+        result = s_unmarshal_http_request(message, &marshalled_cur);
+    }
     (*env)->ReleasePrimitiveArrayCritical(env, marshalled_request, marshalled_request_data, 0);
 
     if (jni_body_stream) {
@@ -305,17 +318,22 @@ struct aws_http_message *aws_http_request_new_from_java_http_request(
     jbyteArray marshalled_request,
     jobject jni_body_stream) {
     const char *exception_message = NULL;
-    struct aws_http_message *request = aws_http_message_new_request(aws_jni_get_allocator());
-    if (request == NULL) {
-        aws_jni_throw_runtime_exception(env, "aws_http_request_new_from_java_http_request: Unable to allocate request");
-        return NULL;
-    }
     const size_t marshalled_request_length = (*env)->GetArrayLength(env, marshalled_request);
 
     jbyte *marshalled_request_data = (*env)->GetPrimitiveArrayCritical(env, marshalled_request, NULL);
     struct aws_byte_cursor marshalled_cur =
         aws_byte_cursor_from_array((uint8_t *)marshalled_request_data, marshalled_request_length);
-    int result = s_unmarshal_http_request(request, &marshalled_cur);
+    enum aws_http_version version = s_unmarshal_http_request_to_get_version(&marshalled_cur);
+    struct aws_http_message *request = version == AWS_HTTP_VERSION_2
+                                           ? aws_http2_message_new_request(aws_jni_get_allocator())
+                                           : aws_http_message_new_request(aws_jni_get_allocator());
+
+    int result = AWS_OP_SUCCESS;
+    if (version != aws_http_message_get_protocol_version(request)) {
+        result = aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    } else {
+        result = s_unmarshal_http_request(request, &marshalled_cur);
+    }
     (*env)->ReleasePrimitiveArrayCritical(env, marshalled_request, marshalled_request_data, 0);
 
     if (result) {
@@ -358,10 +376,11 @@ static inline int s_marshall_http_request(const struct aws_http_message *message
 
     AWS_FATAL_ASSERT(!aws_http_message_get_request_path(message, &path));
 
-    if (aws_byte_buf_reserve_relative(request_buf, sizeof(int) + sizeof(int) + method.len + path.len)) {
+    if (aws_byte_buf_reserve_relative(request_buf, sizeof(int) + sizeof(int) + sizeof(int) + method.len + path.len)) {
         return AWS_OP_ERR;
     }
 
+    aws_byte_buf_write_be32(request_buf, (uint32_t)aws_http_message_get_protocol_version(message));
     aws_byte_buf_write_be32(request_buf, (uint32_t)method.len);
     aws_byte_buf_write_from_whole_cursor(request_buf, method);
     aws_byte_buf_write_be32(request_buf, (uint32_t)path.len);

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -9,9 +9,10 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
+import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpHeader;
-import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.crt.http.Http2Request;
 import software.amazon.awssdk.crt.http.HttpStream;
 import software.amazon.awssdk.crt.http.Http2Stream;
 import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
@@ -19,6 +20,8 @@ import software.amazon.awssdk.crt.http.Http2ClientConnection;
 import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
 import software.amazon.awssdk.crt.http.Http2ClientConnection.Http2ErrorCode;
 import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
+import static software.amazon.awssdk.crt.utils.ByteBufferUtils.transferData;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -29,10 +32,44 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
     private final static String HOST = "https://httpbin.org";
     private final static HttpClientConnection.ProtocolVersion EXPECTED_VERSION = HttpClientConnection.ProtocolVersion.HTTP_2;
 
+    private Http2Request getHttp2Request(String method, String endpoint, String path, String requestBody)
+            throws Exception {
+        URI uri = new URI(endpoint);
+
+        HttpHeader[] requestHeaders = null;
+
+        requestHeaders = new HttpHeader[] { new HttpHeader(":method", method), new HttpHeader(":path", path),
+                new HttpHeader(":scheme", uri.getScheme()), new HttpHeader(":authority", uri.getHost()),
+                new HttpHeader("content-length", Integer.toString(requestBody.getBytes(UTF8).length)), };
+
+        HttpRequestBodyStream bodyStream = null;
+
+        final ByteBuffer bodyBytesIn = ByteBuffer.wrap(requestBody.getBytes(UTF8));
+
+        bodyStream = new HttpRequestBodyStream() {
+            @Override
+            public boolean sendRequestBody(ByteBuffer bodyBytesOut) {
+                transferData(bodyBytesIn, bodyBytesOut);
+
+                return bodyBytesIn.remaining() == 0;
+            }
+
+            @Override
+            public boolean resetPosition() {
+                bodyBytesIn.position(0);
+
+                return true;
+            }
+        };
+
+        Http2Request request = new Http2Request(requestHeaders, bodyStream);
+        return request;
+    }
+
     public TestHttpResponse testHttp2Request(String method, String endpoint, String path, String requestBody,
             int expectedStatus) throws Exception {
         URI uri = new URI(endpoint);
-        HttpRequest request = getHttpRequest(method, endpoint, path, requestBody);
+        Http2Request request = getHttp2Request(method, endpoint, path, requestBody);
 
         TestHttpResponse response = null;
         int numAttempts = 0;
@@ -139,6 +176,7 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
             try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
                     TimeUnit.SECONDS);) {
                 actuallyConnected = true;
+                CompletableFuture<Void> streamComplete = new CompletableFuture<>();
                 Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
                 HttpStreamResponseHandler streamHandler = new HttpStreamResponseHandler() {
                     @Override
@@ -151,11 +189,17 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
                     @Override
                     public void onResponseComplete(HttpStream stream, int errorCode) {
                         stream.close();
+                        if (errorCode != 0) {
+                            streamComplete.completeExceptionally(new CrtRuntimeException(errorCode));
+                        } else {
+                            streamComplete.complete(null);
+                        }
                     }
                 };
-                HttpRequest request = getHttpRequest("GET", HOST, "/get", EMPTY_BODY);
+                Http2Request request = getHttp2Request("GET", HOST, "/get", EMPTY_BODY);
                 Http2Stream h2Stream = conn.makeRequest(request, streamHandler);
                 h2Stream.activate();
+                streamComplete.get();
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -167,4 +211,5 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
 
         CrtResource.waitForNoResources();
     }
+
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseFixture.java
@@ -81,8 +81,8 @@ public class HttpRequestResponseFixture extends HttpClientTestFixture {
         HttpHeader[] requestHeaders = null;
 
         /* TODO: Http2 headers and request */
-        requestHeaders = new HttpHeader[] { new HttpHeader("host", uri.getHost()),
-                new HttpHeader("content-length", Integer.toString(requestBody.getBytes(UTF8).length)) };
+        requestHeaders = new HttpHeader[] { new HttpHeader("Host", uri.getHost()),
+                new HttpHeader("Content-Length", Integer.toString(requestBody.getBytes(UTF8).length)) };
 
         HttpRequestBodyStream bodyStream = null;
 

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseFixture.java
@@ -4,17 +4,16 @@
  */
 package software.amazon.awssdk.crt.test;
 
-import static software.amazon.awssdk.crt.utils.ByteBufferUtils.transferData;
-
 import org.junit.Assert;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.http.Http2ClientConnection;
+import software.amazon.awssdk.crt.http.Http2Request;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.http.HttpRequest;
-import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
+import software.amazon.awssdk.crt.http.HttpRequestBase;
 import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
 import software.amazon.awssdk.crt.http.HttpStream;
 import software.amazon.awssdk.crt.http.Http2Stream;
@@ -74,40 +73,6 @@ public class HttpRequestResponseFixture extends HttpClientTestFixture {
         return false;
     }
 
-    protected HttpRequest getHttpRequest(String method, String endpoint, String path, String requestBody)
-            throws Exception {
-        URI uri = new URI(endpoint);
-
-        HttpHeader[] requestHeaders = null;
-
-        /* TODO: Http2 headers and request */
-        requestHeaders = new HttpHeader[] { new HttpHeader("Host", uri.getHost()),
-                new HttpHeader("Content-Length", Integer.toString(requestBody.getBytes(UTF8).length)) };
-
-        HttpRequestBodyStream bodyStream = null;
-
-        final ByteBuffer bodyBytesIn = ByteBuffer.wrap(requestBody.getBytes(UTF8));
-
-        bodyStream = new HttpRequestBodyStream() {
-            @Override
-            public boolean sendRequestBody(ByteBuffer bodyBytesOut) {
-                transferData(bodyBytesIn, bodyBytesOut);
-
-                return bodyBytesIn.remaining() == 0;
-            }
-
-            @Override
-            public boolean resetPosition() {
-                bodyBytesIn.position(0);
-
-                return true;
-            }
-        };
-
-        HttpRequest request = new HttpRequest(method, path, requestHeaders, bodyStream);
-        return request;
-    }
-
     public static String byteArrayToHex(byte[] input) {
         StringBuilder output = new StringBuilder(input.length * 2);
         for (byte b : input) {
@@ -122,7 +87,7 @@ public class HttpRequestResponseFixture extends HttpClientTestFixture {
         return byteArrayToHex(digest.digest());
     }
 
-    public TestHttpResponse getResponse(URI uri, HttpRequest request, byte[] chunkedData,
+    public TestHttpResponse getResponse(URI uri, HttpRequestBase request, byte[] chunkedData,
             HttpClientConnection.ProtocolVersion expectedVersion) throws Exception {
         boolean actuallyConnected = false;
 
@@ -168,11 +133,11 @@ public class HttpRequestResponseFixture extends HttpClientTestFixture {
                 };
                 if (expectedVersion == HttpClientConnection.ProtocolVersion.HTTP_2) {
                     try (Http2ClientConnection h2Connection = (Http2ClientConnection) conn) {
-                        Http2Stream h2Stream = h2Connection.makeRequest(request, streamHandler);
+                        Http2Stream h2Stream = h2Connection.makeRequest((Http2Request) request, streamHandler);
                         h2Stream.activate();
                     }
                 } else {
-                    HttpStream stream = conn.makeRequest(request, streamHandler);
+                    HttpStream stream = conn.makeRequest((HttpRequest) request, streamHandler);
                     stream.activate();
                     if (chunkedData != null) {
                         stream.writeChunk(chunkedData, true).get(5, TimeUnit.SECONDS);

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -184,11 +184,22 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
         /**
          * Example Json Response Body from httpbin.org:
          *
-         * { "args": {}, "data": "This is a sample to prove that http downloads and
-         * uploads work. It doesn't really matter what's in here, we mainly just need to
-         * verify the downloads and uploads work.", "files": {}, "form": {}, "headers":
-         * { "Content-Length": "166", "Host": "httpbin.org" }, "json": null, "method":
-         * "PUT", "origin": "1.2.3.4, 5.6.7.8", "url": "https://httpbin.org/anything" }
+         * {
+         *  "args": {},
+         *  "data": "This is a sample to prove that http downloads and
+         *   uploads work. It doesn't really matter what's in here, we mainly just need to
+         *   verify the downloads and uploads work.",
+         *  "files": {},
+         *  "form": {},
+         *  "headers": {
+         *      "Content-Length": "166",
+         *      "Host": "httpbin.org"
+         *  },
+         *  "json": null,
+         *  "method": "PUT",
+         *  "origin": "1.2.3.4, 5.6.7.8",
+         *  "url": "https://httpbin.org/anything"
+         * }
          *
          */
 

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -184,22 +184,11 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
         /**
          * Example Json Response Body from httpbin.org:
          *
-         * {
-         *  "args": {},
-         *  "data": "This is a sample to prove that http downloads and
-         *   uploads work. It doesn't really matter what's in here, we mainly just need to
-         *   verify the downloads and uploads work.",
-         *  "files": {},
-         *  "form": {},
-         *  "headers": {
-         *      "Content-Length": "166",
-         *      "Host": "httpbin.org"
-         *  },
-         *  "json": null,
-         *  "method": "PUT",
-         *  "origin": "1.2.3.4, 5.6.7.8",
-         *  "url": "https://httpbin.org/anything"
-         * }
+         * { "args": {}, "data": "This is a sample to prove that http downloads and
+         * uploads work. It doesn't really matter what's in here, we mainly just need to
+         * verify the downloads and uploads work.", "files": {}, "form": {}, "headers":
+         * { "Content-Length": "166", "Host": "httpbin.org" }, "json": null, "method":
+         * "PUT", "origin": "1.2.3.4, 5.6.7.8", "url": "https://httpbin.org/anything" }
          *
          */
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Basically bare minimal for http/2 request, user is responsible to make sure the requests are following the protocol requirement, otherwise, the other side will reject the request.
- Use http/2 request can help the request not going through the transform from http/1 request to http/2
- And HTTP/2 Request will **not apply** those auto fix we did for http/1 request, which like converting headers to lower case, and get host out, etc..
- Any suggestions around will be super appreciated, feeling bad about my OOD....

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
