### PR TITLE
Null and empty will and publish tests

### DIFF
--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -772,8 +772,8 @@ jshort JNICALL Java_software_amazon_awssdk_crt_mqtt_MqttClientConnection_mqttCli
         return 0;
     }
 
-    if (!jni_payload) {
-        aws_jni_throw_runtime_exception(env, "MqttClientConnection.mqtt_publish: Invalid/null payload");
+    if (!jni_topic) {
+        aws_jni_throw_runtime_exception(env, "MqttClientConnection.mqtt_publish: Invalid/null topic");
         return 0;
     }
 
@@ -784,7 +784,12 @@ jshort JNICALL Java_software_amazon_awssdk_crt_mqtt_MqttClientConnection_mqttCli
     }
 
     struct aws_byte_cursor topic = aws_jni_byte_cursor_from_jstring_acquire(env, jni_topic);
-    struct aws_byte_cursor payload = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_payload);
+
+    struct aws_byte_cursor payload;
+    AWS_ZERO_STRUCT(payload);
+    if (jni_payload != NULL) {
+        payload = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_payload);
+    }
 
     enum aws_mqtt_qos qos = jni_qos;
     bool retain = jni_retain != 0;
@@ -792,7 +797,10 @@ jshort JNICALL Java_software_amazon_awssdk_crt_mqtt_MqttClientConnection_mqttCli
     uint16_t msg_id = aws_mqtt_client_connection_publish(
         connection->client_connection, &topic, qos, retain, &payload, s_on_op_complete, pub_ack);
     aws_jni_byte_cursor_from_jstring_release(env, jni_topic, topic);
-    aws_jni_byte_cursor_from_jbyteArray_release(env, jni_payload, payload);
+
+    if (jni_payload != NULL) {
+        aws_jni_byte_cursor_from_jbyteArray_release(env, jni_payload, payload);
+    }
 
     if (msg_id == 0) {
         aws_jni_throw_runtime_exception(

--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -822,18 +822,31 @@ JNIEXPORT jboolean JNICALL Java_software_amazon_awssdk_crt_mqtt_MqttClientConnec
     struct mqtt_jni_connection *connection = (struct mqtt_jni_connection *)jni_connection;
     if (!connection) {
         aws_jni_throw_runtime_exception(env, "MqttClientConnection.mqtt_set_will: Invalid connection");
-        return 0;
+        return false;
     }
 
+    if (jni_topic == NULL) {
+        aws_jni_throw_runtime_exception(env, "MqttClientConnection.mqtt_set_will: Topic must be non-null");
+        return false;
+    }
     struct aws_byte_cursor topic = aws_jni_byte_cursor_from_jstring_acquire(env, jni_topic);
-    struct aws_byte_cursor payload = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_payload);
+
+    struct aws_byte_cursor payload;
+    AWS_ZERO_STRUCT(payload);
+    if (jni_payload != NULL) {
+        payload = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_payload);
+    }
 
     enum aws_mqtt_qos qos = jni_qos;
     bool retain = jni_retain != 0;
 
     int result = aws_mqtt_client_connection_set_will(connection->client_connection, &topic, qos, retain, &payload);
     aws_jni_byte_cursor_from_jstring_release(env, jni_topic, topic);
-    aws_jni_byte_cursor_from_jbyteArray_release(env, jni_payload, payload);
+
+    if (jni_payload != NULL) {
+        aws_jni_byte_cursor_from_jbyteArray_release(env, jni_payload, payload);
+    }
+
     return (result == AWS_OP_SUCCESS);
 }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
@@ -60,7 +60,11 @@ public class MqttClientConnectionFixture extends CrtTestFixture {
     String caRoot = null;
     String iotEndpoint = null;
 
-    protected void modifyConnectionConfiguration(MqttConnectionConfig config) {}
+    Consumer<MqttConnectionConfig> connectionConfigTransformer = null;
+
+    protected void setConnectionConfigTransformer(Consumer<MqttConnectionConfig> connectionConfigTransformer) {
+        this.connectionConfigTransformer = connectionConfigTransformer;
+    }
 
     private boolean findCredentials() {
         CrtTestContext ctx = getContext();
@@ -184,7 +188,9 @@ public class MqttClientConnectionFixture extends CrtTestFixture {
                 config.setKeepAliveSecs(keepAliveSecs);
                 config.setProtocolOperationTimeoutMs(protocolOperationTimeout);
 
-                modifyConnectionConfiguration(config);
+                if (connectionConfigTransformer != null) {
+                    connectionConfigTransformer.accept(config);
+                }
 
                 connection = new MqttClientConnection(config);
                 if (anyMessageHandler != null) {

--- a/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
@@ -5,17 +5,11 @@
 
 package software.amazon.awssdk.crt.test;
 
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
-import software.amazon.awssdk.crt.CrtResource;
-import software.amazon.awssdk.crt.mqtt.MqttConnectionConfig;
-import software.amazon.awssdk.crt.mqtt.MqttException;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
-
-import static org.junit.Assert.fail;
 
 public class WillTest extends MqttClientConnectionFixture {
     @Rule
@@ -27,17 +21,36 @@ public class WillTest extends MqttClientConnectionFixture {
 
     static final String TEST_TOPIC = "/i/am/ded";
     static final String TEST_WILL = "i am ghost nao";
-
-    @Override
-    protected void modifyConnectionConfiguration(MqttConnectionConfig config) {
-        MqttMessage will = new MqttMessage(TEST_TOPIC, TEST_WILL.getBytes(), QualityOfService.AT_LEAST_ONCE);
-
-        config.setWillMessage(will);
-    }
+    static final String TEST_EMPTY_WILL = "";
 
     @Test
     public void testWill() {
         skipIfNetworkUnavailable();
+        setConnectionConfigTransformer((config) -> {
+            config.setWillMessage(new MqttMessage(TEST_TOPIC, TEST_WILL.getBytes(), QualityOfService.AT_LEAST_ONCE));
+        });
+        connect();
+        disconnect();
+        close();
+    }
+
+    @Test
+    public void testEmptyWill() {
+        skipIfNetworkUnavailable();
+        setConnectionConfigTransformer((config) -> {
+            config.setWillMessage(new MqttMessage(TEST_TOPIC, TEST_EMPTY_WILL.getBytes(), QualityOfService.AT_LEAST_ONCE));
+        });
+        connect();
+        disconnect();
+        close();
+    }
+
+    @Test
+    public void testNullWill() {
+        skipIfNetworkUnavailable();
+        setConnectionConfigTransformer((config) -> {
+            config.setWillMessage(new MqttMessage(TEST_TOPIC, null, QualityOfService.AT_LEAST_ONCE));
+        });
         connect();
         disconnect();
         close();


### PR DESCRIPTION
* Update mqtt publish and set will to allow both empty and null payloads.
* Add tests for empty and null will payloads
* Change mqtt publish test to a full round trip, not just a check of the ack.
* Add null and empty payload publish tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
