### PR TITLE
fix marshall request with utf8 path

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/http/HttpRequest.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpRequest.java
@@ -165,7 +165,9 @@ public class HttpRequest {
     public byte[] marshalForJni() {
         int size = 0;
         size += BUFFER_INT_SIZE + method.length();
-        size += BUFFER_INT_SIZE + encodedPath.length();
+
+        byte[] pathBytes = encodedPath.getBytes(UTF8);
+        size += BUFFER_INT_SIZE + pathBytes.length;
     
         for (HttpHeader header : headers) {
             if (header.getNameBytes().length > 0) {
@@ -176,8 +178,8 @@ public class HttpRequest {
         ByteBuffer buffer = ByteBuffer.allocate(size);
         buffer.putInt(method.length());
         buffer.put(method.getBytes(UTF8));
-        buffer.putInt(encodedPath.length());
-        buffer.put(encodedPath.getBytes(UTF8));
+        buffer.putInt(pathBytes.length);
+        buffer.put(pathBytes);
     
         for (HttpHeader header : headers) {
             if (header.getNameBytes().length > 0) {

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -8,7 +8,6 @@ package software.amazon.awssdk.crt.test;
 import static software.amazon.awssdk.crt.utils.ByteBufferUtils.transferData;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtResource;
@@ -25,7 +24,6 @@ import software.amazon.awssdk.crt.io.EventLoopGroup;
 import software.amazon.awssdk.crt.io.HostResolver;
 import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsContext;
-import software.amazon.awssdk.crt.io.TlsContextOptions;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -445,4 +443,9 @@ public class HttpRequestResponseTest extends HttpClientTestFixture {
         CrtResource.waitForNoResources();
     }
 
+    @Test
+    public void testMarshallJniUtf8Path() throws Exception {
+        HttpRequest request = new HttpRequest("GET", "/?ሴ=bar");
+        request.marshalForJni();
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`marshallRequestForJni` [uses](https://github.com/awslabs/aws-crt-java/blob/main/src/main/java/software/amazon/awssdk/crt/http/HttpRequest.java#L168) the string (character) length instead of the UTF-8 byte length when sizing the ByteBuffer to encode to. This fails with a buffer overflow exception when encoding a UTF8 path. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
