### PR TITLE
Sync the builder versions used by CI and CD

### DIFF
--- a/codebuild/cd/generic-unix-build.sh
+++ b/codebuild/cd/generic-unix-build.sh
@@ -21,7 +21,12 @@ if [[ "$AWS_CRT_TARGET" != "$AWS_CRT_HOST" ]]; then
     LIB_PATH=target/cmake-build/aws-crt-java/lib
 fi
 
-python3 -c "from urllib.request import urlretrieve; urlretrieve('https://d19elf31gohf1l.cloudfront.net/LATEST/builder.pyz?date=`date +%s`', 'builder')"
+# Pry the builder version this CRT is using out of ci.yml
+BUILDER_VERSION=$(cat .github/workflows/ci.yml | grep 'BUILDER_VERSION:' | sed 's/\s*BUILDER_VERSION:\s\(.*\)/\1/')
+echo "Using builder version ${BUILDER_VERSION}"
+
+aws s3 cp s3://aws-crt-builder/releases/${BUILDER_VERSION}/builder.pyz ./builder
+
 chmod a+x builder
 ./builder build -p aws-crt-java --target=$AWS_CRT_TARGET run_tests=false
 

--- a/codebuild/cd/generic-unix-build.sh
+++ b/codebuild/cd/generic-unix-build.sh
@@ -22,7 +22,7 @@ if [[ "$AWS_CRT_TARGET" != "$AWS_CRT_HOST" ]]; then
 fi
 
 # Pry the builder version this CRT is using out of ci.yml
-BUILDER_VERSION=$(cat .github/workflows/ci.yml | grep 'BUILDER_VERSION:' | sed 's/\s*BUILDER_VERSION:\s\(.*\)/\1/')
+BUILDER_VERSION=$(cat .github/workflows/ci.yml | grep 'BUILDER_VERSION:' | sed 's/\s*BUILDER_VERSION:\s*\(.*\)/\1/')
 echo "Using builder version ${BUILDER_VERSION}"
 
 aws s3 cp s3://aws-crt-builder/releases/${BUILDER_VERSION}/builder.pyz ./builder


### PR DESCRIPTION
arm linux CD was using a script that ended up pulling an ancient version of the builder, which is no longer going to work



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
