### PR TITLE
Update aws-c-s3 and add CopyObject to meta request enum

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
@@ -9,10 +9,38 @@ import java.util.Map;
 
 public class S3MetaRequestOptions {
 
+    /**
+     * A Meta Request represents a group of generated requests that are being done on behalf of the
+     * original request. For example, one large GetObject request can be transformed into a series
+     * of ranged GetObject requests that are executed in parallel to improve throughput.
+     *
+     * The MetaRequestType is a hint of transformation to be applied.
+     */
     public enum MetaRequestType {
+        /**
+         * The Default meta request type sends any request to S3 as-is (with no transformation). For example,
+         * it can be used to pass a CreateBucket request.
+         */
         DEFAULT(0),
+
+        /**
+         * The GetObject request will be split into a series of ranged GetObject requests that are
+         * executed in parallel to improve throughput, when possible.
+         */
         GET_OBJECT(1),
-        PUT_OBJECT(2);
+
+        /**
+         * The PutObject request will be split into MultiPart uploads that are executed in parallel
+         * to improve throughput, when possible.
+         */
+        PUT_OBJECT(2),
+
+        /**
+         * The CopyObject meta request performs a multi-part copy using multiple S3 UploadPartCopy requests
+         * in parallel, or bypasses a CopyObject request to S3 if the object size is not large enough for
+         * a multipart upload.
+         */
+        COPY_OBJECT(3);
 
         MetaRequestType(int nativeValue) {
             this.nativeValue = nativeValue;
@@ -36,6 +64,7 @@ public class S3MetaRequestOptions {
             enumMapping.put(DEFAULT.getNativeValue(), DEFAULT);
             enumMapping.put(GET_OBJECT.getNativeValue(), GET_OBJECT);
             enumMapping.put(PUT_OBJECT.getNativeValue(), PUT_OBJECT);
+            enumMapping.put(COPY_OBJECT.getNativeValue(), COPY_OBJECT);
             return enumMapping;
         }
 

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandler.java
@@ -3,14 +3,42 @@ package software.amazon.awssdk.crt.s3;
 import java.nio.ByteBuffer;
 import software.amazon.awssdk.crt.http.HttpHeader;
 
+/**
+ * Interface called by native code to provide S3MetaRequest responses.
+ */
 public interface S3MetaRequestResponseHandler {
+
+    /**
+     * Invoked to provide response headers received during execution of the meta request, both for
+     * success and error HTTP status codes.
+     *
+     * @param statusCode statusCode of the HTTP response
+     * @param headers the headers received
+     */
     default void onResponseHeaders(final int statusCode, final HttpHeader[] headers) {
     }
 
+    /**
+     * Invoked to provide the request body as it is received.
+     *
+     * @param bodyBytesIn The body data for this chunk of the object
+     * @param objectRangeStart The byte index of the object that this refers to. For example, for an HTTP message that
+     *  has a range header, the first chunk received will have a range_start that matches the range header's range-start
+     * @param objectRangeEnd corresponds to the past-of-end chunk offset, i.e. objectRangeStart + the chunk length
+     * @return The number of bytes to move the sliding window by. Repeatedly returning zero will eventually cause the
+     * sliding window to fill up and data to stop flowing until the user slides the window back open.
+     */
     default int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
         return 0;
     }
 
+    /**
+     * Invoked when the entire meta request execution is complete.
+     *
+     * @param errorCode The CRT error code
+     * @param responseStatus statusCode of the HTTP response
+     * @param errorPayload body of the error response
+     */
     default void onFinished(int errorCode, int responseStatus, byte[] errorPayload) {
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandler.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandler.java
@@ -37,7 +37,7 @@ public interface S3MetaRequestResponseHandler {
      *
      * @param errorCode The CRT error code
      * @param responseStatus statusCode of the HTTP response
-     * @param errorPayload body of the error response
+     * @param errorPayload body of the error response. Can be null if the request completed successfully
      */
     default void onFinished(int errorCode, int responseStatus, byte[] errorPayload) {
     }


### PR DESCRIPTION
* aws-c-s3 submodule updated to v0.1.31
* add CopyObject meta request type to enum
* added javadoc

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
