### PR TITLE
Release v0.15.15

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/http/HttpRequest.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpRequest.java
@@ -113,6 +113,14 @@ public class HttpRequest {
     }
 
     /**
+     * Replaces the instance headers with the passed headers
+     * @param headers the new headers to assign
+     */
+    public void setHeaders(List<HttpHeader> headers) {
+        this.headers = headers;
+    }
+
+    /**
      * @return An array of the headers for this request
      */
     public HttpHeader[] getHeadersAsArray() {

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
@@ -20,7 +20,6 @@ public class S3ClientOptions {
     private long partSize;
     private double throughputTargetGbps;
     private int maxConnections;
-    private boolean tlsEnabled = true;
     /**
      * For multi-part upload, content-md5 will be calculated if the
      * computeContentMd5 is set to true.
@@ -126,14 +125,5 @@ public class S3ClientOptions {
 
     public StandardRetryOptions getStandardRetryOptions() {
         return this.standardRetryOptions;
-    }
-
-    public S3ClientOptions withTlsEnabled(boolean tlsEnabled) {
-        this.tlsEnabled = tlsEnabled;
-        return this;
-    }
-
-    public Boolean getTlsEnabled() {
-        return this.tlsEnabled;
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
@@ -20,6 +20,7 @@ public class S3ClientOptions {
     private long partSize;
     private double throughputTargetGbps;
     private int maxConnections;
+    private boolean tlsEnabled = true;
     /**
      * For multi-part upload, content-md5 will be calculated if the
      * computeContentMd5 is set to true.
@@ -125,5 +126,14 @@ public class S3ClientOptions {
 
     public StandardRetryOptions getStandardRetryOptions() {
         return this.standardRetryOptions;
+    }
+
+    public S3ClientOptions withTlsEnabled(boolean tlsEnabled) {
+        this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public Boolean getTlsEnabled() {
+        return this.tlsEnabled;
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.crt.http.HttpRequest;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.auth.credentials.CredentialsProvider;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,6 +49,7 @@ public class S3MetaRequestOptions {
     private HttpRequest httpRequest;
     private S3MetaRequestResponseHandler responseHandler;
     private CredentialsProvider credentialsProvider;
+    private URI uri;
 
     public S3MetaRequestOptions withMetaRequestType(MetaRequestType metaRequestType) {
         this.metaRequestType = metaRequestType;
@@ -85,4 +87,12 @@ public class S3MetaRequestOptions {
         return credentialsProvider;
     }
 
+    public S3MetaRequestOptions withURI(URI uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    public URI getURI() {
+        return uri;
+    }
 }

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -50,7 +50,6 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientNew(
     jbyteArray jni_endpoint,
     jlong jni_client_bootstrap,
     jlong jni_tls_ctx,
-    jboolean use_tls,
     jlong jni_credentials_provider,
     jlong part_size,
     jdouble throughput_target_gbps,
@@ -126,8 +125,6 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientNew(
         .region = region,
         .client_bootstrap = client_bootstrap,
         .tls_connection_options = tls_options,
-        // TODO WHETHER TLS IS INITAILIZED OR NOT DOESNT FORCE/PREVENT TLS LATER SO REMOVE?
-        .tls_mode = use_tls ? AWS_MR_TLS_ENABLED : AWS_MR_TLS_DISABLED,
         .signing_config = &signing_config,
         .part_size = (size_t)part_size,
         .throughput_target_gbps = throughput_target_gbps,
@@ -394,7 +391,7 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientMake
         .body_callback = s_on_s3_meta_request_body_callback,
         .finish_callback = s_on_s3_meta_request_finish_callback,
         .shutdown_callback = s_on_s3_meta_request_shutdown_complete_callback,
-        .use_tls = use_tls ? true : false,
+        .tls_mode = use_tls ? AWS_MR_TLS_ENABLED : AWS_MR_TLS_DISABLED,
         .port = port};
 
     struct aws_s3_meta_request *meta_request = aws_s3_client_make_meta_request(client, &meta_request_options);

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -50,6 +50,7 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientNew(
     jbyteArray jni_endpoint,
     jlong jni_client_bootstrap,
     jlong jni_tls_ctx,
+    jboolean use_tls,
     jlong jni_credentials_provider,
     jlong part_size,
     jdouble throughput_target_gbps,
@@ -125,6 +126,8 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientNew(
         .region = region,
         .client_bootstrap = client_bootstrap,
         .tls_connection_options = tls_options,
+        // TODO WHETHER TLS IS INITAILIZED OR NOT DOESNT FORCE/PREVENT TLS LATER SO REMOVE?
+        .tls_mode = use_tls ? AWS_MR_TLS_ENABLED : AWS_MR_TLS_DISABLED,
         .signing_config = &signing_config,
         .part_size = (size_t)part_size,
         .throughput_target_gbps = throughput_target_gbps,
@@ -344,7 +347,9 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientMake
     jbyteArray jni_marshalled_message_data,
     jobject jni_http_request_body_stream,
     jlong jni_credentials_provider,
-    jobject java_response_handler_jobject) {
+    jobject java_response_handler_jobject,
+    jboolean use_tls,
+    int port) {
     (void)jni_class;
 
     struct aws_allocator *allocator = aws_jni_get_allocator();
@@ -388,7 +393,9 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientMake
         .headers_callback = s_on_s3_meta_request_headers_callback,
         .body_callback = s_on_s3_meta_request_body_callback,
         .finish_callback = s_on_s3_meta_request_finish_callback,
-        .shutdown_callback = s_on_s3_meta_request_shutdown_complete_callback};
+        .shutdown_callback = s_on_s3_meta_request_shutdown_complete_callback,
+        .use_tls = use_tls ? true : false,
+        .port = port};
 
     struct aws_s3_meta_request *meta_request = aws_s3_client_make_meta_request(client, &meta_request_options);
 

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.crt.utils.ByteBufferUtils;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -31,11 +32,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
 
 public class S3ClientTest extends CrtTestFixture {
 
-    static final String ENDPOINT = "aws-crt-test-stuff-us-west-2.s3.us-west-2.amazonaws.com";
-    static final String REGION = "us-west-2";
+    static final String ENDPOINT = "localhost";
+    static final String REGION = "us-east-1";
 
     public S3ClientTest() {
     }
@@ -121,11 +123,11 @@ public class S3ClientTest extends CrtTestFixture {
     }
 
     @Test
-    public void testS3Get() {
+    public void testS3GetWithURI() {
         skipIfNetworkUnavailable();
         Assume.assumeTrue(hasAwsCredentials());
 
-        S3ClientOptions clientOptions = new S3ClientOptions().withEndpoint(ENDPOINT).withRegion(REGION);
+        S3ClientOptions clientOptions = new S3ClientOptions().withEndpoint("INVALID").withRegion(REGION).withTlsEnabled(true);
         try (S3Client client = createS3Client(clientOptions)) {
             CompletableFuture<Integer> onFinishedFuture = new CompletableFuture<>();
             S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
@@ -151,19 +153,70 @@ public class S3ClientTest extends CrtTestFixture {
                 }
             };
 
-            HttpHeader[] headers = { new HttpHeader("Host", ENDPOINT) };
+            HttpHeader[] headers = { new HttpHeader("Host", "INVALID") };
             HttpRequest httpRequest = new HttpRequest("GET", "/get_object_test_1MB.txt", headers, null);
 
             S3MetaRequestOptions metaRequestOptions = new S3MetaRequestOptions()
                     .withMetaRequestType(MetaRequestType.GET_OBJECT).withHttpRequest(httpRequest)
-                    .withResponseHandler(responseHandler);
+                    .withResponseHandler(responseHandler)
+                    .withURI(URI.create("http://" + ENDPOINT + ":80"));
 
             try (S3MetaRequest metaRequest = client.makeMetaRequest(metaRequestOptions)) {
                 Assert.assertEquals(Integer.valueOf(0), onFinishedFuture.get());
             }
-        } catch (InterruptedException | ExecutionException ex) {
+        } catch (Exception ex /*InterruptedException | ExecutionException ex*/) {
             Assert.fail(ex.getMessage());
         }
+
+    }
+
+    @Test
+    public void testS3Get() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(hasAwsCredentials());
+
+        S3ClientOptions clientOptions = new S3ClientOptions().withEndpoint(ENDPOINT).withRegion(REGION);
+        Stream.of(Boolean.TRUE, Boolean.FALSE).forEach(tlsYN -> {
+            clientOptions.withTlsEnabled(tlsYN);
+            try (S3Client client = createS3Client(clientOptions)) {
+                CompletableFuture<Integer> onFinishedFuture = new CompletableFuture<>();
+                S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
+
+                    @Override
+                    public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+                        byte[] bytes = new byte[bodyBytesIn.remaining()];
+                        bodyBytesIn.get(bytes);
+                        Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3, "Body Response: " + Arrays.toString(bytes));
+                        return 0;
+                    }
+
+                    @Override
+                    public void onFinished(int errorCode, int responseStatus, byte[] errorPayload) {
+                        Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3,
+                                "Meta request finished with error code " + errorCode);
+                        if (errorCode != 0) {
+                            onFinishedFuture.completeExceptionally(
+                                    new CrtS3RuntimeException(errorCode, responseStatus, errorPayload));
+                            return;
+                        }
+                        onFinishedFuture.complete(Integer.valueOf(errorCode));
+                    }
+                };
+
+                HttpHeader[] headers = { new HttpHeader("Host", ENDPOINT) };
+                HttpRequest httpRequest = new HttpRequest("GET", "/get_object_test_1MB.txt", headers, null);
+
+                S3MetaRequestOptions metaRequestOptions = new S3MetaRequestOptions()
+                        .withMetaRequestType(MetaRequestType.GET_OBJECT).withHttpRequest(httpRequest)
+                        .withResponseHandler(responseHandler);
+
+                try (S3MetaRequest metaRequest = client.makeMetaRequest(metaRequestOptions)) {
+                    Assert.assertEquals(Integer.valueOf(0), onFinishedFuture.get());
+                }
+            } catch (InterruptedException | ExecutionException ex) {
+                Assert.fail(ex.getMessage());
+            }
+        });
     }
 
     @Test
@@ -241,62 +294,65 @@ public class S3ClientTest extends CrtTestFixture {
         Assume.assumeTrue(hasAwsCredentials());
 
         S3ClientOptions clientOptions = new S3ClientOptions().withEndpoint(ENDPOINT).withRegion(REGION);
-        try (S3Client client = createS3Client(clientOptions)) {
-            CompletableFuture<Integer> onFinishedFuture = new CompletableFuture<>();
-            S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
+        Stream.of(Boolean.TRUE, Boolean.FALSE).forEach(tlsYN -> {
+            clientOptions.withTlsEnabled(tlsYN);
+            try (S3Client client = createS3Client(clientOptions)) {
+                CompletableFuture<Integer> onFinishedFuture = new CompletableFuture<>();
+                S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
 
-                @Override
-                public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
-                    Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3, "Body Response: " + bodyBytesIn.toString());
-                    return 0;
-                }
-
-                @Override
-                public void onFinished(int errorCode, int responseStatus, byte[] errorPayload) {
-                    Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3,
-                            "Meta request finished with error code " + errorCode);
-                    if (errorCode != 0) {
-                        onFinishedFuture.completeExceptionally(
-                                new CrtS3RuntimeException(errorCode, responseStatus, errorPayload));
-                        return;
+                    @Override
+                    public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
+                        Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3, "Body Response: " + bodyBytesIn.toString());
+                        return 0;
                     }
-                    onFinishedFuture.complete(Integer.valueOf(errorCode));
+
+                    @Override
+                    public void onFinished(int errorCode, int responseStatus, byte[] errorPayload) {
+                        Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3,
+                                "Meta request finished with error code " + errorCode);
+                        if (errorCode != 0) {
+                            onFinishedFuture.completeExceptionally(
+                                    new CrtS3RuntimeException(errorCode, responseStatus, errorPayload));
+                            return;
+                        }
+                        onFinishedFuture.complete(Integer.valueOf(errorCode));
+                    }
+                };
+
+                final ByteBuffer payload = ByteBuffer.wrap(createTestPayload());
+                HttpRequestBodyStream payloadStream = new HttpRequestBodyStream() {
+                    @Override
+                    public boolean sendRequestBody(ByteBuffer outBuffer) {
+                        ByteBufferUtils.transferData(payload, outBuffer);
+                        return payload.remaining() == 0;
+                    }
+
+                    @Override
+                    public boolean resetPosition() {
+                        return true;
+                    }
+
+                    @Override
+                    public long getLength() {
+                        return payload.capacity();
+                    }
+                };
+
+                HttpHeader[] headers = {new HttpHeader("Host", ENDPOINT),
+                        new HttpHeader("Content-Length", Integer.valueOf(payload.capacity()).toString()),};
+                HttpRequest httpRequest = new HttpRequest("PUT", "/put_object_test_1MB" + tlsYN + ".txt", headers, payloadStream);
+
+                S3MetaRequestOptions metaRequestOptions = new S3MetaRequestOptions()
+                        .withMetaRequestType(MetaRequestType.PUT_OBJECT).withHttpRequest(httpRequest)
+                        .withResponseHandler(responseHandler);
+
+                try (S3MetaRequest metaRequest = client.makeMetaRequest(metaRequestOptions)) {
+                    Assert.assertEquals(Integer.valueOf(0), onFinishedFuture.get());
                 }
-            };
-
-            final ByteBuffer payload = ByteBuffer.wrap(createTestPayload());
-            HttpRequestBodyStream payloadStream = new HttpRequestBodyStream() {
-                @Override
-                public boolean sendRequestBody(ByteBuffer outBuffer) {
-                    ByteBufferUtils.transferData(payload, outBuffer);
-                    return payload.remaining() == 0;
-                }
-
-                @Override
-                public boolean resetPosition() {
-                    return true;
-                }
-
-                @Override
-                public long getLength() {
-                    return payload.capacity();
-                }
-            };
-
-            HttpHeader[] headers = { new HttpHeader("Host", ENDPOINT),
-                    new HttpHeader("Content-Length", Integer.valueOf(payload.capacity()).toString()), };
-            HttpRequest httpRequest = new HttpRequest("PUT", "/put_object_test_1MB.txt", headers, payloadStream);
-
-            S3MetaRequestOptions metaRequestOptions = new S3MetaRequestOptions()
-                    .withMetaRequestType(MetaRequestType.PUT_OBJECT).withHttpRequest(httpRequest)
-                    .withResponseHandler(responseHandler);
-
-            try (S3MetaRequest metaRequest = client.makeMetaRequest(metaRequestOptions)) {
-                Assert.assertEquals(Integer.valueOf(0), onFinishedFuture.get());
+            } catch (InterruptedException | ExecutionException ex) {
+                Assert.fail(ex.getMessage());
             }
-        } catch (InterruptedException | ExecutionException ex) {
-            Assert.fail(ex.getMessage());
-        }
+        });
     }
 
     static class TransferStats {


### PR DESCRIPTION
This PR addresses the following two issues:

1. https://github.com/awslabs/aws-crt-java/issues/431
2. https://github.com/awslabs/aws-crt-java/issues/432

This PR supports the ability to perform S3 get and put operations over HTTP as well as HTTPS, *and* with custom ports. This PR depends on changes made to the aws-c-s3 repo. Those changes are at my fork here: https://github.com/aceeric/aws-c-s3/tree/release-v0.1.30

I wasn't sure the best way to submit this PR with the submodule dependency so I'm starting this way for now.

The approach in this PR adds a URI into the `S3MetaRequestOptions` class. This field is evaluated by the `S3Client.makeMetaRequest` method, and propagated to the JNI and C layers below where it influences how the connection is created. I left the default behavior for the `S3Client` in which a TLS context is always created for the client - either explicitly by the caller - or implicitly by the CRT. In the meta request though - if the URI is "http" then that TLS Context is simply excluded in the call to `aws_s3_client_make_meta_request`.

I considered two alternate approaches, but elected to submit this one. The alternate approaches were:

1) Accept a port and scheme in the `S3MetaRequestOptions` class. Reason: The URI field is somewhat redundant with the `HttpRequest` host header. However, splitting out the scheme and port individually makes the `S3MetaRequestOptions` class a little busier
2) Modify the CRT `HttpRequest` to look more like the AWS SDK `SdkHttpRequest` class, which accepts protocol, host, and port. But that change would have a huge footprint on the CRT

In the end - I went with this approach as a starter. I also modified the `S3ClientTest` class to accept region and endpoint as env vars to support my testing. I elected to make these changes to the latest tagged release. So I realize I'm a little behind. If you accept this PR I can rebase on the latest of this and the submodule and re-submit.