### PR TITLE
Fix signing failure not popping up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,12 @@
                         <endpoint>${crt.test.endpoint}</endpoint>
                         <rootca>${crt.test.rootca}</rootca>
                     </systemPropertyVariables>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>software.amazon.awssdk.crt.test.FailFastListener</value>
+                        </property>
+                    </properties>
                     <shutdown>kill</shutdown>
                     <argLine>-Daws.crt.memory.tracing=2 -Xcheck:jni</argLine>
                     <runOrder>alphabetical</runOrder>

--- a/src/native/aws_signing.c
+++ b/src/native/aws_signing.c
@@ -413,6 +413,7 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
             (struct aws_signing_config_base *)&signing_config,
             s_aws_request_signing_complete,
             callback_data)) {
+        AWS_LOGF_DEBUG(AWS_LS_HTTP_CONNECTION_MANAGER, "sign failed");
         aws_jni_throw_runtime_exception(env, "Failed to initiate signing process for HttpRequest");
         goto on_error;
     }
@@ -422,8 +423,6 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
 on_error:
 
     s_cleanup_callback_data(callback_data);
-
-    (*env)->ExceptionClear(env);
 }
 
 JNIEXPORT
@@ -499,8 +498,6 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
 on_error:
 
     s_cleanup_callback_data(callback_data);
-
-    (*env)->ExceptionClear(env);
 }
 
 JNIEXPORT
@@ -566,8 +563,6 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
 on_error:
 
     s_cleanup_callback_data(callback_data);
-
-    (*env)->ExceptionClear(env);
 }
 
 JNIEXPORT

--- a/src/native/aws_signing.c
+++ b/src/native/aws_signing.c
@@ -413,7 +413,6 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_signing_AwsSigner_awsSignerSig
             (struct aws_signing_config_base *)&signing_config,
             s_aws_request_signing_complete,
             callback_data)) {
-        AWS_LOGF_DEBUG(AWS_LS_HTTP_CONNECTION_MANAGER, "sign failed");
         aws_jni_throw_runtime_exception(env, "Failed to initiate signing process for HttpRequest");
         goto on_error;
     }

--- a/src/native/credentials_provider.c
+++ b/src/native/credentials_provider.c
@@ -645,6 +645,17 @@ struct aws_credentials_provider_get_credentials_callback_data {
     jobject java_credentials_future;
 };
 
+static void s_callback_data_clean_up(struct aws_credentials_provider_get_credentials_callback_data *callback_data) {
+    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    (*env)->DeleteGlobalRef(env, callback_data->java_crt_credentials_provider);
+    (*env)->DeleteGlobalRef(env, callback_data->java_credentials_future);
+
+    aws_credentials_provider_release(callback_data->provider);
+
+    // We're done with this callback data, free it.
+    aws_mem_release(aws_jni_get_allocator(), callback_data);
+}
+
 static void s_on_get_credentials_callback(struct aws_credentials *credentials, int error_code, void *user_data) {
     (void)error_code;
 
@@ -699,14 +710,7 @@ static void s_on_get_credentials_callback(struct aws_credentials *credentials, i
         }
         (*env)->DeleteLocalRef(env, java_credentials);
     }
-
-    (*env)->DeleteGlobalRef(env, callback_data->java_crt_credentials_provider);
-    (*env)->DeleteGlobalRef(env, callback_data->java_credentials_future);
-
-    aws_credentials_provider_release(callback_data->provider);
-
-    // We're done with this callback data, free it.
-    aws_mem_release(aws_jni_get_allocator(), callback_data);
+    s_callback_data_clean_up(callback_data);
 }
 
 JNIEXPORT
@@ -744,7 +748,8 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_credentials_CredentialsProvide
 
     if (aws_credentials_provider_get_credentials(provider, s_on_get_credentials_callback, callback_data)) {
         aws_jni_throw_runtime_exception(env, "CrtCredentialsProvider.credentialsProviderGetCredentials: call failure");
-        aws_credentials_provider_release(provider);
+        /* callback will not be invoked on failure, clean up the resource here. */
+        s_callback_data_clean_up(callback_data);
     }
 }
 

--- a/src/native/credentials_provider.c
+++ b/src/native/credentials_provider.c
@@ -530,6 +530,7 @@ static int s_credentials_provider_delegate_get_credentials(
         callback_data->jni_delegate_credential_handler,
         credentials_handler_properties.on_handler_get_credentials_method_id);
     if (aws_jni_check_and_clear_exception(env)) {
+        aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
         goto fetch_credentials_failed;
     }
 

--- a/src/native/credentials_provider.c
+++ b/src/native/credentials_provider.c
@@ -645,7 +645,7 @@ struct aws_credentials_provider_get_credentials_callback_data {
     jobject java_credentials_future;
 };
 
-static void s_callback_data_clean_up(struct aws_credentials_provider_get_credentials_callback_data *callback_data) {
+static void s_cp_callback_data_clean_up(struct aws_credentials_provider_get_credentials_callback_data *callback_data) {
     JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
     (*env)->DeleteGlobalRef(env, callback_data->java_crt_credentials_provider);
     (*env)->DeleteGlobalRef(env, callback_data->java_credentials_future);
@@ -710,7 +710,7 @@ static void s_on_get_credentials_callback(struct aws_credentials *credentials, i
         }
         (*env)->DeleteLocalRef(env, java_credentials);
     }
-    s_callback_data_clean_up(callback_data);
+    s_cp_callback_data_clean_up(callback_data);
 }
 
 JNIEXPORT
@@ -749,7 +749,7 @@ void JNICALL Java_software_amazon_awssdk_crt_auth_credentials_CredentialsProvide
     if (aws_credentials_provider_get_credentials(provider, s_on_get_credentials_callback, callback_data)) {
         aws_jni_throw_runtime_exception(env, "CrtCredentialsProvider.credentialsProviderGetCredentials: call failure");
         /* callback will not be invoked on failure, clean up the resource here. */
-        s_callback_data_clean_up(callback_data);
+        s_cp_callback_data_clean_up(callback_data);
     }
 }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/CredentialsProviderTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CredentialsProviderTest.java
@@ -7,7 +7,6 @@ package software.amazon.awssdk.crt.test;
 
 import com.sun.net.httpserver.HttpServer;
 
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/software/amazon/awssdk/crt/test/CredentialsProviderTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CredentialsProviderTest.java
@@ -6,6 +6,8 @@
 package software.amazon.awssdk.crt.test;
 
 import com.sun.net.httpserver.HttpServer;
+
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -70,8 +72,8 @@ public class CredentialsProviderTest extends CrtTestFixture {
     public void testCreateDestroyDefaultChain() {
         skipIfNetworkUnavailable();
         try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
-             HostResolver resolver = new HostResolver(eventLoopGroup);
-             ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver)) {
+                HostResolver resolver = new HostResolver(eventLoopGroup);
+                ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver)) {
             DefaultChainCredentialsProvider.DefaultChainCredentialsProviderBuilder builder = new DefaultChainCredentialsProvider.DefaultChainCredentialsProviderBuilder();
             builder.withClientBootstrap(bootstrap);
 
@@ -88,8 +90,8 @@ public class CredentialsProviderTest extends CrtTestFixture {
     public void testGetCredentialsDefaultChain() {
         skipIfNetworkUnavailable();
         try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
-             HostResolver resolver = new HostResolver(eventLoopGroup);
-             ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver)) {
+                HostResolver resolver = new HostResolver(eventLoopGroup);
+                ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver)) {
             DefaultChainCredentialsProvider.DefaultChainCredentialsProviderBuilder builder = new DefaultChainCredentialsProvider.DefaultChainCredentialsProviderBuilder();
             builder.withClientBootstrap(bootstrap);
 
@@ -176,6 +178,29 @@ public class CredentialsProviderTest extends CrtTestFixture {
     }
 
     @Test
+    public void testDelegateException() {
+        DelegateCredentialsProvider.DelegateCredentialsProviderBuilder builder = new DelegateCredentialsProvider.DelegateCredentialsProviderBuilder();
+        DelegateCredentialsHandler credentialsHandler = new DelegateCredentialsHandler() {
+            @Override
+            public Credentials getCredentials() {
+                throw new RuntimeException("hate coding");
+            }
+        };
+        boolean failed = false;
+        builder.withHandler(credentialsHandler);
+        try (DelegateCredentialsProvider provider = builder.build()) {
+            CompletableFuture<Credentials> future = provider.getCredentials();
+            Credentials credentials = future.get();
+            assertTrue(Arrays.equals(credentials.getAccessKeyId(), ACCESS_KEY_ID.getBytes()));
+            assertTrue(Arrays.equals(credentials.getSecretAccessKey(), SECRET_ACCESS_KEY.getBytes()));
+            assertTrue(Arrays.equals(credentials.getSessionToken(), null));
+        } catch (Exception ex) {
+            failed = true;
+        }
+        assertTrue(failed);
+    }
+
+    @Test
     public void testCreateDestroyProfile_ValidCreds() throws IOException {
         Path confPath = Files.createTempFile("testCreateDestroyProfile_ValidProfile_conf_", "");
         Path credsPath = Files.createTempFile("testCreateDestroyProfile_ValidProfile_creds_", "");
@@ -247,10 +272,11 @@ public class CredentialsProviderTest extends CrtTestFixture {
         }
     }
 
-
-    @Ignore // Enable this test if/when https://github.com/awslabs/aws-c-auth/issues/142 has been resolved
+    @Ignore // Enable this test if/when https://github.com/awslabs/aws-c-auth/issues/142 has
+            // been resolved
     @Test
-    public void testCreateDestroyEcs_ValidCreds() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    public void testCreateDestroyEcs_ValidCreds()
+            throws IOException, ExecutionException, InterruptedException, TimeoutException {
         skipIfNetworkUnavailable();
 
         HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
@@ -324,7 +350,6 @@ public class CredentialsProviderTest extends CrtTestFixture {
                         .withTlsContext(tlsCtx)
                         .build()) {
 
-
             fail("Expected StsWebIdentityCredentialsProvider construction to fail due to missing config state.");
         } catch (CrtRuntimeException e) {
             // Check that the right exception type caused the completion error in the future
@@ -339,8 +364,7 @@ public class CredentialsProviderTest extends CrtTestFixture {
                 EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
                 HostResolver resolver = new HostResolver(eventLoopGroup);
                 ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver);
-                StaticCredentialsProvider staticCP = new StaticCredentialsProvider
-                        .StaticCredentialsProviderBuilder()
+                StaticCredentialsProvider staticCP = new StaticCredentialsProvider.StaticCredentialsProviderBuilder()
                         .withAccessKeyId(ACCESS_KEY_ID.getBytes())
                         .withSecretAccessKey(SECRET_ACCESS_KEY.getBytes())
                         .withSessionToken(SESSION_TOKEN.getBytes())

--- a/src/test/java/software/amazon/awssdk/crt/test/FailFastListener.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/FailFastListener.java
@@ -1,0 +1,11 @@
+package software.amazon.awssdk.crt.test;
+
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+public class FailFastListener extends RunListener {
+    public void testFailure(Failure failure) throws Exception {
+        System.err.println("FAILURE: " + failure);
+        System.exit(-1);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

- We clear the exception raised at the end of the signing functions, which will cover the failure and causing the signing to hang forever.
- When delegate credential provider failed to get the credential, memory leak will happen.
- We need to stop the test if one of them failed to make it easier to allocate the failure test.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
