### PR TITLE
Support mutual TLS using certificate in a Windows cert store

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -89,6 +89,7 @@ public final class TlsContextOptions extends CrtResource {
     private String pkcs12Path;
     private String pkcs12Password;
     private TlsContextPkcs11Options pkcs11Options;
+    private String windowsCertStorePath;
 
     /**
      * Creates a new set of options that can be used to create a {@link TlsContext}
@@ -118,7 +119,8 @@ public final class TlsContextOptions extends CrtResource {
                 verifyPeer,
                 pkcs12Path,
                 pkcs12Password,
-                pkcs11Options
+                pkcs11Options,
+                windowsCertStorePath
             ));
         }
         return super.getNativeHandle();
@@ -319,6 +321,23 @@ public final class TlsContextOptions extends CrtResource {
         return options;
     }
 
+    /**
+     * Windows platforms only - Helper which creates mTLS options using a
+     * certificate in a Windows certificate store.
+     *
+     * @param certificatePath Path to certificate in a Windows certificate store.
+     *                        The path must use backslashes and end with the
+     *                        certificate's thumbprint. Example:
+     *                        {@code CurrentUser\MY\A11F8A9B5DF5B98BA3508FBCA575D09570E0D2C6}
+     * @return A set of options for setting up an mTLS connection
+     */
+    public static TlsContextOptions createWithMtlsWindowsCertStorePath(String certificatePath) {
+        TlsContextOptions options = new TlsContextOptions();
+        options.withMtlsWindowsCertStorePath(certificatePath);
+        options.verifyPeer = true;
+        return options;
+    }
+
     /*******************************************************************************
      * .with() methods
      ******************************************************************************/
@@ -423,6 +442,21 @@ public final class TlsContextOptions extends CrtResource {
     }
 
     /**
+     * Windows platforms only, specifies mTLS using a certificate in a Windows
+     * certificate store.
+     *
+     * @param certificatePath Path to certificate in a Windows certificate store.
+     *                        The path must use backslashes and end with the
+     *                        certificate's thumbprint. Example:
+     *                        {@code CurrentUser\MY\A11F8A9B5DF5B98BA3508FBCA575D09570E0D2C6}
+     * @return this
+     */
+    public TlsContextOptions withMtlsWindowsCertStorePath(String certificatePath) {
+        this.windowsCertStorePath = certificatePath;
+        return this;
+    }
+
+    /**
      * Sets whether or not TLS will validate the certificate from the peer. On clients,
      * this is enabled by default. On servers, this is disabled by default.
      * @param verify true to verify peers, false to ignore certs
@@ -459,7 +493,8 @@ public final class TlsContextOptions extends CrtResource {
                 boolean verifyPeer,
                 String pkcs12Path,
                 String pkcs12Password,
-                TlsContextPkcs11Options pkcs11Options
+                TlsContextPkcs11Options pkcs11Options,
+                String windowsCertStorePath
             );
 
     private static native void tlsContextOptionsDestroy(long elg);

--- a/src/native/tls_context_options.c
+++ b/src/native/tls_context_options.c
@@ -25,6 +25,7 @@ struct jni_tls_ctx_options {
     struct aws_string *pkcs12_password;
     struct aws_string *certificate;
     struct aws_string *private_key;
+    struct aws_string *windows_cert_store_path;
     struct aws_string *ca_root;
 
     struct aws_tls_ctx_pkcs11_options *pkcs11_options;
@@ -56,6 +57,7 @@ static void s_jni_tls_ctx_options_destroy(struct jni_tls_ctx_options *tls) {
     aws_string_destroy_secure(tls->pkcs12_password);
     aws_string_destroy(tls->certificate);
     aws_string_destroy_secure(tls->private_key);
+    aws_string_destroy(tls->windows_cert_store_path);
     aws_string_destroy(tls->ca_root);
 
     aws_tls_ctx_pkcs11_options_from_java_destroy(tls->pkcs11_options);
@@ -83,7 +85,8 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     jboolean jni_verify_peer,
     jstring jni_pkcs12_path,
     jstring jni_pkcs12_password,
-    jobject jni_pkcs11_options) {
+    jobject jni_pkcs11_options,
+    jstring jni_windows_cert_store_path) {
     (void)jni_class;
 
     struct aws_allocator *allocator = aws_jni_get_allocator();
@@ -142,9 +145,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
             aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_init_client_mtls_with_pkcs11 failed");
             goto on_error;
         }
-    }
-#if defined(__APPLE__)
-    else if (jni_pkcs12_path && jni_pkcs12_password) {
+    } else if (jni_pkcs12_path && jni_pkcs12_password) {
         tls->pkcs12_path = aws_jni_new_string_from_jstring(env, jni_pkcs12_path);
         if (!tls->pkcs12_path) {
             aws_jni_throw_runtime_exception(env, "failed to get pkcs12Path string");
@@ -162,10 +163,20 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
             aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_init_client_mtls_pkcs12_from_path failed");
             goto on_error;
         }
+    } else if (jni_windows_cert_store_path) {
+        tls->windows_cert_store_path = aws_jni_new_string_from_jstring(env, jni_windows_cert_store_path);
+        if (!tls->windows_cert_store_path) {
+            aws_jni_throw_runtime_exception(env, "failed to get windowsCertStorePath string");
+            goto on_error;
+        }
+
+        if (aws_tls_ctx_options_init_client_mtls_from_system_path(
+                &tls->options, allocator, aws_string_c_str(tls->windows_cert_store_path))) {
+
+            aws_jni_throw_runtime_exception(env, "aws_tls_ctx_options_init_client_mtls_from_system_path failed");
+            goto on_error;
+        }
     }
-#endif
-    (void)jni_pkcs12_path;
-    (void)jni_pkcs12_password;
 
     if (jni_ca) {
         tls->ca_root = aws_jni_new_string_from_jstring(env, jni_ca);


### PR DESCRIPTION
Add the ability to use a client certificate located in a Windows certificate store. Previously, the client certificate and private key had to be passed by filepath or file contents. With this change, certificates and keys stored on TPM devices can be used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
