### PR TITLE
Remove event loop group shutdown callback 

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/EventLoopGroup.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/EventLoopGroup.java
@@ -24,7 +24,7 @@ public final class EventLoopGroup extends CrtResource {
      * @throws CrtRuntimeException If the system is unable to allocate space for a native event loop group
      */
     public EventLoopGroup(int numThreads) throws CrtRuntimeException {
-        acquireNativeHandle(eventLoopGroupNew(this, numThreads));
+        acquireNativeHandle(eventLoopGroupNew(numThreads));
     }
 
     /**
@@ -35,7 +35,7 @@ public final class EventLoopGroup extends CrtResource {
      * @throws CrtRuntimeException If the system is unable to allocate space for a native event loop group
      */
     public EventLoopGroup(int cpuGroup, int numThreads) throws CrtRuntimeException {
-        acquireNativeHandle(eventLoopGroupNewPinnedToCpuGroup(this, cpuGroup, numThreads));
+        acquireNativeHandle(eventLoopGroupNewPinnedToCpuGroup(cpuGroup, numThreads));
     }
 
     /**
@@ -54,17 +54,7 @@ public final class EventLoopGroup extends CrtResource {
         if (!isNull()) {
             eventLoopGroupDestroy(getNativeHandle());
         }
-    }
-
-    /**
-     * Called from Native when the asynchronous cleanup process needed for event loop groups has completed.
-     */
-    private void onCleanupComplete() {
-        Log.log(Log.LogLevel.Trace, Log.LogSubject.IoEventLoop, "EventLoopGroup.onCleanupComplete");
-
-        releaseReferences();
-
-        this.shutdownComplete.complete(null);
+        shutdownComplete.complete(null);
     }
 
     public CompletableFuture<Void> getShutdownCompleteFuture() { return shutdownComplete; }
@@ -132,8 +122,8 @@ public final class EventLoopGroup extends CrtResource {
     /*******************************************************************************
      * native methods
      ******************************************************************************/
-    private static native long eventLoopGroupNew(EventLoopGroup thisObj, int numThreads) throws CrtRuntimeException;
-    private static native long eventLoopGroupNewPinnedToCpuGroup(EventLoopGroup thisObj, int cpuGroup, int numThreads) throws CrtRuntimeException;
+    private static native long eventLoopGroupNew(int numThreads) throws CrtRuntimeException;
+    private static native long eventLoopGroupNewPinnedToCpuGroup(int cpuGroup, int numThreads) throws CrtRuntimeException;
 
     private static native void eventLoopGroupDestroy(long elg);
 };

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -295,16 +295,6 @@ static void s_cache_async_callback(JNIEnv *env) {
     AWS_FATAL_ASSERT(async_callback_properties.on_failure);
 }
 
-struct java_event_loop_group_properties event_loop_group_properties;
-
-static void s_cache_event_loop_group(JNIEnv *env) {
-    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/io/EventLoopGroup");
-    AWS_FATAL_ASSERT(cls);
-
-    event_loop_group_properties.onCleanupComplete = (*env)->GetMethodID(env, cls, "onCleanupComplete", "()V");
-    AWS_FATAL_ASSERT(event_loop_group_properties.onCleanupComplete);
-}
-
 struct java_client_bootstrap_properties client_bootstrap_properties;
 
 static void s_cache_client_bootstrap(JNIEnv *env) {
@@ -810,7 +800,6 @@ void cache_java_class_ids(JNIEnv *env) {
     s_cache_credentials(env);
     s_cache_credentials_handler(env);
     s_cache_async_callback(env);
-    s_cache_event_loop_group(env);
     s_cache_client_bootstrap(env);
     s_cache_tls_context_pkcs11_options(env);
     s_cache_http_client_connection_manager(env);

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -131,12 +131,6 @@ struct java_async_callback_properties {
 };
 extern struct java_async_callback_properties async_callback_properties;
 
-/* EventLoopGroup */
-struct java_event_loop_group_properties {
-    jmethodID onCleanupComplete;
-};
-extern struct java_event_loop_group_properties event_loop_group_properties;
-
 /* ClientBootstrap */
 struct java_client_bootstrap_properties {
     jmethodID onShutdownComplete;


### PR DESCRIPTION
* Remove event loop group shutdown callback that was doing nothing useful and likely causing rare crashes when the JVM shuts down first (the async elg cleanup thread was not attached to the JVM and thus would not keep it alive).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
