### PR TITLE
Refactor CRT JVM shutdown safety

### DIFF
--- a/.builder/actions/aws_crt_java_test.py
+++ b/.builder/actions/aws_crt_java_test.py
@@ -10,7 +10,6 @@ class AWSCrtJavaTest(Builder.Action):
         env.shell.setenv('AWS_CRT_MEMORY_TRACING', '2')
         actions = []
 
-        os.system("echo TESTING")
         all_test_result = os.system("mvn -P continuous-integration -B test -DredirectTestOutputToFile=true -DreuseForks=false \
             -DrerunFailingTestsCount=5 -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true")
 

--- a/.builder/actions/aws_crt_java_test.py
+++ b/.builder/actions/aws_crt_java_test.py
@@ -12,7 +12,7 @@ class AWSCrtJavaTest(Builder.Action):
 
         os.system("echo TESTING")
         if os.system("mvn -P continuous-integration -B test -DredirectTestOutputToFile=true -DreuseForks=false \
-            -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true"):
+            -DrerunFailingTestsCount=5 -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true"):
             # Failed
             actions.append("exit 1")
         os.system("cat log.txt")

--- a/.builder/actions/aws_crt_java_test.py
+++ b/.builder/actions/aws_crt_java_test.py
@@ -10,6 +10,7 @@ class AWSCrtJavaTest(Builder.Action):
         env.shell.setenv('AWS_CRT_MEMORY_TRACING', '2')
         actions = []
 
+        os.system("echo TESTING")
         if os.system("mvn -B test -DredirectTestOutputToFile=true \
             -DrerunFailingTestsCount=5 -DskipAfterFailureCount=1 -DreuseForks=false \
             -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true"):

--- a/.builder/actions/aws_crt_java_test.py
+++ b/.builder/actions/aws_crt_java_test.py
@@ -10,7 +10,7 @@ class AWSCrtJavaTest(Builder.Action):
         env.shell.setenv('AWS_CRT_MEMORY_TRACING', '2')
         actions = []
 
-        if os.system("mvn -B test -DredirectTestOutputToFile=true -DforkCount=0 \
+        if os.system("mvn -B test -DredirectTestOutputToFile=true \
             -DrerunFailingTestsCount=5 -DskipAfterFailureCount=1 -DreuseForks=false \
             -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true"):
             # Failed

--- a/.builder/actions/aws_crt_java_test.py
+++ b/.builder/actions/aws_crt_java_test.py
@@ -11,8 +11,7 @@ class AWSCrtJavaTest(Builder.Action):
         actions = []
 
         os.system("echo TESTING")
-        if os.system("mvn -B test -DredirectTestOutputToFile=true \
-            -DrerunFailingTestsCount=5 -DskipAfterFailureCount=1 -DreuseForks=false \
+        if os.system("mvn -P continuous-integration -B test -DredirectTestOutputToFile=true -DreuseForks=false \
             -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true"):
             # Failed
             actions.append("exit 1")

--- a/.builder/actions/aws_crt_java_test.py
+++ b/.builder/actions/aws_crt_java_test.py
@@ -11,7 +11,7 @@ class AWSCrtJavaTest(Builder.Action):
         actions = []
 
         if os.system("mvn -B test -DredirectTestOutputToFile=true -DforkCount=0 \
-            -DrerunFailingTestsCount=5 -DskipAfterFailureCount=1 \
+            -DrerunFailingTestsCount=5 -DskipAfterFailureCount=1 -DreuseForks=false \
             -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true"):
             # Failed
             actions.append("exit 1")

--- a/.builder/actions/aws_crt_java_test.py
+++ b/.builder/actions/aws_crt_java_test.py
@@ -11,8 +11,14 @@ class AWSCrtJavaTest(Builder.Action):
         actions = []
 
         os.system("echo TESTING")
-        if os.system("mvn -P continuous-integration -B test -DredirectTestOutputToFile=true -DreuseForks=false \
-            -DrerunFailingTestsCount=5 -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true"):
+        all_test_result = os.system("mvn -P continuous-integration -B test -DredirectTestOutputToFile=true -DreuseForks=false \
+            -DrerunFailingTestsCount=5 -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true")
+
+        env.shell.setenv('AWS_CRT_SHUTDOWN_TESTING', '1')
+        shutdown_test_result = os.system("mvn -P continuous-integration -B test -DredirectTestOutputToFile=true -DreuseForks=false \
+            -Daws.crt.memory.tracing=2 -Daws.crt.debugnative=true -Dtest=ShutdownTest")
+
+        if shutdown_test_result or all_test_result:
             # Failed
             actions.append("exit 1")
         os.system("cat log.txt")

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -43,6 +43,14 @@ public final class CRT {
         boolean strictShutdown = System.getProperty("aws.crt.strictshutdown") != null;
         awsCrtInit(memoryTracingLevel, debugWait, strictShutdown);
 
+        Runtime.getRuntime().addShutdownHook(new Thread()
+        {
+            public void run()
+            {
+                CRT.onJvmShutdown();
+            }
+        });
+
         try {
             Log.initLoggingFromSystemProperties();
         } catch (IllegalArgumentException e) {
@@ -319,4 +327,6 @@ public final class CRT {
     }
 
     private static native void nativeCheckJniExceptionContract(boolean clearException);
+
+    private static native void onJvmShutdown();
 };

--- a/src/native/aws_signing.c
+++ b/src/native/aws_signing.c
@@ -53,8 +53,9 @@ struct s_aws_sign_request_callback_data {
 
 static void s_cleanup_callback_data(struct s_aws_sign_request_callback_data *callback_data) {
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
-    if (env == NULL) {
+    if (env != NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
     }
@@ -109,6 +110,7 @@ static void s_cleanup_callback_data(struct s_aws_sign_request_callback_data *cal
     }
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     aws_mem_release(aws_jni_get_allocator(), callback_data);
 }
@@ -216,10 +218,11 @@ static void s_aws_request_signing_complete(struct aws_signing_result *result, in
 
     struct s_aws_sign_request_callback_data *callback_data = userdata;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        goto done;
+        return;
     }
 
     if (result == NULL || error_code != AWS_ERROR_SUCCESS) {
@@ -244,6 +247,7 @@ static void s_aws_request_signing_complete(struct aws_signing_result *result, in
 done:
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     s_cleanup_callback_data(callback_data);
 }
@@ -252,10 +256,11 @@ static void s_aws_chunk_like_signing_complete(struct aws_signing_result *result,
 
     struct s_aws_sign_request_callback_data *callback_data = userdata;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        goto done;
+        return;
     }
 
     if (result == NULL || error_code != AWS_ERROR_SUCCESS) {
@@ -268,6 +273,7 @@ static void s_aws_chunk_like_signing_complete(struct aws_signing_result *result,
 done:
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     s_cleanup_callback_data(callback_data);
 }
@@ -283,6 +289,7 @@ static void s_aws_trailing_headers_signing_complete(struct aws_signing_result *r
 static bool s_should_sign_header(const struct aws_byte_cursor *name, void *user_data) {
     struct s_aws_sign_request_callback_data *callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -298,6 +305,7 @@ static bool s_should_sign_header(const struct aws_byte_cursor *name, void *user_
     (*env)->DeleteLocalRef(env, header_name);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     return result;
 }

--- a/src/native/aws_signing.c
+++ b/src/native/aws_signing.c
@@ -239,7 +239,7 @@ static void s_aws_request_signing_complete(struct aws_signing_result *result, in
 
     s_aws_complete_signing_result(env, result, callback_data, java_signed_request);
 
-done:
+done:;
 
     JavaVM *jvm = callback_data->jvm;
     s_cleanup_callback_data(callback_data, env);
@@ -266,7 +266,7 @@ static void s_aws_chunk_like_signing_complete(struct aws_signing_result *result,
 
     s_aws_complete_signing_result(env, result, callback_data, NULL);
 
-done:
+done:;
 
     JavaVM *jvm = callback_data->jvm;
     s_cleanup_callback_data(callback_data, env);

--- a/src/native/client_bootstrap.c
+++ b/src/native/client_bootstrap.c
@@ -46,6 +46,7 @@ static void s_shutdown_callback_data_destroy(JNIEnv *env, struct shutdown_callba
 static void s_client_bootstrap_shutdown_complete(void *user_data) {
     struct shutdown_callback_data *callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -63,6 +64,7 @@ static void s_client_bootstrap_shutdown_complete(void *user_data) {
     JavaVM *jvm = callback_data->jvm;
     s_shutdown_callback_data_destroy(env, callback_data);
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT

--- a/src/native/client_bootstrap.c
+++ b/src/native/client_bootstrap.c
@@ -46,7 +46,7 @@ static void s_shutdown_callback_data_destroy(JNIEnv *env, struct shutdown_callba
 static void s_client_bootstrap_shutdown_complete(void *user_data) {
     struct shutdown_callback_data *callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -60,7 +60,9 @@ static void s_client_bootstrap_shutdown_complete(void *user_data) {
         AWS_FATAL_ASSERT(!aws_jni_check_and_clear_exception(env));
     }
 
+    JavaVM *jvm = callback_data->jvm;
     s_shutdown_callback_data_destroy(env, callback_data);
+    aws_jni_release_thread_env(jvm, env);
 }
 
 JNIEXPORT

--- a/src/native/credentials_provider.c
+++ b/src/native/credentials_provider.c
@@ -56,7 +56,7 @@ static void s_on_shutdown_complete(void *user_data) {
     AWS_LOGF_DEBUG(AWS_LS_AUTH_CREDENTIALS_PROVIDER, "Credentials providers shutdown complete");
 
     // Tell the Java credentials providers that shutdown is done.  This lets it release its references.
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -73,7 +73,11 @@ static void s_on_shutdown_complete(void *user_data) {
 
     struct aws_allocator *allocator = aws_jni_get_allocator();
     // We're done with this callback data, clean it up.
+
+    JavaVM *jvm = callback_data->jvm;
     s_callback_data_clean_up(env, allocator, callback_data);
+
+    aws_jni_release_thread_env(jvm, env);
 }
 
 JNIEXPORT jlong JNICALL
@@ -526,7 +530,7 @@ static int s_credentials_provider_delegate_get_credentials(
     struct aws_allocator *allocator = aws_jni_get_allocator();
 
     int return_value = AWS_OP_ERR;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
@@ -585,6 +589,9 @@ empty_credentials:
     (*env)->DeleteLocalRef(env, java_session_token);
 fetch_credentials_failed:
     (*env)->DeleteLocalRef(env, java_credentials);
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     return return_value;
 }
 
@@ -654,7 +661,7 @@ struct aws_credentials_provider_get_credentials_callback_data {
 };
 
 static void s_cp_callback_data_clean_up(struct aws_credentials_provider_get_credentials_callback_data *callback_data) {
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -662,6 +669,8 @@ static void s_cp_callback_data_clean_up(struct aws_credentials_provider_get_cred
 
     (*env)->DeleteGlobalRef(env, callback_data->java_crt_credentials_provider);
     (*env)->DeleteGlobalRef(env, callback_data->java_credentials_future);
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
 
     aws_credentials_provider_release(callback_data->provider);
 
@@ -674,7 +683,7 @@ static void s_on_get_credentials_callback(struct aws_credentials *credentials, i
 
     struct aws_credentials_provider_get_credentials_callback_data *callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -731,6 +740,9 @@ static void s_on_get_credentials_callback(struct aws_credentials *credentials, i
         }
         (*env)->DeleteLocalRef(env, java_credentials);
     }
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     s_cp_callback_data_clean_up(callback_data);
 }
 

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -156,7 +156,9 @@ done:
 }
 
 JNIEnv *aws_jni_acquire_thread_env(JavaVM *jvm) {
-    aws_rw_lock_rlock(&s_jvm_table_lock);
+    if (aws_rw_lock_try_rlock(&s_jvm_table_lock)) {
+        return NULL;
+    }
 
     if (s_jvms == NULL) {
         aws_raise_error(AWS_ERROR_JAVA_CRT_JVM_DESTROYED);

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -8,7 +8,9 @@
 #include <aws/common/atomics.h>
 #include <aws/common/clock.h>
 #include <aws/common/common.h>
+#include <aws/common/hash_table.h>
 #include <aws/common/logging.h>
+#include <aws/common/rw_lock.h>
 #include <aws/common/string.h>
 #include <aws/common/system_info.h>
 #include <aws/common/thread.h>
@@ -45,6 +47,123 @@ struct aws_allocator *aws_jni_get_allocator() {
         s_allocator = s_init_allocator();
     }
     return s_allocator;
+}
+
+void s_detach_jvm_from_thread(void *user_data) {
+    AWS_LOGF_DEBUG(AWS_LS_COMMON_GENERAL, "s_detach_jvm_from_thread invoked");
+    JavaVM *jvm = user_data;
+    (*jvm)->DetachCurrentThread(jvm);
+}
+
+static JNIEnv *s_aws_jni_get_thread_env(JavaVM *jvm) {
+#ifdef ANDROID
+    JNIEnv *env = NULL;
+#else
+    void *env = NULL;
+#endif
+    if ((*jvm)->GetEnv(jvm, (void **)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
+        AWS_LOGF_DEBUG(AWS_LS_COMMON_GENERAL, "s_aws_jni_get_thread_env returned detached, attaching");
+#ifdef ANDROID
+        jint result = (*jvm)->AttachCurrentThreadAsDaemon(jvm, &env, NULL);
+#else
+        jint result = (*jvm)->AttachCurrentThreadAsDaemon(jvm, (void **)&env, NULL);
+#endif
+        /* Ran out of memory, don't log in this case */
+        AWS_FATAL_ASSERT(result != JNI_ENOMEM);
+        if (result != JNI_OK) {
+            fprintf(stderr, "Unrecoverable AttachCurrentThreadAsDaemon failed, JNI error code is %d\n", (int)result);
+            return NULL;
+        }
+        /* This should only happen in event loop threads, the JVM main thread attachment is
+         * managed by the JVM, so we only need to clean up event loop thread attachments */
+        AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_thread_current_at_exit(s_detach_jvm_from_thread, (void *)jvm));
+    }
+
+    return env;
+}
+
+static struct aws_rw_lock s_jvm_table_lock = AWS_RW_LOCK_INIT;
+static struct aws_hash_table *s_jvms = NULL;
+
+static void s_jvm_table_add_jvm_for_env(JNIEnv *env) {
+    aws_rw_lock_wlock(&s_jvm_table_lock);
+
+    if (s_jvms == NULL) {
+        s_jvms = aws_mem_calloc(aws_default_allocator(), 1, sizeof(struct aws_hash_table));
+        AWS_FATAL_ASSERT(
+            AWS_OP_SUCCESS ==
+            aws_hash_table_init(s_jvms, aws_default_allocator(), 1, aws_hash_ptr, aws_ptr_eq, NULL, NULL));
+    }
+
+    JavaVM *jvm = NULL;
+    jint jvmresult = (*env)->GetJavaVM(env, &jvm);
+    AWS_FATAL_ASSERT(jvmresult == 0 && jvm != NULL);
+
+    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_hash_table_put(s_jvms, jvm, NULL, NULL));
+
+    aws_rw_lock_wunlock(&s_jvm_table_lock);
+}
+
+static void s_jvm_table_remove_jvm_for_env(JNIEnv *env) {
+    aws_rw_lock_wlock(&s_jvm_table_lock);
+
+    if (s_jvms == NULL) {
+        goto done;
+    }
+
+    JavaVM *jvm = NULL;
+    jint jvmresult = (*env)->GetJavaVM(env, &jvm);
+    AWS_FATAL_ASSERT(jvmresult == 0 && jvm != NULL);
+
+    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_hash_table_remove(s_jvms, jvm, NULL, NULL));
+
+    if (aws_hash_table_get_entry_count(s_jvms) == 0) {
+        aws_hash_table_clean_up(s_jvms);
+        aws_mem_release(aws_default_allocator(), s_jvms);
+        s_jvms = NULL;
+    }
+
+done:
+
+    aws_rw_lock_wunlock(&s_jvm_table_lock);
+}
+
+JNIEnv *aws_jni_acquire_thread_env(JavaVM *jvm) {
+    aws_rw_lock_rlock(&s_jvm_table_lock);
+
+    if (s_jvms == NULL) {
+        aws_raise_error(AWS_ERROR_JAVA_CRT_JVM_DESTROYED);
+        goto error;
+    }
+
+    struct aws_hash_element *element = NULL;
+    int find_result = aws_hash_table_find(s_jvms, jvm, &element);
+    if (find_result != AWS_OP_SUCCESS || element == NULL) {
+        aws_raise_error(AWS_ERROR_JAVA_CRT_JVM_DESTROYED);
+        goto error;
+    }
+
+    JNIEnv *env = s_aws_jni_get_thread_env(jvm);
+    if (env == NULL) {
+        goto error;
+    }
+
+    return env;
+
+error:
+
+    aws_rw_lock_runlock(&s_jvm_table_lock);
+
+    return NULL;
+}
+
+void aws_jni_release_thread_env(JavaVM *jvm, JNIEnv *env) {
+    (void)jvm;
+    (void)env;
+
+    if (env != NULL) {
+        aws_rw_lock_runlock(&s_jvm_table_lock);
+    }
 }
 
 void aws_jni_throw_runtime_exception(JNIEnv *env, const char *msg, ...) {
@@ -212,40 +331,38 @@ struct aws_string *aws_jni_new_string_from_jstring(JNIEnv *env, jstring str) {
     return result;
 }
 
-void s_detach_jvm_from_thread(void *user_data) {
-    AWS_LOGF_DEBUG(AWS_LS_COMMON_GENERAL, "s_detach_jvm_from_thread invoked");
-    JavaVM *jvm = user_data;
-    (*jvm)->DetachCurrentThread(jvm);
-}
+#define AWS_DEFINE_ERROR_INFO_CRT(CODE, STR) AWS_DEFINE_ERROR_INFO(CODE, STR, "aws-crt-java")
 
-JNIEnv *aws_jni_get_thread_env(JavaVM *jvm) {
-#ifdef ANDROID
-    JNIEnv *env = NULL;
-#else
-    void *env = NULL;
-#endif
-    if ((*jvm)->GetEnv(jvm, (void **)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
-        AWS_LOGF_DEBUG(AWS_LS_COMMON_GENERAL, "aws_jni_get_thread_env returned detached, attaching");
-#ifdef ANDROID
-        jint result = (*jvm)->AttachCurrentThreadAsDaemon(jvm, &env, NULL);
-#else
-        jint result = (*jvm)->AttachCurrentThreadAsDaemon(jvm, (void **)&env, NULL);
-#endif
-        /* Ran out of memory, don't log in this case */
-        AWS_FATAL_ASSERT(result != JNI_ENOMEM);
-        if (result != JNI_OK) {
-            fprintf(stderr, "Unrecoverable AttachCurrentThreadAsDaemon failed, JNI error code is %d\n", (int)result);
-            return NULL;
-        }
-        /* This should only happen in event loop threads, the JVM main thread attachment is
-         * managed by the JVM, so we only need to clean up event loop thread attachments */
-        AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_thread_current_at_exit(s_detach_jvm_from_thread, (void *)jvm));
-    }
+/* clang-format off */
+static struct aws_error_info s_crt_errors[] = {
+    AWS_DEFINE_ERROR_INFO_CRT(
+        AWS_ERROR_JAVA_CRT_JVM_DESTROYED,
+        "Attempt to use a JVM that has already been destroyed"),
+};
+/* clang-format on */
 
-    return env;
-}
+static struct aws_error_info_list s_crt_error_list = {
+    .error_list = s_crt_errors,
+    .count = sizeof(s_crt_errors) / sizeof(struct aws_error_info),
+};
+
+static struct aws_log_subject_info s_crt_log_subject_infos[] = {
+    DEFINE_LOG_SUBJECT_INFO(
+        AWS_LS_JAVA_CRT_GENERAL,
+        "JavaCrtGeneral",
+        "Subject for aws-crt-java logging that defies categorization."),
+};
+
+static struct aws_log_subject_info_list s_crt_log_subject_list = {
+    .subject_list = s_crt_log_subject_infos,
+    .count = AWS_ARRAY_SIZE(s_crt_log_subject_infos),
+};
 
 static void s_jni_atexit_strict(void) {
+
+    aws_unregister_log_subject_info_list(&s_crt_log_subject_list);
+    aws_unregister_error_info(&s_crt_error_list);
+
     aws_s3_library_clean_up();
     aws_event_stream_library_clean_up();
     aws_auth_library_clean_up();
@@ -263,6 +380,7 @@ static void s_jni_atexit_strict(void) {
         struct aws_allocator *tracer_allocator = aws_jni_get_allocator();
         aws_mem_tracer_destroy(tracer_allocator);
     }
+
     s_allocator = NULL;
 }
 
@@ -339,6 +457,10 @@ void JNICALL Java_software_amazon_awssdk_crt_CRT_awsCrtInit(
     aws_event_stream_library_init(allocator);
     aws_s3_library_init(allocator);
 
+    aws_register_error_info(&s_crt_error_list);
+    aws_register_log_subject_info_list(&s_crt_log_subject_list);
+
+    s_jvm_table_add_jvm_for_env(env);
     cache_java_class_ids(env);
 
     if (jni_strict_shutdown) {
@@ -346,6 +468,14 @@ void JNICALL Java_software_amazon_awssdk_crt_CRT_awsCrtInit(
     } else {
         atexit(s_jni_atexit_gentle);
     }
+}
+
+JNIEXPORT
+void JNICALL Java_software_amazon_awssdk_crt_CRT_onJvmShutdown(JNIEnv *env, jclass jni_crt_class) {
+
+    (void)jni_crt_class;
+
+    s_jvm_table_remove_jvm_for_env(env);
 }
 
 JNIEXPORT

--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -172,6 +172,7 @@ JNIEnv *aws_jni_acquire_thread_env(JavaVM *jvm) {
 
     JNIEnv *env = s_aws_jni_get_thread_env(jvm);
     if (env == NULL) {
+        aws_raise_error(AWS_ERROR_JAVA_CRT_JVM_DESTROYED);
         goto error;
     }
 

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -168,6 +168,11 @@ struct aws_string *aws_jni_new_string_from_jstring(JNIEnv *env, jstring str);
  ******************************************************************************/
 JNIEnv *aws_jni_acquire_thread_env(JavaVM *jvm);
 
+/*******************************************************************************
+ * aws_jni_release_thread_env - Releases an acquired JNIEnv for the current thread.  Every successfully
+ * acquired JNIEnv must be released exactly once.  Internally, all this does is release the reader
+ * lock on the set of valid JVMs.
+ ******************************************************************************/
 void aws_jni_release_thread_env(JavaVM *jvm, JNIEnv *env);
 
 #endif /* AWS_JNI_CRT_H */

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -162,7 +162,6 @@ struct aws_byte_cursor aws_jni_byte_cursor_from_direct_byte_buffer(JNIEnv *env, 
 struct aws_string *aws_jni_new_string_from_jstring(JNIEnv *env, jstring str);
 
 /*******************************************************************************
-<<<<<<< HEAD
  * aws_jni_acquire_thread_env - Acquires the JNIEnv for the current thread from the VM,
  * attaching the env if necessary.  aws_jni_release_thread_env() must be called once
  * the caller is through with the environment.

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -17,7 +17,13 @@
 enum aws_java_crt_log_subject {
     AWS_LS_JAVA_CRT_GENERAL = AWS_LOG_SUBJECT_BEGIN_RANGE(AWS_CRT_JAVA_PACKAGE_ID),
 
-    AWS_LS_JAVA_CRT_LAST = AWS_LOG_SUBJECT_END_RANGE(AWS_CRT_JAVA_PACKAGE_ID)
+    AWS_LS_JAVA_CRT_LAST = AWS_LOG_SUBJECT_END_RANGE(AWS_CRT_JAVA_PACKAGE_ID),
+};
+
+enum aws_java_crt_error {
+    AWS_ERROR_JAVA_CRT_JVM_DESTROYED = AWS_ERROR_ENUM_BEGIN_RANGE(AWS_CRT_JAVA_PACKAGE_ID),
+
+    AWS_ERROR_JAVA_CRT_END_RANGE = AWS_ERROR_ENUM_END_RANGE(AWS_CRT_JAVA_PACKAGE_ID),
 };
 
 struct aws_allocator *aws_jni_get_allocator(void);
@@ -156,9 +162,12 @@ struct aws_byte_cursor aws_jni_byte_cursor_from_direct_byte_buffer(JNIEnv *env, 
 struct aws_string *aws_jni_new_string_from_jstring(JNIEnv *env, jstring str);
 
 /*******************************************************************************
- * aws_jni_get_thread_env - Gets the JNIEnv for the current thread from the VM,
- * attaching the env if necessary
+ * aws_jni_acquire_thread_env - Acquires the JNIEnv for the current thread from the VM,
+ * attaching the env if necessary.  aws_jni_release_thread_env() must be called once
+ * the caller is through with the environment.
  ******************************************************************************/
-JNIEnv *aws_jni_get_thread_env(JavaVM *jvm);
+JNIEnv *aws_jni_acquire_thread_env(JavaVM *jvm);
+
+void aws_jni_release_thread_env(JavaVM *jvm, JNIEnv *env);
 
 #endif /* AWS_JNI_CRT_H */

--- a/src/native/event_stream_rpc_client.c
+++ b/src/native/event_stream_rpc_client.c
@@ -489,7 +489,7 @@ static void s_stream_continuation_closed(
     /* don't really care if they threw here, but we want to make the jvm happy that we checked */
     aws_jni_check_and_clear_exception(env);
 
-    JavaVM *jvm = jvm = continuation_callback_data->jvm;
+    JavaVM *jvm = continuation_callback_data->jvm;
     s_client_continuation_data_destroy(env, continuation_callback_data);
     aws_jni_release_thread_env(jvm, env);
 }

--- a/src/native/event_stream_rpc_client.c
+++ b/src/native/event_stream_rpc_client.c
@@ -40,6 +40,7 @@ static void s_destroy_connection_callback_data(struct connection_callback_data *
         return;
     }
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -51,6 +52,7 @@ static void s_destroy_connection_callback_data(struct connection_callback_data *
     }
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     aws_mem_release(aws_jni_get_allocator(), callback_data);
 }
@@ -61,6 +63,8 @@ static void s_on_connection_setup(
     void *user_data) {
     (void)connection;
     struct connection_callback_data *callback_data = user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -79,6 +83,7 @@ static void s_on_connection_setup(
     }
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     if (error_code) {
         s_destroy_connection_callback_data(callback_data);
@@ -92,6 +97,8 @@ static void s_on_connection_shutdown(
     (void)connection;
 
     struct connection_callback_data *callback_data = user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -106,6 +113,7 @@ static void s_on_connection_shutdown(
     aws_jni_check_and_clear_exception(env);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     s_destroy_connection_callback_data(callback_data);
 }
@@ -117,6 +125,8 @@ static void s_connection_protocol_message(
     (void)connection;
 
     struct connection_callback_data *callback_data = user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -143,6 +153,7 @@ static void s_connection_protocol_message(
     aws_jni_check_and_clear_exception(env);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT
@@ -335,6 +346,7 @@ static void s_destroy_message_flush_callback_args(JNIEnv *env, struct message_fl
 static void s_message_flush_fn(int error_code, void *user_data) {
     struct message_flush_callback_args *callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -349,6 +361,7 @@ static void s_message_flush_fn(int error_code, void *user_data) {
     s_destroy_message_flush_callback_args(env, callback_data);
 
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT
@@ -442,6 +455,7 @@ static void s_stream_continuation(
 
     struct continuation_callback_data *callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -469,6 +483,7 @@ static void s_stream_continuation(
     aws_jni_check_and_clear_exception(env);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 static void s_stream_continuation_closed(
@@ -476,6 +491,8 @@ static void s_stream_continuation_closed(
     void *user_data) {
     (void)token;
     struct continuation_callback_data *continuation_callback_data = user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(continuation_callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -492,6 +509,7 @@ static void s_stream_continuation_closed(
     JavaVM *jvm = continuation_callback_data->jvm;
     s_client_continuation_data_destroy(env, continuation_callback_data);
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT

--- a/src/native/event_stream_rpc_client.c
+++ b/src/native/event_stream_rpc_client.c
@@ -40,7 +40,7 @@ static void s_destroy_connection_callback_data(struct connection_callback_data *
         return;
     }
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -49,6 +49,8 @@ static void s_destroy_connection_callback_data(struct connection_callback_data *
     if (callback_data->java_connection_handler) {
         (*env)->DeleteGlobalRef(env, callback_data->java_connection_handler);
     }
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
 
     aws_mem_release(aws_jni_get_allocator(), callback_data);
 }
@@ -59,7 +61,7 @@ static void s_on_connection_setup(
     void *user_data) {
     (void)connection;
     struct connection_callback_data *callback_data = user_data;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -76,6 +78,8 @@ static void s_on_connection_setup(
         aws_event_stream_rpc_client_connection_close(connection, AWS_ERROR_UNKNOWN);
     }
 
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     if (error_code) {
         s_destroy_connection_callback_data(callback_data);
     }
@@ -88,7 +92,7 @@ static void s_on_connection_shutdown(
     (void)connection;
 
     struct connection_callback_data *callback_data = user_data;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -101,6 +105,8 @@ static void s_on_connection_shutdown(
         error_code);
     aws_jni_check_and_clear_exception(env);
 
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     s_destroy_connection_callback_data(callback_data);
 }
 
@@ -111,7 +117,7 @@ static void s_connection_protocol_message(
     (void)connection;
 
     struct connection_callback_data *callback_data = user_data;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -135,6 +141,8 @@ static void s_connection_protocol_message(
     (*env)->DeleteLocalRef(env, payload_byte_array);
     (*env)->DeleteLocalRef(env, headers_array);
     aws_jni_check_and_clear_exception(env);
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
 }
 
 JNIEXPORT
@@ -327,7 +335,7 @@ static void s_destroy_message_flush_callback_args(JNIEnv *env, struct message_fl
 static void s_message_flush_fn(int error_code, void *user_data) {
     struct message_flush_callback_args *callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -337,7 +345,10 @@ static void s_message_flush_fn(int error_code, void *user_data) {
         env, callback_data->callback, event_stream_server_message_flush_properties.callback, error_code);
     aws_jni_check_and_clear_exception(env);
 
+    JavaVM *jvm = callback_data->jvm;
     s_destroy_message_flush_callback_args(env, callback_data);
+
+    aws_jni_release_thread_env(jvm, env);
 }
 
 JNIEXPORT
@@ -431,7 +442,7 @@ static void s_stream_continuation(
 
     struct continuation_callback_data *callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -456,6 +467,8 @@ static void s_stream_continuation(
     (*env)->DeleteLocalRef(env, headers_array);
     /* don't really care if they threw here, but we want to make the jvm happy that we checked */
     aws_jni_check_and_clear_exception(env);
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
 }
 
 static void s_stream_continuation_closed(
@@ -463,7 +476,7 @@ static void s_stream_continuation_closed(
     void *user_data) {
     (void)token;
     struct continuation_callback_data *continuation_callback_data = user_data;
-    JNIEnv *env = aws_jni_get_thread_env(continuation_callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(continuation_callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -475,7 +488,10 @@ static void s_stream_continuation_closed(
         event_stream_client_continuation_handler_properties.onContinuationClosed);
     /* don't really care if they threw here, but we want to make the jvm happy that we checked */
     aws_jni_check_and_clear_exception(env);
+
+    JavaVM *jvm = jvm = continuation_callback_data->jvm;
     s_client_continuation_data_destroy(env, continuation_callback_data);
+    aws_jni_release_thread_env(jvm, env);
 }
 
 JNIEXPORT

--- a/src/native/event_stream_rpc_server.c
+++ b/src/native/event_stream_rpc_server.c
@@ -87,7 +87,7 @@ static void s_server_listener_shutdown_complete(
 
     struct shutdown_callback_data *callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -100,7 +100,9 @@ static void s_server_listener_shutdown_complete(
         (*env)->DeleteLocalRef(env, java_server_listener);
     }
 
+    JavaVM *jvm = callback_data->jvm;
     s_shutdown_callback_data_destroy(env, callback_data);
+    aws_jni_release_thread_env(jvm, env);
 }
 
 struct continuation_callback_data {
@@ -133,7 +135,7 @@ static void s_stream_continuation_fn(
 
     struct continuation_callback_data *callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -156,6 +158,8 @@ static void s_stream_continuation_fn(
     (*env)->DeleteLocalRef(env, payload_byte_array);
     /* don't really care if they threw here, but we want to make the jvm happy that we checked */
     aws_jni_check_and_clear_exception(env);
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
 }
 
 static void s_stream_continuation_closed_fn(
@@ -164,7 +168,7 @@ static void s_stream_continuation_closed_fn(
     (void)token;
     struct continuation_callback_data *continuation_callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(continuation_callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(continuation_callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -176,7 +180,10 @@ static void s_stream_continuation_closed_fn(
         event_stream_server_continuation_handler_properties.onContinuationClosed);
     /* don't really care if they threw here, but we want to make the jvm happy that we checked */
     aws_jni_check_and_clear_exception(env);
+
+    JavaVM *jvm = continuation_callback_data->jvm;
     s_server_continuation_data_destroy(env, continuation_callback_data);
+    aws_jni_release_thread_env(jvm, env);
 }
 
 static int s_on_incoming_stream_fn(
@@ -191,7 +198,7 @@ static int s_on_incoming_stream_fn(
 
     jobject java_continuation = NULL;
     jobject java_continuation_handler = NULL;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
@@ -252,6 +259,8 @@ static int s_on_incoming_stream_fn(
     (*env)->DeleteLocalRef(env, java_continuation_handler);
     (*env)->DeleteLocalRef(env, java_continuation);
 
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     return AWS_OP_SUCCESS;
 
 on_error:
@@ -267,6 +276,8 @@ on_error:
     aws_event_stream_rpc_server_connection_close(connection, aws_last_error());
     s_server_continuation_data_destroy(env, continuation_callback_data);
 
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     return AWS_OP_ERR;
 }
 
@@ -277,7 +288,7 @@ static void s_connection_protocol_message_fn(
     (void)connection;
 
     struct connection_callback_data *callback_data = user_data;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -301,6 +312,8 @@ static void s_connection_protocol_message_fn(
     (*env)->DeleteLocalRef(env, payload_byte_array);
     /* don't really care if they threw here, but we want to make the jvm happy that we checked */
     aws_jni_check_and_clear_exception(env);
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
 }
 
 static int s_on_new_connection_fn(
@@ -311,7 +324,7 @@ static int s_on_new_connection_fn(
 
     struct shutdown_callback_data *callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
@@ -369,6 +382,8 @@ static int s_on_new_connection_fn(
     (*env)->DeleteLocalRef(env, java_connection_handler);
     (*env)->DeleteLocalRef(env, java_server_connection);
 
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     return AWS_OP_SUCCESS;
 
 error:
@@ -383,6 +398,8 @@ error:
 
     s_server_connection_data_destroy(env, connection_callback_data);
 
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     return AWS_OP_ERR;
 }
 
@@ -394,7 +411,7 @@ static void s_on_connection_shutdown_fn(
 
     struct connection_callback_data *callback_data = aws_event_stream_rpc_server_connection_get_user_data(connection);
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -419,7 +436,9 @@ static void s_on_connection_shutdown_fn(
     (*env)->DeleteLocalRef(env, java_listener_handler);
 
     /* this is the should be connection specific callback data. */
+    JavaVM *jvm = callback_data->jvm;
     s_server_connection_data_destroy(env, callback_data);
+    aws_jni_release_thread_env(jvm, env);
 }
 
 JNIEXPORT
@@ -636,7 +655,7 @@ static void s_destroy_message_flush_callback_args(JNIEnv *env, struct message_fl
 static void s_message_flush_fn(int error_code, void *user_data) {
     struct message_flush_callback_args *callback_data = user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -645,7 +664,10 @@ static void s_message_flush_fn(int error_code, void *user_data) {
     (*env)->CallVoidMethod(
         env, callback_data->callback, event_stream_server_message_flush_properties.callback, error_code);
     aws_jni_check_and_clear_exception(env);
+
+    JavaVM *jvm = callback_data->jvm;
     s_destroy_message_flush_callback_args(env, callback_data);
+    aws_jni_release_thread_env(jvm, env);
 }
 
 JNIEXPORT

--- a/src/native/event_stream_rpc_server.c
+++ b/src/native/event_stream_rpc_server.c
@@ -230,11 +230,13 @@ static int s_on_incoming_stream_fn(
     aws_jni_check_and_clear_exception(env);
 
     if (!java_continuation) {
+        aws_raise_error(AWS_ERROR_INVALID_STATE);
         goto on_error;
     }
 
     continuation_callback_data->java_continuation = (*env)->NewGlobalRef(env, java_continuation);
     if (continuation_callback_data->java_continuation == NULL) {
+        aws_raise_error(AWS_ERROR_INVALID_STATE);
         goto on_error;
     }
 
@@ -252,11 +254,13 @@ static int s_on_incoming_stream_fn(
     }
 
     if (!java_continuation_handler) {
+        aws_raise_error(AWS_ERROR_INVALID_STATE);
         goto on_error;
     }
 
     continuation_callback_data->java_continuation_handler = (*env)->NewGlobalRef(env, java_continuation_handler);
     if (continuation_callback_data->java_continuation_handler == NULL) {
+        aws_raise_error(AWS_ERROR_INVALID_STATE);
         goto on_error;
     }
 
@@ -364,6 +368,7 @@ static int s_on_new_connection_fn(
             event_stream_server_listener_handler_properties.newConnConstructor,
             (jlong)connection);
         if (aws_jni_check_and_clear_exception(env) || java_server_connection == NULL) {
+            aws_raise_error(AWS_ERROR_INVALID_STATE);
             goto error;
         }
 
@@ -381,11 +386,13 @@ static int s_on_new_connection_fn(
     aws_jni_check_and_clear_exception(env);
 
     if (!java_connection_handler) {
+        aws_raise_error(AWS_ERROR_INVALID_STATE);
         goto error;
     }
 
     connection_callback_data->java_connection_handler = (*env)->NewGlobalRef(env, java_connection_handler);
     if (connection_callback_data->java_connection_handler == NULL) {
+        aws_raise_error(AWS_ERROR_INVALID_STATE);
         goto error;
     }
 

--- a/src/native/event_stream_rpc_server.c
+++ b/src/native/event_stream_rpc_server.c
@@ -87,6 +87,7 @@ static void s_server_listener_shutdown_complete(
 
     struct shutdown_callback_data *callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -103,6 +104,7 @@ static void s_server_listener_shutdown_complete(
     JavaVM *jvm = callback_data->jvm;
     s_shutdown_callback_data_destroy(env, callback_data);
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 struct continuation_callback_data {
@@ -135,6 +137,7 @@ static void s_stream_continuation_fn(
 
     struct continuation_callback_data *callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -160,6 +163,7 @@ static void s_stream_continuation_fn(
     aws_jni_check_and_clear_exception(env);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 static void s_stream_continuation_closed_fn(
@@ -168,6 +172,7 @@ static void s_stream_continuation_closed_fn(
     (void)token;
     struct continuation_callback_data *continuation_callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(continuation_callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -184,6 +189,7 @@ static void s_stream_continuation_closed_fn(
     JavaVM *jvm = continuation_callback_data->jvm;
     s_server_continuation_data_destroy(env, continuation_callback_data);
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 static int s_on_incoming_stream_fn(
@@ -198,10 +204,12 @@ static int s_on_incoming_stream_fn(
 
     jobject java_continuation = NULL;
     jobject java_continuation_handler = NULL;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return aws_raise_error(AWS_ERROR_INVALID_STATE);
+        return AWS_OP_ERR;
     }
 
     struct continuation_callback_data *continuation_callback_data =
@@ -260,6 +268,7 @@ static int s_on_incoming_stream_fn(
     (*env)->DeleteLocalRef(env, java_continuation);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE SUCCESS PATH **********/
 
     return AWS_OP_SUCCESS;
 
@@ -277,6 +286,7 @@ on_error:
     s_server_continuation_data_destroy(env, continuation_callback_data);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE FAILURE PATH **********/
 
     return AWS_OP_ERR;
 }
@@ -288,6 +298,8 @@ static void s_connection_protocol_message_fn(
     (void)connection;
 
     struct connection_callback_data *callback_data = user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -314,6 +326,7 @@ static void s_connection_protocol_message_fn(
     aws_jni_check_and_clear_exception(env);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 static int s_on_new_connection_fn(
@@ -324,10 +337,11 @@ static int s_on_new_connection_fn(
 
     struct shutdown_callback_data *callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return aws_raise_error(AWS_ERROR_INVALID_STATE);
+        return AWS_OP_ERR;
     }
 
     jobject java_server_connection = NULL;
@@ -383,6 +397,7 @@ static int s_on_new_connection_fn(
     (*env)->DeleteLocalRef(env, java_server_connection);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE SUCCESS PATH **********/
 
     return AWS_OP_SUCCESS;
 
@@ -399,6 +414,7 @@ error:
     s_server_connection_data_destroy(env, connection_callback_data);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE ERROR PATH **********/
 
     return AWS_OP_ERR;
 }
@@ -411,6 +427,7 @@ static void s_on_connection_shutdown_fn(
 
     struct connection_callback_data *callback_data = aws_event_stream_rpc_server_connection_get_user_data(connection);
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -439,6 +456,7 @@ static void s_on_connection_shutdown_fn(
     JavaVM *jvm = callback_data->jvm;
     s_server_connection_data_destroy(env, callback_data);
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT
@@ -655,6 +673,7 @@ static void s_destroy_message_flush_callback_args(JNIEnv *env, struct message_fl
 static void s_message_flush_fn(int error_code, void *user_data) {
     struct message_flush_callback_args *callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -668,6 +687,7 @@ static void s_message_flush_fn(int error_code, void *user_data) {
     JavaVM *jvm = callback_data->jvm;
     s_destroy_message_flush_callback_args(env, callback_data);
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT

--- a/src/native/http_connection_manager.c
+++ b/src/native/http_connection_manager.c
@@ -51,6 +51,7 @@ static void s_destroy_manager_binding(struct http_connection_manager_binding *bi
         return;
     }
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(binding->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -62,6 +63,7 @@ static void s_destroy_manager_binding(struct http_connection_manager_binding *bi
     }
 
     aws_jni_release_thread_env(binding->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     aws_mem_release(aws_jni_get_allocator(), binding);
 }
@@ -69,6 +71,8 @@ static void s_destroy_manager_binding(struct http_connection_manager_binding *bi
 static void s_on_http_conn_manager_shutdown_complete_callback(void *user_data) {
 
     struct http_connection_manager_binding *binding = (struct http_connection_manager_binding *)user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(binding->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -86,6 +90,7 @@ static void s_on_http_conn_manager_shutdown_complete_callback(void *user_data) {
     }
 
     aws_jni_release_thread_env(binding->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     // We're done with this wrapper, free it.
     s_destroy_manager_binding(binding);
@@ -336,6 +341,7 @@ static void s_destroy_connection_binding(struct aws_http_connection_binding *bin
         return;
     }
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(binding->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -347,6 +353,7 @@ static void s_destroy_connection_binding(struct aws_http_connection_binding *bin
     }
 
     aws_jni_release_thread_env(binding->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     if (binding->manager != NULL && binding->connection != NULL) {
         aws_http_connection_manager_release_connection(binding->manager, binding->connection);
@@ -362,6 +369,8 @@ static void s_on_http_conn_acquisition_callback(
 
     struct aws_http_connection_binding *binding = (struct aws_http_connection_binding *)user_data;
     binding->connection = connection;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(binding->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -389,6 +398,7 @@ static void s_on_http_conn_acquisition_callback(
     AWS_FATAL_ASSERT(!aws_jni_check_and_clear_exception(env));
 
     aws_jni_release_thread_env(binding->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     if (error_code) {
         s_destroy_connection_binding(binding);

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -152,10 +152,11 @@ static int s_on_incoming_header_block_done_fn(
 
     struct http_stream_callback_data *callback = (struct http_stream_callback_data *)user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return aws_raise_error(AWS_ERROR_INVALID_STATE);
+        return AWS_OP_ERR;
     }
 
     int result = AWS_OP_ERR;
@@ -200,6 +201,7 @@ static int s_on_incoming_header_block_done_fn(
 done:
 
     aws_jni_release_thread_env(callback->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     return result;
 }
@@ -209,10 +211,11 @@ static int s_on_incoming_body_fn(struct aws_http_stream *stream, const struct aw
 
     size_t total_window_increment = 0;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return aws_raise_error(AWS_ERROR_INVALID_STATE);
+        return AWS_OP_ERR;
     }
 
     int result = AWS_OP_ERR;
@@ -251,6 +254,7 @@ static int s_on_incoming_body_fn(struct aws_http_stream *stream, const struct aw
 done:
 
     aws_jni_release_thread_env(callback->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     return result;
 }
@@ -258,6 +262,8 @@ done:
 static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_code, void *user_data) {
 
     struct http_stream_callback_data *callback = (struct http_stream_callback_data *)user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -281,6 +287,7 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
     JavaVM *jvm = callback->jvm;
     http_stream_callback_destroy(env, callback);
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT jobject JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnection_httpClientConnectionMakeRequest(
@@ -385,6 +392,7 @@ static void s_write_chunk_complete(struct aws_http_stream *stream, int error_cod
 
     struct http_stream_chunked_callback_data *chunked_callback_data = user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(chunked_callback_data->stream_cb_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -401,6 +409,7 @@ static void s_write_chunk_complete(struct aws_http_stream *stream, int error_cod
     JavaVM *jvm = chunked_callback_data->stream_cb_data->jvm;
     s_cleanup_chunked_callback_data(env, chunked_callback_data);
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT jint JNICALL Java_software_amazon_awssdk_crt_http_HttpStream_httpStreamWriteChunk(

--- a/src/native/http_request_utils.c
+++ b/src/native/http_request_utils.c
@@ -40,7 +40,7 @@ static int s_aws_input_stream_seek(struct aws_input_stream *stream, int64_t offs
             return AWS_OP_ERR;
         }
 
-        JNIEnv *env = aws_jni_get_thread_env(impl->jvm);
+        JNIEnv *env = aws_jni_acquire_thread_env(impl->jvm);
         if (env == NULL) {
             /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
             return aws_raise_error(AWS_ERROR_INVALID_STATE);
@@ -52,8 +52,9 @@ static int s_aws_input_stream_seek(struct aws_input_stream *stream, int64_t offs
         }
 
         if (aws_jni_check_and_clear_exception(env)) {
-            return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
+            result = aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
         }
+        aws_jni_release_thread_env(impl->jvm, env);
     }
 
     if (result == AWS_OP_SUCCESS) {
@@ -80,7 +81,7 @@ static int s_aws_input_stream_read(struct aws_input_stream *stream, struct aws_b
         return AWS_OP_SUCCESS;
     }
 
-    JNIEnv *env = aws_jni_get_thread_env(impl->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(impl->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
@@ -93,16 +94,19 @@ static int s_aws_input_stream_read(struct aws_input_stream *stream, struct aws_b
     impl->body_done = (*env)->CallBooleanMethod(
         env, impl->http_request_body_stream, http_request_body_stream_properties.send_outgoing_body, direct_buffer);
 
+    int result = AWS_OP_SUCCESS;
     if (aws_jni_check_and_clear_exception(env)) {
-        return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
+        result = aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
+    } else {
+        size_t amt_written = aws_jni_byte_buffer_get_position(env, direct_buffer);
+        dest->len += amt_written;
     }
-
-    size_t amt_written = aws_jni_byte_buffer_get_position(env, direct_buffer);
-    dest->len += amt_written;
 
     (*env)->DeleteLocalRef(env, direct_buffer);
 
-    return AWS_OP_SUCCESS;
+    aws_jni_release_thread_env(impl->jvm, env);
+
+    return result;
 }
 
 static int s_aws_input_stream_get_status(struct aws_input_stream *stream, struct aws_stream_status *status) {
@@ -121,7 +125,7 @@ static int s_aws_input_stream_get_length(struct aws_input_stream *stream, int64_
         AWS_CONTAINER_OF(stream, struct aws_http_request_body_stream_impl, base);
 
     if (impl->http_request_body_stream != NULL) {
-        JNIEnv *env = aws_jni_get_thread_env(impl->jvm);
+        JNIEnv *env = aws_jni_acquire_thread_env(impl->jvm);
         if (env == NULL) {
             /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
             return aws_raise_error(AWS_ERROR_INVALID_STATE);
@@ -130,17 +134,21 @@ static int s_aws_input_stream_get_length(struct aws_input_stream *stream, int64_
         *length =
             (*env)->CallLongMethod(env, impl->http_request_body_stream, http_request_body_stream_properties.get_length);
 
+        int result = AWS_OP_SUCCESS;
         if (aws_jni_check_and_clear_exception(env)) {
-            return aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
+            result = aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
         }
-        return AWS_OP_SUCCESS;
+
+        aws_jni_release_thread_env(impl->jvm, env);
+
+        return result;
     }
 
     return AWS_OP_ERR;
 }
 
 static void s_aws_input_stream_destroy(struct aws_http_request_body_stream_impl *impl) {
-    JNIEnv *env = aws_jni_get_thread_env(impl->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(impl->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -149,6 +157,8 @@ static void s_aws_input_stream_destroy(struct aws_http_request_body_stream_impl 
     if (impl->http_request_body_stream != NULL) {
         (*env)->DeleteGlobalRef(env, impl->http_request_body_stream);
     }
+
+    aws_jni_release_thread_env(impl->jvm, env);
 
     aws_mem_release(impl->allocator, impl);
 }

--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -170,7 +170,8 @@ static void s_on_connection_complete(
     struct mqtt_jni_connection *connection = connect_callback->connection;
 
     /********** JNI ENV ACQUIRE **********/
-    JNIEnv *env = aws_jni_acquire_thread_env(connection->jvm);
+    JavaVM *jvm = connection->jvm;
+    JNIEnv *env = aws_jni_acquire_thread_env(jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -191,7 +192,6 @@ static void s_on_connection_complete(
         }
     }
 
-    JavaVM *jvm = connect_callback->jvm;
     mqtt_jni_async_callback_destroy(connect_callback, env);
 
     aws_jni_release_thread_env(jvm, env);
@@ -224,6 +224,8 @@ static void s_on_connection_interrupted(
     int error_code,
     void *user_data) {
     (void)client_connection;
+
+    struct mqtt_jni_connection *connection = user_data;
 
     /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(connection->jvm);
@@ -627,7 +629,7 @@ static void s_cleanup_handler(void *user_data) {
     struct mqtt_jni_async_callback *handler = user_data;
 
     /********** JNI ENV ACQUIRE **********/
-    JavaVM *jvm = callback->connection->jvm;
+    JavaVM *jvm = handler->connection->jvm;
     JNIEnv *env = aws_jni_acquire_thread_env(jvm);
     if (env == NULL) {
         return;

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -163,6 +163,8 @@ JNIEXPORT void JNICALL
 
 static void s_on_s3_client_shutdown_complete_callback(void *user_data) {
     struct s3_client_callback_data *callback = (struct s3_client_callback_data *)user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -185,6 +187,7 @@ static void s_on_s3_client_shutdown_complete_callback(void *user_data) {
     (*env)->DeleteGlobalRef(env, callback->java_s3_client);
 
     aws_jni_release_thread_env(callback->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     aws_mem_release(aws_jni_get_allocator(), user_data);
 }
@@ -203,10 +206,11 @@ static int s_on_s3_meta_request_body_callback(
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return aws_raise_error(AWS_ERROR_INVALID_STATE);
+        return AWS_OP_ERR;
     }
 
     jobject jni_payload = aws_jni_byte_array_from_cursor(env, body);
@@ -236,6 +240,7 @@ cleanup:
     (*env)->DeleteLocalRef(env, jni_payload);
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     return return_value;
 }
@@ -249,10 +254,11 @@ static int s_on_s3_meta_request_headers_callback(
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
 
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return aws_raise_error(AWS_ERROR_INVALID_STATE);
+        return AWS_OP_ERR;
     }
 
     jobject java_headers_buffer = NULL;
@@ -304,6 +310,7 @@ cleanup:
     }
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 
     return return_value;
 }
@@ -317,6 +324,8 @@ static void s_on_s3_meta_request_finish_callback(
 
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -349,6 +358,7 @@ static void s_on_s3_meta_request_finish_callback(
     }
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 static void s_on_s3_meta_request_progress_callback(
@@ -360,6 +370,8 @@ static void s_on_s3_meta_request_progress_callback(
 
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -404,6 +416,7 @@ static void s_on_s3_meta_request_progress_callback(
 done:
 
     aws_jni_release_thread_env(callback_data->jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 static void s_s3_meta_request_callback_cleanup(
@@ -518,6 +531,8 @@ done:
 static void s_on_s3_meta_request_shutdown_complete_callback(void *user_data) {
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
+
+    /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
@@ -540,6 +555,7 @@ static void s_on_s3_meta_request_shutdown_complete_callback(void *user_data) {
     s_s3_meta_request_callback_cleanup(env, callback_data);
 
     aws_jni_release_thread_env(jvm, env);
+    /********** JNI ENV RELEASE **********/
 }
 
 JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_s3_S3MetaRequest_s3MetaRequestDestroy(

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -255,6 +255,7 @@ static int s_on_s3_meta_request_headers_callback(
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
     }
 
+    jobject java_headers_buffer = NULL;
     struct aws_allocator *allocator = aws_jni_get_allocator();
     /* calculate initial header capacity */
     size_t headers_initial_capacity = 0;
@@ -276,7 +277,7 @@ static int s_on_s3_meta_request_headers_callback(
         aws_http_headers_get_index(headers, header_index, &header);
         aws_marshal_http_headers_to_dynamic_buffer(&headers_buf, &header, 1);
     }
-    jobject java_headers_buffer = aws_jni_direct_byte_buffer_from_raw_ptr(env, headers_buf.buffer, headers_buf.len);
+    java_headers_buffer = aws_jni_direct_byte_buffer_from_raw_ptr(env, headers_buf.buffer, headers_buf.len);
 
     if (callback_data->java_s3_meta_request_response_handler_native_adapter != NULL) {
         (*env)->CallVoidMethod(

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -163,7 +163,7 @@ JNIEXPORT void JNICALL
 
 static void s_on_s3_client_shutdown_complete_callback(void *user_data) {
     struct s3_client_callback_data *callback = (struct s3_client_callback_data *)user_data;
-    JNIEnv *env = aws_jni_get_thread_env(callback->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -183,6 +183,9 @@ static void s_on_s3_client_shutdown_complete_callback(void *user_data) {
 
     // We're done with this callback data, free it.
     (*env)->DeleteGlobalRef(env, callback->java_s3_client);
+
+    aws_jni_release_thread_env(callback->jvm, env);
+
     aws_mem_release(aws_jni_get_allocator(), user_data);
 }
 
@@ -200,7 +203,7 @@ static int s_on_s3_meta_request_body_callback(
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
@@ -232,6 +235,8 @@ static int s_on_s3_meta_request_body_callback(
 cleanup:
     (*env)->DeleteLocalRef(env, jni_payload);
 
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     return return_value;
 }
 
@@ -244,7 +249,7 @@ static int s_on_s3_meta_request_headers_callback(
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
 
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return aws_raise_error(AWS_ERROR_INVALID_STATE);
@@ -263,7 +268,7 @@ static int s_on_s3_meta_request_headers_callback(
     struct aws_byte_buf headers_buf;
     AWS_ZERO_STRUCT(headers_buf);
     if (aws_byte_buf_init(&headers_buf, allocator, headers_initial_capacity)) {
-        return AWS_OP_ERR;
+        goto cleanup; /* safe since we zeroed */
     }
 
     for (size_t header_index = 0; header_index < aws_http_headers_count(headers); ++header_index) {
@@ -297,6 +302,8 @@ cleanup:
         (*env)->DeleteLocalRef(env, java_headers_buffer);
     }
 
+    aws_jni_release_thread_env(callback_data->jvm, env);
+
     return return_value;
 }
 
@@ -309,7 +316,7 @@ static void s_on_s3_meta_request_finish_callback(
 
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -339,6 +346,8 @@ static void s_on_s3_meta_request_finish_callback(
         }
         (*env)->DeleteLocalRef(env, jni_payload);
     }
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
 }
 
 static void s_on_s3_meta_request_progress_callback(
@@ -350,7 +359,7 @@ static void s_on_s3_meta_request_progress_callback(
 
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -362,7 +371,7 @@ static void s_on_s3_meta_request_progress_callback(
         s3_meta_request_progress_properties.s3_meta_request_progress_constructor_method_id);
     if ((*env)->ExceptionCheck(env) || progress_object == NULL) {
         /* progress object constructor failed, nothing to do */
-        return;
+        goto done;
     }
 
     (*env)->SetLongField(
@@ -390,6 +399,10 @@ static void s_on_s3_meta_request_progress_callback(
     }
 
     (*env)->DeleteLocalRef(env, progress_object);
+
+done:
+
+    aws_jni_release_thread_env(callback_data->jvm, env);
 }
 
 static void s_s3_meta_request_callback_cleanup(
@@ -504,7 +517,7 @@ done:
 static void s_on_s3_meta_request_shutdown_complete_callback(void *user_data) {
     struct s3_client_make_meta_request_callback_data *callback_data =
         (struct s3_client_make_meta_request_callback_data *)user_data;
-    JNIEnv *env = aws_jni_get_thread_env(callback_data->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -522,7 +535,10 @@ static void s_on_s3_meta_request_shutdown_complete_callback(void *user_data) {
     }
 
     // We're done with this callback data, free it.
+    JavaVM *jvm = callback_data->jvm;
     s_s3_meta_request_callback_cleanup(env, callback_data);
+
+    aws_jni_release_thread_env(jvm, env);
 }
 
 JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_s3_S3MetaRequest_s3MetaRequestDestroy(

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -231,6 +231,7 @@ static int s_on_s3_meta_request_body_callback(
                 AWS_LS_S3_META_REQUEST,
                 "id=%p: Ignored Exception from S3MetaRequest.onResponseBody callback",
                 (void *)meta_request);
+            aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
             goto cleanup;
         }
     }
@@ -298,6 +299,8 @@ static int s_on_s3_meta_request_headers_callback(
                 AWS_LS_S3_META_REQUEST,
                 "id=%p: Exception thrown from S3MetaRequest.onResponseHeaders callback",
                 (void *)meta_request);
+
+            aws_raise_error(AWS_ERROR_HTTP_CALLBACK_FAILURE);
             goto cleanup;
         }
     }

--- a/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
+++ b/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
@@ -56,6 +56,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
             "get_object_test_10MB.txt");
     private static final String PUT_OBJECT_KEY = System.getProperty("crt.test_s3_put_object_key", "file.upload");
     private static final String PUT_OBJECT_WITH_METADATA_KEY = System.getProperty("crt.test_s3_put_object_with_metadata_key", "file_with_metadata.upload");
+    private static final String PUT_OBJECT_WITH_METADATA_MULTIPART_KEY = System.getProperty("crt.test_s3_put_object_with_metadata_multipart_key", "file_with_metadata_multipart.upload");
 
     private static final String GET_OBJECT_SPECIAL_CHARACTERS = System.getProperty("crt.test_s3_special_characters_key",
             "filename _@_=_&_?_+_)_.txt");
@@ -705,11 +706,10 @@ public class S3NativeClientTest extends AwsClientTestFixture {
         testPutObjectWithUserDefinedMetadata(false);
     }
 
-    /*
     @Test
     public void testPutObjectWithUserDefinedMetadataMultiPart() throws Exception {
         testPutObjectWithUserDefinedMetadata(true);
-    }*/
+    }
 
     private void testPutObjectWithUserDefinedMetadata(boolean doMultipart) throws Exception {
         skipIfNetworkUnavailable();
@@ -722,6 +722,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
                         100.)) {
 
             final long contentLength = doMultipart ? MIN_PART_SIZE_5MB * 4 : 1024l;
+            final String objectKey = doMultipart ? PUT_OBJECT_WITH_METADATA_MULTIPART_KEY : PUT_OBJECT_WITH_METADATA_KEY;
             final long lengthWritten[] = { 0 };
             final String userMetadataKey = "CustomKey1";
             final String userMetadataValue = "SampleValue";
@@ -733,7 +734,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
             nativeClient.putObject(
                     PutObjectRequest.builder()
                             .bucket(BUCKET)
-                            .key(PUT_OBJECT_WITH_METADATA_KEY)
+                            .key(objectKey)
                             .contentLength(contentLength)
                             .metadata(userMetadata)
                             .build(),
@@ -747,13 +748,13 @@ public class S3NativeClientTest extends AwsClientTestFixture {
                     }).join();
 
             // wait propagation
-            waitForPropagation(nativeClient, BUCKET, PUT_OBJECT_WITH_METADATA_KEY, userMetadataKey);
+            waitForPropagation(nativeClient, BUCKET, objectKey, userMetadataKey);
 
             // get
             final long length[] = { 0 };
             final GetObjectOutput getObjectOutput = nativeClient.getObject(GetObjectRequest.builder()
                             .bucket(BUCKET)
-                            .key(PUT_OBJECT_WITH_METADATA_KEY)
+                            .key(objectKey)
                             .build(),
                     new ResponseDataConsumer<GetObjectOutput>() {
 

--- a/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
+++ b/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
@@ -65,6 +65,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
 
     private static final int DEFAULT_NUM_THREADS = 3;
     private static final int DEFAULT_MAX_HOST_ENTRIES = 8;
+    private static final long MIN_PART_SIZE_5MB = 5l * 1024l * 1024l;
 
     @BeforeClass
     public static void haveAwsCredentials() {
@@ -464,19 +465,18 @@ public class S3NativeClientTest extends AwsClientTestFixture {
     public void testPutObjectCancelHelper(CancelTestData<PutObjectOutput> testData,
             CancelRequestDataSupplier dataSupplier) {
         skipIfNetworkUnavailable();
-        final long partSize5MB = 5l * 1024l * 1024l;
 
         try (final EventLoopGroup elGroup = new EventLoopGroup(DEFAULT_NUM_THREADS);
                 final HostResolver resolver = new HostResolver(elGroup, DEFAULT_MAX_HOST_ENTRIES);
                 final ClientBootstrap clientBootstrap = new ClientBootstrap(elGroup, resolver);
                 final CredentialsProvider provider = getTestCredentialsProvider();
 
-                final S3NativeClient nativeClient = new S3NativeClient(REGION, clientBootstrap, provider, partSize5MB,
-                        100.)) {
+                final S3NativeClient nativeClient = new S3NativeClient(REGION, clientBootstrap, provider,
+                        MIN_PART_SIZE_5MB, 100.)) {
 
             CancellationException cancelException = null;
 
-            dataSupplier.setPartSize(partSize5MB);
+            dataSupplier.setPartSize(MIN_PART_SIZE_5MB);
 
             try {
                 testData.ResultFuture = nativeClient.putObject(PutObjectRequest.builder().bucket(BUCKET)
@@ -699,18 +699,28 @@ public class S3NativeClientTest extends AwsClientTestFixture {
                                 null));
     }
 
+
     @Test
-    public void testPutObjectWithUserDefinedMetadata() throws Exception {
+    public void testPutObjectWithUserDefinedMetadataSinglePart() throws Exception {
+        testPutObjectWithUserDefinedMetadata(false);
+    }
+
+    @Test
+    public void testPutObjectWithUserDefinedMetadataMultiPart() throws Exception {
+        testPutObjectWithUserDefinedMetadata(true);
+    }
+
+    private void testPutObjectWithUserDefinedMetadata(boolean doMultipart) throws Exception {
         skipIfNetworkUnavailable();
 
         try (final EventLoopGroup elGroup = new EventLoopGroup(DEFAULT_NUM_THREADS);
                 final HostResolver resolver = new HostResolver(elGroup, DEFAULT_MAX_HOST_ENTRIES);
                 final ClientBootstrap clientBootstrap = new ClientBootstrap(elGroup, resolver);
                 final CredentialsProvider provider = getTestCredentialsProvider();
-                final S3NativeClient nativeClient = new S3NativeClient(REGION, clientBootstrap, provider, 64_000_000l,
+                final S3NativeClient nativeClient = new S3NativeClient(REGION, clientBootstrap, provider, MIN_PART_SIZE_5MB,
                         100.)) {
 
-            final long contentLength = 1024l;
+            final long contentLength = doMultipart ? MIN_PART_SIZE_5MB * 4 : 1024l;
             final long lengthWritten[] = { 0 };
             final String userMetadataKey = "CustomKey1";
             final String userMetadataValue = "SampleValue";

--- a/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
+++ b/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
@@ -705,10 +705,11 @@ public class S3NativeClientTest extends AwsClientTestFixture {
         testPutObjectWithUserDefinedMetadata(false);
     }
 
+    /*
     @Test
     public void testPutObjectWithUserDefinedMetadataMultiPart() throws Exception {
         testPutObjectWithUserDefinedMetadata(true);
-    }
+    }*/
 
     private void testPutObjectWithUserDefinedMetadata(boolean doMultipart) throws Exception {
         skipIfNetworkUnavailable();

--- a/src/test/java/software/amazon/awssdk/crt/test/ShutdownTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/ShutdownTest.java
@@ -1,0 +1,43 @@
+package software.amazon.awssdk.crt.test;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import software.amazon.awssdk.crt.http.HttpClientConnection;
+import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
+import software.amazon.awssdk.crt.http.HttpClientConnectionManagerOptions;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
+
+public class ShutdownTest {
+
+    private HttpClientConnectionManager createConnectionManager(URI uri) {
+        try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
+             HostResolver resolver = new HostResolver(eventLoopGroup);
+             ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver);
+             SocketOptions sockOpts = new SocketOptions();
+             TlsContextOptions tlsOpts = TlsContextOptions.createDefaultClient();
+             TlsContext tlsContext = new TlsContext(tlsOpts)) {
+
+            HttpClientConnectionManagerOptions options = new HttpClientConnectionManagerOptions();
+            options.withClientBootstrap(bootstrap)
+                    .withSocketOptions(sockOpts)
+                    .withTlsContext(tlsContext)
+                    .withUri(uri)
+                    .withMaxConnections(1);
+
+            return HttpClientConnectionManager.create(options);
+        }
+    }
+
+    @Test
+    public void testShutdownDuringAcquire() throws Exception {
+
+        HttpClientConnectionManager manager = createConnectionManager(new URI("https://aws-crt-test-stuff.s3.amazonaws.com"));
+        CompletableFuture<HttpClientConnection> connection = manager.acquireConnection();
+    }
+}

--- a/src/test/java/software/amazon/awssdk/crt/test/ShutdownTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/ShutdownTest.java
@@ -15,6 +15,17 @@ import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 
+/*
+ A temporary test that sets up an asynchronously-acquired resource (HttpClientConnection) and then immediately
+ exits in order to try and trigger a JVM shutdown while acquisition is still outstanding in native code, checking
+ the safety of the callback if the acquisition completes after JVM shutdown and before process exit.
+
+ This is temporary and only has a chance of hitting the condition if it's the only test ran (which is why
+ we filter it with an environment variable and run it as a single test in a separate CI step).
+
+ Long term, we want to switch this to a mvn execable utility that supports triggering JVM shutdown at controllable
+ points, in the same way that the Python CRT checks sloppy shutdown.
+ */
 public class ShutdownTest {
 
     private static String SHUTDOWN_TEST_ENABLED = System.getenv("AWS_CRT_SHUTDOWN_TESTING");

--- a/src/test/java/software/amazon/awssdk/crt/test/ShutdownTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/ShutdownTest.java
@@ -2,6 +2,8 @@ package software.amazon.awssdk.crt.test;
 
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
+
+import org.junit.Assume;
 import org.junit.Test;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
@@ -14,6 +16,12 @@ import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 
 public class ShutdownTest {
+
+    private static String SHUTDOWN_TEST_ENABLED = System.getenv("AWS_CRT_SHUTDOWN_TESTING");
+
+    private static boolean doShutdownTest() {
+        return SHUTDOWN_TEST_ENABLED != null;
+    }
 
     private HttpClientConnectionManager createConnectionManager(URI uri) {
         try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
@@ -36,6 +44,7 @@ public class ShutdownTest {
 
     @Test
     public void testShutdownDuringAcquire() throws Exception {
+        Assume.assumeTrue(doShutdownTest());
 
         HttpClientConnectionManager manager = createConnectionManager(new URI("https://aws-crt-test-stuff.s3.amazonaws.com"));
         CompletableFuture<HttpClientConnection> connection = manager.acquireConnection();


### PR DESCRIPTION
* Refactors all JNIEnv usage to be within the scope of a read-write lock based on JVM status

The problem: if CRT resources are not precisely tracked and handled by a complicated ref-counting API, native CRT threads can outlive the JVM while still performing requested work.  When the native thread attempts to callback to Java in the time period between JVM shutdown and process shutdown, the cached JVM pointer is potentially garbage (it's not just a const vtable).  Dereferencing the invalid JVM pointer would lead to crashes on shutdown.

The solution: track the state of the JVM internally using the CRT's init as the introduction and a JVM shutdown hook invocation as the end of validity.  Change the JNIEnv retrieval API to use locks to guarantee that the JVM will remain valid for the duration of the JNIEnv usage.  Use a read-write lock to minimize contention and performance degradation: only CRT init and JVM shutdown ever take the writer lock, all other uses use a reader lock.  Under normal operation, performance and concurrency should not be affected other than the cost of taking an uncontested reader lock.

The multiple-JVM use case is not yet supported, but the changes here are compatible with it should it eventually be needed.
Multi-JVM support would require:
* ref-counting CRT init/shutdown
* per-JVM class/method/member id tracking (java_class_ids.h)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
