### PR TITLE
Fix S3 test logic

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/s3/CrtS3RuntimeException.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/CrtS3RuntimeException.java
@@ -77,5 +77,10 @@ public class CrtS3RuntimeException extends CrtRuntimeException {
      */
     public int getStatusCode() {
         return statusCode;
+
+    }
+    @Override
+    public String toString() {
+        return String.format("%s: response status code(%d). aws error code(%s), aws error message(%s)", super.toString(), statusCode, awsErrorCode, awsErrorMessage);
     }
 }

--- a/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
+++ b/src/test/java/com/amazonaws/s3/S3NativeClientTest.java
@@ -56,6 +56,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
             "get_object_test_10MB.txt");
     private static final String PUT_OBJECT_KEY = System.getProperty("crt.test_s3_put_object_key", "file.upload");
     private static final String PUT_OBJECT_WITH_METADATA_KEY = System.getProperty("crt.test_s3_put_object_with_metadata_key", "file_with_metadata.upload");
+    private static final String PUT_OBJECT_WITH_METADATA_MULTIPART_KEY = System.getProperty("crt.test_s3_put_object_with_metadata_multipart_key", "file_with_metadata_multipart.upload");
 
     private static final String GET_OBJECT_SPECIAL_CHARACTERS = System.getProperty("crt.test_s3_special_characters_key",
             "filename _@_=_&_?_+_)_.txt");
@@ -721,6 +722,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
                         100.)) {
 
             final long contentLength = doMultipart ? MIN_PART_SIZE_5MB * 4 : 1024l;
+            final String objectKey = doMultipart ? PUT_OBJECT_WITH_METADATA_MULTIPART_KEY : PUT_OBJECT_WITH_METADATA_KEY;
             final long lengthWritten[] = { 0 };
             final String userMetadataKey = "CustomKey1";
             final String userMetadataValue = "SampleValue";
@@ -732,7 +734,7 @@ public class S3NativeClientTest extends AwsClientTestFixture {
             nativeClient.putObject(
                     PutObjectRequest.builder()
                             .bucket(BUCKET)
-                            .key(PUT_OBJECT_WITH_METADATA_KEY)
+                            .key(objectKey)
                             .contentLength(contentLength)
                             .metadata(userMetadata)
                             .build(),
@@ -746,13 +748,13 @@ public class S3NativeClientTest extends AwsClientTestFixture {
                     }).join();
 
             // wait propagation
-            waitForPropagation(nativeClient, BUCKET, PUT_OBJECT_WITH_METADATA_KEY, userMetadataKey);
+            waitForPropagation(nativeClient, BUCKET, objectKey, userMetadataKey);
 
             // get
             final long length[] = { 0 };
             final GetObjectOutput getObjectOutput = nativeClient.getObject(GetObjectRequest.builder()
                             .bucket(BUCKET)
-                            .key(PUT_OBJECT_WITH_METADATA_KEY)
+                            .key(objectKey)
                             .build(),
                     new ResponseDataConsumer<GetObjectOutput>() {
 


### PR DESCRIPTION
- fix test logic that may not correctly wait for the file to be updated by using another key
- added more details about the s3 exception to the exception string.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
