### PR TITLE
fix content-MD5 propagation.

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/s3/S3Client.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3Client.java
@@ -113,7 +113,7 @@ public class S3Client extends CrtResource {
      ******************************************************************************/
     private static native long s3ClientNew(S3Client thisObj, byte[] region, byte[] endpoint, long clientBootstrap,
             long tlsContext, long signingConfig, long partSize, double throughputTargetGbps, int maxConnections,
-            StandardRetryOptions standardRetryOptions, Boolean computeContentMd5) throws CrtRuntimeException;
+            StandardRetryOptions standardRetryOptions, boolean computeContentMd5) throws CrtRuntimeException;
 
     private static native void s3ClientDestroy(long client);
 

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
@@ -109,12 +109,12 @@ public class S3ClientOptions {
         return maxConnections;
     }
 
-    public S3ClientOptions withComputeContentMd5(boolean computeContentMd5) {
+    public S3ClientOptions withComputeContentMd5(Boolean computeContentMd5) {
         this.computeContentMd5 = computeContentMd5;
         return this;
     }
 
-    public boolean getComputeContentMd5() {
+    public Boolean getComputeContentMd5() {
         return computeContentMd5;
     }
 

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
@@ -30,7 +30,7 @@ public class S3ClientOptions {
      *
      * Default is false;
      */
-    private Boolean computeContentMd5;
+    private boolean computeContentMd5;
     private StandardRetryOptions standardRetryOptions;
 
     public S3ClientOptions() {
@@ -109,12 +109,12 @@ public class S3ClientOptions {
         return maxConnections;
     }
 
-    public S3ClientOptions withComputeContentMd5(Boolean computeContentMd5) {
+    public S3ClientOptions withComputeContentMd5(boolean computeContentMd5) {
         this.computeContentMd5 = computeContentMd5;
         return this;
     }
 
-    public Boolean getComputeContentMd5() {
+    public boolean getComputeContentMd5() {
         return computeContentMd5;
     }
 

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3ClientOptions.java
@@ -30,7 +30,7 @@ public class S3ClientOptions {
      *
      * Default is false;
      */
-    private boolean computeContentMd5;
+    private Boolean computeContentMd5;
     private StandardRetryOptions standardRetryOptions;
 
     public S3ClientOptions() {


### PR DESCRIPTION
- `Boolean` is an object in Java, where `boolean` is the same as C bool :)
- Changed the arg that passed into C, which will not affect user

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
