### PR TITLE
Clean up .dll files on Windows

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -149,7 +149,7 @@ public final class CRT {
             }
 
             // Prefix the lib
-            String prefix = "AWSCRT_";
+            String prefix = "AWSCRT_TEST";
             String libraryName = System.mapLibraryName(CRT_LIB_NAME);
             String libraryPath = "/" + getOSIdentifier() + "/" + getArchIdentifier() + "/" + libraryName;
 

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -155,20 +155,19 @@ public final class CRT {
 
             File tempSharedLib = File.createTempFile(prefix, libraryName, tmpdirFile);
 
-			// The lib should be deleted when we're done using it.
-			// Ask Java to try and delete it on exit, we do this immediately
+			// The temp lib file should be deleted when we're done with it.
+			// Ask Java to try and delete it on exit. We call this immediately
 			// so that if anything goes wrong writing the file to disk, or
 			// loading it as a shared lib, it will still get cleaned up.
 			tempSharedLib.deleteOnExit();
 
-
-            // Unfortunately File.deleteOnExit() won't work on Windows,
-			// where files cannot be deleted while they're in use.
-            // Once our .dll is loaded, it can't be deleted by this process.
+            // Unfortunately File.deleteOnExit() won't work on Windows, where
+            // files cannot be deleted while they're in use. On Windows, once
+            // our .dll is loaded, it can't be deleted by this process.
             //
             // The Windows-only solution to this problem is to scan on startup
-            // for old instances of the .dll and try to delete them.
-            // If another process is still using the .dll, the delete will fail, which is fine.
+            // for old instances of the .dll and try to delete them. If another
+            // process is still using the .dll, the delete will fail, which is fine.
             String os = getOSIdentifier();
             if (os == "windows") {
                 try {
@@ -179,8 +178,9 @@ public final class CRT {
                     });
 
                     // Don't delete files that are too new.
-                    // We don't want to delete a lib in the millisecond between
-                    // when we've finished writing it to disk, but haven't yet loaded it.
+                    // We don't want to delete another process's lib in the
+                    // millisecond between the file being written to disk,
+                    // and the file being loaded as a shared lib.
                     long aFewSecondsAgo = System.currentTimeMillis() - 10_000; // 10sec
                     for (File oldLib : oldLibs) {
                         try {

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -154,33 +154,25 @@ public final class CRT {
             String libraryPath = "/" + getOSIdentifier() + "/" + getArchIdentifier() + "/" + libraryName;
 
             File tempSharedLib = File.createTempFile(prefix, libraryName, tmpdirFile);
+            File tempSharedTest = File.createTempFile(prefix + "test", libraryName, tmpdirFile);
 
             // open a stream to read the shared lib contents from this JAR
             try (InputStream in = CRT.class.getResourceAsStream(libraryPath)) {
-                try {
-                    if (in == null) {
-                        throw new IOException("Unable to open library in jar for AWS CRT: " + libraryPath);
-                    }
-
-                    if (tempSharedLib.exists()) {
-                        tempSharedLib.delete();
-                    }
-
-                    // Copy from jar stream to temp file
-                    try (FileOutputStream out = new FileOutputStream(tempSharedLib)) {
-                        try {
-                            int read;
-                            byte[] bytes = new byte[1024];
-                            while ((read = in.read(bytes)) != -1) {
-                                out.write(bytes, 0, read);
-                            }
-                        } finally {
-                            out.close();
-                        }
-                    }
+                if (in == null) {
+                    throw new IOException("Unable to open library in jar for AWS CRT: " + libraryPath);
                 }
-                finally{
-                    in.close();
+
+                if (tempSharedLib.exists()) {
+                    tempSharedLib.delete();
+                }
+
+                // Copy from jar stream to temp file
+                try (FileOutputStream out = new FileOutputStream(tempSharedLib)) {
+                    int read;
+                    byte [] bytes = new byte[1024];
+                    while ((read = in.read(bytes)) != -1){
+                        out.write(bytes, 0, read);
+                    }
                 }
             }
 
@@ -196,6 +188,7 @@ public final class CRT {
 
             // Ensure that the shared lib will be destroyed when java exits
             tempSharedLib.deleteOnExit();
+            tempSharedTest.deleteOnExit();
 
             // load the shared lib from the temp path
             System.load(tempSharedLib.getAbsolutePath());

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -124,6 +124,15 @@ public final class CRT {
         throw new UnknownPlatformException("AWS CRT: architecture not supported: " + arch);
     }
 
+    private static void cleanPreviousTempFiles(String path){
+        String tmpdirPath;
+        File tmpdirFile;
+        try{
+
+        }
+
+    }
+
     private static void extractAndLoadLibrary(String path) {
         try {
             // Check java.io.tmpdir
@@ -149,7 +158,7 @@ public final class CRT {
             }
 
             // Prefix the lib
-            String prefix = "AWSCRT_TEST";
+            String prefix = "AWSCRT_";
             String libraryName = System.mapLibraryName(CRT_LIB_NAME);
             String libraryPath = "/" + getOSIdentifier() + "/" + getArchIdentifier() + "/" + libraryName;
 
@@ -172,6 +181,7 @@ public final class CRT {
                     while ((read = in.read(bytes)) != -1){
                         out.write(bytes, 0, read);
                     }
+                    out.close();
                 }
             }
 

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -124,15 +124,6 @@ public final class CRT {
         throw new UnknownPlatformException("AWS CRT: architecture not supported: " + arch);
     }
 
-    private static void cleanPreviousTempFiles(String path){
-        String tmpdirPath;
-        File tmpdirFile;
-        try{
-
-        }
-
-    }
-
     private static void extractAndLoadLibrary(String path) {
         try {
             // Check java.io.tmpdir

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -157,20 +157,26 @@ public final class CRT {
 
             // open a stream to read the shared lib contents from this JAR
             try (InputStream in = CRT.class.getResourceAsStream(libraryPath)) {
-                if (in == null) {
-                    throw new IOException("Unable to open library in jar for AWS CRT: " + libraryPath);
-                }
+                try {
+                    if (in == null) {
+                        throw new IOException("Unable to open library in jar for AWS CRT: " + libraryPath);
+                    }
 
-                if (tempSharedLib.exists()) {
-                    tempSharedLib.delete();
-                }
+                    if (tempSharedLib.exists()) {
+                        tempSharedLib.delete();
+                    }
 
-                // Copy from jar stream to temp file
-                try (FileOutputStream out = new FileOutputStream(tempSharedLib)) {
-                    int read;
-                    byte [] bytes = new byte[1024];
-                    while ((read = in.read(bytes)) != -1){
-                        out.write(bytes, 0, read);
+                    // Copy from jar stream to temp file
+                    try (FileOutputStream out = new FileOutputStream(tempSharedLib)) {
+                        try {
+                            int read;
+                            byte[] bytes = new byte[1024];
+                            while ((read = in.read(bytes)) != -1) {
+                                out.write(bytes, 0, read);
+                            }
+                        } finally {
+                            out.close();
+                        }
                     }
                 }
                 finally{

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -170,7 +170,7 @@ public final class CRT {
             // for old instances of the .dll and try to delete them. If another
             // process is still using the .dll, the delete will fail, which is fine.
             String os = getOSIdentifier();
-            if (os == "windows") {
+            if (os.equals("windows")) {
                 tryDeleteOldLibrariesFromTempDir(tmpdirFile, tempSharedLibPrefix, libraryName);
             }
 

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -172,7 +172,9 @@ public final class CRT {
                     while ((read = in.read(bytes)) != -1){
                         out.write(bytes, 0, read);
                     }
-                    out.close();
+                }
+                finally{
+                    in.close();
                 }
             }
 

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -149,7 +149,7 @@ public final class CRT {
             }
 
             // Prefix the lib
-            String prefix = "AWSCRT_" + new Date().getTime();
+            String prefix = "AWSCRT_";
             String libraryName = System.mapLibraryName(CRT_LIB_NAME);
             String libraryPath = "/" + getOSIdentifier() + "/" + getArchIdentifier() + "/" + libraryName;
 


### PR DESCRIPTION
**ISSUE:** On Windows, the .dll file extracted to the temp directory was never being deleted. And repeated runs of the program were filling the disk with old .dll files.

**DIAGNOSIS:** We were using [File.deleteOnExit()](https://docs.oracle.com/javase/8/docs/api/java/io/File.html#deleteOnExit--) to clean up the shared lib, which is working OK on other platforms, but not on Windows. On Windows, files cannot be deleted while they're in use, and it appears that Java doesn't try to "unload" the .dll, so it's apparently impossible for a Java process to delete a .dll that it's using.

I did an experiment with a dead-simple JNI library. I simply loaded it, and called `File.deleteOnExit()`. That .dll didn't get deleted either. So it's not just a problem with our .dll being very complex.

**DESCRIPTION OF CHANGES:** On Windows only, during startup, scan the temp dir for old instances of `AWSCRT_*aws-crt-jni.dll` and try to delete them.

**SIDE-NOTE:**
I realized that on non-Windows platforms, the shared-lib won't be deleted on exit if Java dies suddenly (crash in C, OS terminated process, etc). But on non-Windows platforms you can delete the shared-lib from disk immediately after loading it, you don't need to wait until the process exits. I did experiments on Mac and this works. But I left it out of this PR because this is an emergency fix for windows and I don't want to introduce non-necessary changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
