### PR TITLE
Added support for value arm7l for os.arch on android

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -119,6 +119,8 @@ public final class CRT {
             return "armv8";
         } else if (arch.equals("arm")) {
             return "armv6";
+        } else if (arch.equals("armv7l")) {
+            return "armv7";
         }
 
         throw new UnknownPlatformException("AWS CRT: architecture not supported: " + arch);


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Add support value  "arm7l" of  "os.arch" java system property on android.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
