### PR TITLE
Give docs job write permissions.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   update-docs-branch:
     runs-on: ubuntu-20.04 # latest
+    permissions:
+      contents: write # allow push
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Our Github workflows no longer have write permissions by default, so be explicit here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
