### PR TITLE
Fix brew install command for cmake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requirements:
 * ninja
 * Java: Any JDK8 or above, ensure `JAVA_HOME` is set
 * Maven
-1) `brew install maven cmake3` (if you have homebrew installed, otherwise install these manually)
+1) `brew install maven cmake` (if you have homebrew installed, otherwise install these manually)
 2) `git clone https://github.com/awslabs/aws-crt-java.git`
 3) `cd aws-crt-java`
 4) `git submodule update --init --recursive`


### PR DESCRIPTION
OSX: 'brew install cmake' installs cmake 3.1+

*Issue #, if available:*

*Description of changes:*

Change `brew install cmake3` to `brew install cmake` as this is the correct command


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
