### PR TITLE
Update temp file creation

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -10,6 +10,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
 
 /**
@@ -155,7 +156,7 @@ public final class CRT {
             // Prefix the lib we'll extract to disk
             String tempSharedLibPrefix = "AWSCRT_";
 
-            File tempSharedLib = Files.createTempFile(tmpdirFile.toPath(), tempSharedLibPrefix, libraryName).toFile();
+            File tempSharedLib = Files.createTempFile(Paths.get(tmpdirFile.getPath()), tempSharedLibPrefix, libraryName).toFile();
 
 			// The temp lib file should be deleted when we're done with it.
 			// Ask Java to try and delete it on exit. We call this immediately

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -9,8 +9,6 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.*;
 
 /**
@@ -156,7 +154,8 @@ public final class CRT {
             // Prefix the lib we'll extract to disk
             String tempSharedLibPrefix = "AWSCRT_";
 
-            File tempSharedLib = Files.createTempFile(Paths.get(tmpdirFile.getPath()), tempSharedLibPrefix, libraryName).toFile();
+            File tempSharedLib = File.createTempFile(tempSharedLibPrefix, libraryName, tmpdirFile);
+            tempSharedLib.setWritable(true, true);
 
 			// The temp lib file should be deleted when we're done with it.
 			// Ask Java to try and delete it on exit. We call this immediately

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -9,6 +9,7 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -154,7 +155,7 @@ public final class CRT {
             // Prefix the lib we'll extract to disk
             String tempSharedLibPrefix = "AWSCRT_";
 
-            File tempSharedLib = File.createTempFile(tempSharedLibPrefix, libraryName, tmpdirFile);
+            File tempSharedLib = Files.createTempFile(tmpdirFile.toPath(), tempSharedLibPrefix, libraryName).toFile();
 
 			// The temp lib file should be deleted when we're done with it.
 			// Ask Java to try and delete it on exit. We call this immediately

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -155,7 +155,15 @@ public final class CRT {
             String tempSharedLibPrefix = "AWSCRT_";
 
             File tempSharedLib = File.createTempFile(tempSharedLibPrefix, libraryName, tmpdirFile);
-            tempSharedLib.setWritable(true, true);
+            if (!tempSharedLib.setExecutable(true, true)) {
+                throw new CrtRuntimeException("Unable to make shared library executable by owner only");
+            }
+            if (!tempSharedLib.setWritable(true, true)) {
+                throw new CrtRuntimeException("Unable to make shared library writeable by owner only");
+            }
+            if (!tempSharedLib.setReadable(true, true)) {
+                throw new CrtRuntimeException("Unable to make shared library readable by owner only");
+            }
 
 			// The temp lib file should be deleted when we're done with it.
 			// Ask Java to try and delete it on exit. We call this immediately
@@ -182,10 +190,6 @@ public final class CRT {
                     throw new IOException("Unable to open library in jar for AWS CRT: " + libResourcePath);
                 }
 
-                if (tempSharedLib.exists()) {
-                    tempSharedLib.delete();
-                }
-
                 // Copy from jar stream to temp file
                 try (FileOutputStream out = new FileOutputStream(tempSharedLib)) {
                     int read;
@@ -196,14 +200,8 @@ public final class CRT {
                 }
             }
 
-            if (!tempSharedLib.setExecutable(true)) {
-                throw new CrtRuntimeException("Unable to make shared library executable");
-            }
             if (!tempSharedLib.setWritable(false)) {
                 throw new CrtRuntimeException("Unable to make shared library read-only");
-            }
-            if (!tempSharedLib.setReadable(true)) {
-                throw new CrtRuntimeException("Unable to make shared library readable");
             }
 
             // load the shared lib from the temp path


### PR DESCRIPTION
- Move the change of permission before writing to the file. In case any other user changes the file before the permission set
- Restrict the read/executable only by owner (Current user)
- remove the check exiting of the tempfile, which doesn't really do anything.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
