### PR TITLE
Deprecate older PQ TlsCipherPreference Enum values

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
@@ -18,90 +18,52 @@ public enum TlsCipherPreference {
     TLS_CIPHER_SYSTEM_DEFAULT(0),
 
     /**
-     * This TlsCipherPreference contains BIKE Round 1 and SIKE Round 1 Draft Hybrid TLS Ciphers at the top of the
-     * preference list.
-     *
-     * For more info see:
-     *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
-     *   - https://aws.amazon.com/blogs/security/post-quantum-tls-now-supported-in-aws-kms/
-     *
-     * These Hybrid TLS ciphers perform two Key Exchanges (1 ECDHE + 1 Post-Quantum) during the TLS Handshake in order
-     * to combine the security of Classical ECDHE Key Exchange with the conjectured quantum-resistance of newly
-     * proposed key exchanges.
-     *
-     * The algorithms these new Post-Quantum ciphers are based on have been submitted to NIST's Post-Quantum Crypto
-     * Standardization Process, and are still under review.
-     *
-     * While these Post Quantum Hybrid TLS Ciphers are the most preferred ciphers in the preference list, classical
-     * ciphers are still present and can be negotiated if the TLS peer does not support these Hybrid TLS Ciphers.
-     *
-     * Since this Cipher Preference contains algorithms still being evaluated by NIST, it may stop being supported at
-     * any time.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
      */
+    @Deprecated
     TLS_CIPHER_KMS_PQ_TLSv1_0_2019_06(1),
 
     /**
-     * This TlsCipherPreference contains SIKE Round 1 Draft Hybrid TLS Ciphers at the top of the preference list.
-     *
-     * For more info see:
-     *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
-     *   - https://aws.amazon.com/blogs/security/post-quantum-tls-now-supported-in-aws-kms/
-     *
-     * Since this Cipher Preference contains algorithms still being evaluated by NIST, it may stop being supported at
-     * any time.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
      */
+    @Deprecated
     TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2019_11(2),
 
     /**
-     * This TlsCipherPreference contains BIKE Round 2, SIKE Round 2, BIKE Round 1, and SIKE Round 1 Draft Hybrid TLS
-     * Ciphers at the top of the preference list.
-     *
-     * For more info see:
-     *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
-     *   - https://aws.amazon.com/blogs/security/post-quantum-tls-now-supported-in-aws-kms/
-     *
-     * Since this Cipher Preference contains algorithms still being evaluated by NIST, it may stop being supported at
-     * any time.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
      */
+    @Deprecated
     TLS_CIPHER_PREF_KMS_PQ_TLSv1_0_2020_02(3),
 
     /**
-     * This TlsCipherPreference contains SIKE Round 2 and SIKE Round 1 Draft Hybrid TLS Ciphers at the top of the
-     * preference list.
-     *
-     * For more info see:
-     *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
-     *   - https://aws.amazon.com/blogs/security/post-quantum-tls-now-supported-in-aws-kms/
-     *
-     * Since this Cipher Preference contains algorithms still being evaluated by NIST, it may stop being supported at
-     * any time.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
      */
+    @Deprecated
     TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2020_02(4),
 
     /**
-     * This TlsCipherPreference contains Kyber Round 2, BIKE Round 2, SIKE Round 2, BIKE Round 1, and SIKE Round 1 Draft
-     * Hybrid TLS Ciphers at the top of the preference list.
-     *
-     * For more info see:
-     *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
-     *   - https://aws.amazon.com/blogs/security/post-quantum-tls-now-supported-in-aws-kms/
-     *
-     * Since this Cipher Preference contains algorithms still being evaluated by NIST, it may stop being supported at
-     * any time.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
      */
+    @Deprecated
     TLS_CIPHER_PREF_KMS_PQ_TLSv1_0_2020_07(5),
 
     /**
-     * This TlsCipherPreference supports TLS 1.0 through TLS 1.3, as well as supporting Kyber Round 3, Bike Round 3,
-     * and SIKE Round 3.
+     * This TlsCipherPreference supports TLS 1.0 through TLS 1.3, and contains Kyber Round 3 as its highest priority
+     * PQ algorithm. PQ algorithms in this preference list will be used in hybrid mode, and will be combined with a
+     * classical ECDHE key exchange.
+     *
+     * NIST has announced that Kyber will be first post-quantum key-agreement algorithm that it will standardize.
+     * However, the NIST standardization process might introduce minor changes that may cause the final Kyber standard
+     * to differ from the Kyber Round 3 implementation available in this preference list.
+     *
+     * Since this TlsCipherPreference contains algorithms that have not yet been officially standardized by NIST, this
+     * preference list, and any of the PQ algorithms in it, may stop being supported at any time.
      *
      * For more info see:
      *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
      *   - https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design
-     *   - https://aws.amazon.com/blogs/security/post-quantum-tls-now-supported-in-aws-kms/
-     *
-     * Since this Cipher Preference contains algorithms still being evaluated by NIST, it may stop being supported at
-     * any time.
+     *   - https://aws.amazon.com/blogs/security/how-to-tune-tls-for-hybrid-post-quantum-cryptography-with-kyber/
+     *   - https://nvlpubs.nist.gov/nistpubs/ir/2022/NIST.IR.8413.pdf
      */
     TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05(6);
 

--- a/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
@@ -129,7 +129,7 @@ public class TlsContextOptionsTest extends CrtTestFixture {
             boolean exceptionThrown = false;
 
             try {
-                options.setCipherPreference(TlsCipherPreference.TLS_CIPHER_KMS_PQ_TLSv1_0_2019_06);
+                options.setCipherPreference(TlsCipherPreference.TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05);
                 options.minTlsVersion = TlsVersions.TLSv1_2;
                 Assert.assertEquals(0, options.getNativeHandle()); // Will never get here
             } catch (IllegalArgumentException | IllegalStateException e) {


### PR DESCRIPTION
*Issue #, if available:*
Previous discussion: https://github.com/awslabs/aws-c-io/pull/497#discussion_r916153488

*Description of changes:*
Deprecates older PQ TlsCipherPreference enum values that contain older PQ algorithms that s2n will be dropping support for.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
