### PR TITLE
(Possible) Mqtt disconnect shutdown hang fix

### DIFF
--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -217,32 +217,8 @@ void aws_jni_release_thread_env(JavaVM *jvm, JNIEnv *env) {
     }
 }
 
-JNIEnv *aws_jni_shutdown_acquire_thread_env(JavaVM *jvm) {
-    /* Only will work if the JVM is shutting down, the static JVM is NULL, and the JVM pointer is not null. */
-    if (s_jvms != NULL || jvm == NULL) {
-        return NULL;
-    }
-
-    /* We use try-lock here to avoid deadlock case. See comment in aws_jni_acquire_thread_env for details */
-    if (aws_rw_lock_try_rlock(&s_jvm_table_lock)) {
-        if (aws_last_error() != AWS_ERROR_UNSUPPORTED_OPERATION) {
-            aws_raise_error(AWS_ERROR_JAVA_CRT_JVM_DESTROYED);
-        }
-        return NULL;
-    }
-
-    JNIEnv *env = s_aws_jni_get_thread_env(jvm);
-    if (env == NULL) {
-        aws_raise_error(AWS_ERROR_JAVA_CRT_JVM_DESTROYED);
-        goto error;
-    }
-
-    return env;
-
-error:
-
-    aws_rw_lock_runlock(&s_jvm_table_lock);
-    return NULL;
+bool aws_jni_is_shutdown_and_unsafe() {
+    return s_jvms == NULL;
 }
 
 void aws_jni_throw_runtime_exception(JNIEnv *env, const char *msg, ...) {

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -176,6 +176,18 @@ JNIEnv *aws_jni_acquire_thread_env(JavaVM *jvm);
 void aws_jni_release_thread_env(JavaVM *jvm, JNIEnv *env);
 
 /*******************************************************************************
+ * aws_jni_shutdown_acquire_thread_env - Acquires the JNIEnv for the current thread from the VM,
+ * attaching the env if necessary.  This function ONLY works if the JVM is shutting down, I.E the
+ * JVM shutdown hook was invoked.
+ * 
+ * It should only be used to get a thread to perform last-minute Java operations to allow
+ * a smooth shutdown, like completing promises that Java code may be waiting on.
+ * 
+ * aws_jni_release_thread_env() must be called once the caller is through with the environment.
+ ******************************************************************************/
+JNIEnv *aws_jni_shutdown_acquire_thread_env(JavaVM *jvm);
+
+/*******************************************************************************
  * aws_jni_new_crt_exception_from_error_code - Creates a new jobject from the aws
  * error code, which is the type of software/amazon/awssdk/crt/CrtRuntimeException.
  * Reference of the jobject needed to be cleaned up after use.

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -178,7 +178,7 @@ void aws_jni_release_thread_env(JavaVM *jvm, JNIEnv *env);
 /*******************************************************************************
  * Returns true if the JVM is shutdown and is no longer safe to call.
  ******************************************************************************/
-bool aws_jni_is_shutdown_and_unsafe();
+bool aws_jni_is_shutdown_and_unsafe(void);
 
 /*******************************************************************************
  * aws_jni_new_crt_exception_from_error_code - Creates a new jobject from the aws

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -176,16 +176,9 @@ JNIEnv *aws_jni_acquire_thread_env(JavaVM *jvm);
 void aws_jni_release_thread_env(JavaVM *jvm, JNIEnv *env);
 
 /*******************************************************************************
- * aws_jni_shutdown_acquire_thread_env - Acquires the JNIEnv for the current thread from the VM,
- * attaching the env if necessary.  This function ONLY works if the JVM is shutting down, I.E the
- * JVM shutdown hook was invoked.
- * 
- * It should only be used to get a thread to perform last-minute Java operations to allow
- * a smooth shutdown, like completing promises that Java code may be waiting on.
- * 
- * aws_jni_release_thread_env() must be called once the caller is through with the environment.
+ * Returns true if the JVM is shutdown and is no longer safe to call.
  ******************************************************************************/
-JNIEnv *aws_jni_shutdown_acquire_thread_env(JavaVM *jvm);
+bool aws_jni_is_shutdown_and_unsafe();
 
 /*******************************************************************************
  * aws_jni_new_crt_exception_from_error_code - Creates a new jobject from the aws

--- a/src/native/mqtt_connection.c
+++ b/src/native/mqtt_connection.c
@@ -171,8 +171,15 @@ static void s_on_connection_complete(
     JavaVM *jvm = connection->jvm;
     JNIEnv *env = aws_jni_acquire_thread_env(jvm);
     if (env == NULL) {
-        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return;
+        /*
+         * Is the JVM shutting down but not fully shut down? If so, try to get an ENV
+         * using our JVM pointer so we can continue to avoid having Java promises waiting on this connection.
+         */
+        env = aws_jni_shutdown_acquire_thread_env(jvm);
+        if (env == NULL) {
+            /* If we still cannot get an ENV, then the JVM is fully shut down. Don't crash. */
+            return;
+        }
     }
 
     jobject mqtt_connection = (*env)->NewLocalRef(env, connection->java_mqtt_connection);
@@ -228,8 +235,15 @@ static void s_on_connection_interrupted(
     /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(connection->jvm);
     if (env == NULL) {
-        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return;
+        /*
+         * Is the JVM shutting down but not fully shut down? If so, try to get an ENV
+         * using our JVM pointer so we can continue to avoid having Java promises waiting on this connection.
+         */
+        env = aws_jni_shutdown_acquire_thread_env(connection->jvm);
+        if (env == NULL) {
+            /* If we still cannot get an ENV, then the JVM is fully shut down. Don't crash. */
+            return;
+        }
     }
 
     s_on_connection_interrupted_internal(user_data, error_code, NULL, env);
@@ -251,8 +265,15 @@ static void s_on_connection_resumed(
     /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(connection->jvm);
     if (env == NULL) {
-        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return;
+        /*
+         * Is the JVM shutting down but not fully shut down? If so, try to get an ENV
+         * using our JVM pointer so we can continue to avoid having Java promises waiting on this connection.
+         */
+        env = aws_jni_shutdown_acquire_thread_env(connection->jvm);
+        if (env == NULL) {
+            /* If we still cannot get an ENV, then the JVM is fully shut down. Don't crash. */
+            return;
+        }
     }
 
     jobject mqtt_connection = (*env)->NewLocalRef(env, connection->java_mqtt_connection);
@@ -278,8 +299,15 @@ static void s_on_connection_disconnected(struct aws_mqtt_client_connection *clie
     /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(jni_connection->jvm);
     if (env == NULL) {
-        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return;
+        /*
+         * Is the JVM shutting down but not fully shut down? If so, try to get an ENV
+         * using our JVM pointer so we can continue to avoid having Java promises waiting on this connection.
+         */
+        env = aws_jni_shutdown_acquire_thread_env(jni_connection->jvm);
+        if (env == NULL) {
+            /* If we still cannot get an ENV, then the JVM is fully shut down. Don't crash. */
+            return;
+        }
     }
 
     s_on_connection_interrupted_internal(connect_callback->connection, 0, connect_callback->async_callback, env);
@@ -387,8 +415,15 @@ static void s_on_shutdown_disconnect_complete(struct aws_mqtt_client_connection 
     /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(jni_connection->jvm);
     if (env == NULL) {
-        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return;
+        /*
+         * Is the JVM shutting down but not fully shut down? If so, try to get an ENV
+         * using our JVM pointer so we can continue to avoid having Java promises waiting on this connection.
+         */
+        env = aws_jni_shutdown_acquire_thread_env(jni_connection->jvm);
+        if (env == NULL) {
+            /* If we still cannot get an ENV, then the JVM is fully shut down. Don't crash. */
+            return;
+        }
     }
 
     jobject mqtt_connection = (*env)->NewLocalRef(env, jni_connection->java_mqtt_connection);
@@ -597,7 +632,15 @@ static void s_on_op_complete(
     JavaVM *jvm = callback->connection->jvm;
     JNIEnv *env = aws_jni_acquire_thread_env(jvm);
     if (env == NULL) {
-        return;
+        /*
+         * Is the JVM shutting down but not fully shut down? If so, try to get an ENV
+         * using our JVM pointer so we can continue to avoid having Java promises waiting on this connection.
+         */
+        env = aws_jni_shutdown_acquire_thread_env(jvm);
+        if (env == NULL) {
+            /* If we still cannot get an ENV, then the JVM is fully shut down. Don't crash. */
+            return;
+        }
     }
 
     if (error_code) {
@@ -631,7 +674,15 @@ static void s_cleanup_handler(void *user_data) {
     JavaVM *jvm = handler->connection->jvm;
     JNIEnv *env = aws_jni_acquire_thread_env(jvm);
     if (env == NULL) {
-        return;
+        /*
+         * Is the JVM shutting down but not fully shut down? If so, try to get an ENV
+         * using our JVM pointer so we can continue to avoid having Java promises waiting on this connection.
+         */
+        env = aws_jni_shutdown_acquire_thread_env(jvm);
+        if (env == NULL) {
+            /* If we still cannot get an ENV, then the JVM is fully shut down. Don't crash. */
+            return;
+        }
     }
 
     s_mqtt_jni_async_callback_destroy(handler, env);
@@ -662,8 +713,15 @@ static void s_on_subscription_delivered(
     /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(callback->connection->jvm);
     if (env == NULL) {
-        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return;
+        /*
+         * Is the JVM shutting down but not fully shut down? If so, try to get an ENV
+         * using our JVM pointer so we can continue to avoid having Java promises waiting on this connection.
+         */
+        env = aws_jni_shutdown_acquire_thread_env(callback->connection->jvm);
+        if (env == NULL) {
+            /* If we still cannot get an ENV, then the JVM is fully shut down. Don't crash. */
+            return;
+        }
     }
 
     jbyteArray jni_payload = (*env)->NewByteArray(env, (jsize)payload->len);


### PR DESCRIPTION
*Description of changes:*

Adds a new function to check if the JNI layer is no longer safe to call and then checks this before trying to perform MQTT operations. This fixes a small hang on Windows in some situations where a promise is waiting to be finished but the JVM is shutting down and no longer safe to call.

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
