### PR TITLE
Add testing for `AwsSigningConfig.shouldSignHeader` callback.

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/SigningTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/SigningTest.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
@@ -128,36 +130,65 @@ public class SigningTest extends CrtTestFixture {
         return new HttpRequest(method, path, requestHeaders, badBodyStream);
     }
 
-    private boolean hasHeader(HttpRequest request, String name) {
+    private HttpHeader findHeader(HttpRequest request, String name) {
         for (HttpHeader header : request.getHeaders()) {
-            if (header.getName().equals(name)) {
-                return true;
+            if (header.getName().equalsIgnoreCase(name)) {
+                return header;
             }
         }
+        return null;
+    }
 
-        return false;
+    private boolean hasHeader(HttpRequest request, String name) {
+        return findHeader(request, name) != null;
     }
 
     private boolean hasHeaderWithValue(HttpRequest request, String name, String value) {
-        for (HttpHeader header : request.getHeaders()) {
-            if (header.getName().equals(name) && header.getValue().equals(value)) {
-                return true;
-            }
+        HttpHeader header = findHeader(request, name);
+        if (header == null) {
+            return false;
         }
 
-        return false;
+        return header.getValue().equals(value);
     }
 
     private boolean hasHeaderWithValuePrefix(HttpRequest request, String name, String valuePrefix) {
-        for (HttpHeader header : request.getHeaders()) {
-            if (header.getName().equals(name) && header.getValue().startsWith(valuePrefix)) {
+        HttpHeader header = findHeader(request, name);
+        if (header == null) {
+            return false;
+        }
+
+        return header.getValue().startsWith(valuePrefix);
+    }
+
+    private boolean isHeaderSignedByAuthHeader(HttpRequest signedRequest, String header) {
+        assertTrue(hasHeader(signedRequest, "Authorization"));
+        String authValue = findHeader(signedRequest, "Authorization").getValue();
+        Matcher signedHeadersMatcher = Pattern.compile("SignedHeaders=([^,]*)").matcher(authValue);
+        assertTrue(signedHeadersMatcher.find());
+        String signedHeadersValue = signedHeadersMatcher.group(1);
+        String[] signedHeaders = signedHeadersValue.split(";");
+        for (String signedHeader : signedHeaders) {
+            if (header.equalsIgnoreCase(signedHeader)) {
                 return true;
             }
         }
-
         return false;
     }
 
+    private boolean isHeaderSignedByQueryParams(HttpRequest signedRequest, String header) {
+        String path = signedRequest.getEncodedPath();
+        Matcher signedHeadersMatcher = Pattern.compile("X-Amz-SignedHeaders=([^&]*)").matcher(path);
+        assertTrue(signedHeadersMatcher.find());
+        String signedHeadersValue = signedHeadersMatcher.group(1);
+        String[] signedHeaders = signedHeadersValue.split("%3B");
+        for (String signedHeader : signedHeaders) {
+            if (header.equalsIgnoreCase(signedHeader)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     @Test
     public void testSigningSuccess() throws Exception {
@@ -167,8 +198,10 @@ public class SigningTest extends CrtTestFixture {
             .build();) {
 
             HttpRequest request = createSimpleRequest("https://www.example.com", "POST", "/derp", "<body>Hello</body>");
+            request.addHeader("SignMePlease", "yes oh yes");
+            request.addHeader("DoNotSignThis", "no oh no");
 
-            Predicate<String> filterParam = param -> !param.equals("bad-param");
+            Predicate<String> shouldSignHeader = name -> !name.equalsIgnoreCase("DoNotSignThis");
 
             try (AwsSigningConfig config = new AwsSigningConfig()) {
                 config.setAlgorithm(AwsSigningConfig.AwsSigningAlgorithm.SIGV4);
@@ -177,7 +210,7 @@ public class SigningTest extends CrtTestFixture {
                 config.setService("service");
                 config.setTime(System.currentTimeMillis());
                 config.setCredentialsProvider(provider);
-                config.setShouldSignHeader(filterParam);
+                config.setShouldSignHeader(shouldSignHeader);
                 config.setUseDoubleUriEncode(true);
                 config.setShouldNormalizeUriPath(true);
                 config.setSignedBodyValue(AwsSigningConfig.AwsSignedBodyValue.EMPTY_SHA256);
@@ -188,6 +221,10 @@ public class SigningTest extends CrtTestFixture {
 
                 assertTrue(hasHeader(signedRequest, "X-Amz-Date"));
                 assertTrue(hasHeader(signedRequest, "Authorization"));
+
+                // check that shouldSignHeader is working
+                assertTrue(isHeaderSignedByAuthHeader(signedRequest, "SignMePlease"));
+                assertTrue(!isHeaderSignedByAuthHeader(signedRequest, "DoNotSignThis"));
             }
         }
     }
@@ -244,6 +281,10 @@ public class SigningTest extends CrtTestFixture {
             .build();) {
 
             HttpRequest request = createSigv4TestSuiteRequest();
+            request.addHeader("SignMePlease", "yes oh yes");
+            request.addHeader("DoNotSignThis", "no oh no");
+
+            Predicate<String> shouldSignHeader = name -> !name.equalsIgnoreCase("DoNotSignThis");
 
             try (AwsSigningConfig config = new AwsSigningConfig()) {
                 config.setAlgorithm(AwsSigningConfig.AwsSigningAlgorithm.SIGV4);
@@ -252,6 +293,7 @@ public class SigningTest extends CrtTestFixture {
                 config.setService("service");
                 config.setTime(DATE_FORMAT.parse("2015-08-30T12:36:00Z").getTime());
                 config.setCredentialsProvider(provider);
+                config.setShouldSignHeader(shouldSignHeader);
                 config.setUseDoubleUriEncode(true);
                 config.setShouldNormalizeUriPath(true);
                 config.setSignedBodyValue(AwsSigningConfig.AwsSignedBodyValue.EMPTY_SHA256);
@@ -264,10 +306,14 @@ public class SigningTest extends CrtTestFixture {
                 String path = signedRequest.getEncodedPath();
 
                 assertTrue(path.contains("X-Amz-Signature="));
-                assertTrue(path.contains("X-Amz-SignedHeaders=host"));
                 assertTrue(path.contains("X-Amz-Credential=AKIDEXAMPLE%2F20150830%2F"));
                 assertTrue(path.contains("X-Amz-Algorithm=AWS4-HMAC-SHA256"));
                 assertTrue(path.contains("X-Amz-Expires=60"));
+
+
+                assertTrue(isHeaderSignedByQueryParams(signedRequest, "host"));
+                assertTrue(isHeaderSignedByQueryParams(signedRequest, "SignMePlease"));
+                assertTrue(!isHeaderSignedByQueryParams(signedRequest, "DoNotSignThis"));
             }
         }
     }


### PR DESCRIPTION
We suspected something was wrong ... but it seems to be working as expected

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
