### PR TITLE
Fix event stream server crash during shutting down

### DIFF
--- a/src/native/event_stream_rpc_server.c
+++ b/src/native/event_stream_rpc_server.c
@@ -432,17 +432,16 @@ static void s_on_connection_shutdown_fn(
     int error_code,
     void *user_data) {
 
-    struct shutdown_callback_data *shutdown_callback_data = user_data;
-
-    /********** JNI ENV ACQUIRE **********/
-    JNIEnv *env = aws_jni_acquire_thread_env(shutdown_callback_data->jvm);
-    if (env == NULL) {
-        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
-        return;
-    }
     struct connection_callback_data *callback_data = aws_event_stream_rpc_server_connection_get_user_data(connection);
     if (!callback_data) {
-        /* The connection was not setup correctly. Probably failed within s_on_new_connection_fn. Just end here. */
+        /* The connection was not setup correctly. Probably failed within s_on_new_connection_fn. Early out. */
+        return;
+    }
+
+    /********** JNI ENV ACQUIRE **********/
+    JNIEnv *env = aws_jni_acquire_thread_env(callback_data->jvm);
+    if (env == NULL) {
+        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
     }
 

--- a/src/native/event_stream_rpc_server.c
+++ b/src/native/event_stream_rpc_server.c
@@ -432,6 +432,7 @@ static void s_on_connection_shutdown_fn(
     int error_code,
     void *user_data) {
 
+    (void)user_data;
     struct connection_callback_data *callback_data = aws_event_stream_rpc_server_connection_get_user_data(connection);
     if (!callback_data) {
         /* The connection was not setup correctly. Probably failed within s_on_new_connection_fn. Early out. */


### PR DESCRIPTION
*Issue #, if available:*

- If the `on_new_connection` failed, the `connection_callback_data` will not be properly set for the connection. And the channel will start to shutdown.
- During the channel shutdown callback, `s_on_connection_shutdown_fn` will use `connection_callback_data` that was not properly setup. It leads to a crash

*Description of changes:*

- Check the `connection_callback_data` was set or not, if not, nothing needs to be cleaned up from callback, just early out

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
