### PR TITLE
Http stream binding fix

### DIFF
--- a/src/native/http2_stream_manager.c
+++ b/src/native/http2_stream_manager.c
@@ -314,7 +314,7 @@ static void s_on_stream_acquired(struct aws_http_stream *stream, int error_code,
             (*env)->ExceptionClear(env);
             aws_http_stream_binding_release(env, callback_data->stream_binding);
         } else {
-            /* Stream is activated once we acquired from the Stream Manager. Hold the refcount on the binding */
+            /* Acquire for the native stream */
             aws_http_stream_binding_acquire(callback_data->stream_binding);
             callback_data->stream_binding->java_http_stream_base = (*env)->NewGlobalRef(env, j_http_stream);
             (*env)->CallVoidMethod(

--- a/src/native/http2_stream_manager.c
+++ b/src/native/http2_stream_manager.c
@@ -380,6 +380,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_Http2StreamManager_h
         .on_response_header_block_done = aws_java_http_stream_on_incoming_header_block_done_fn,
         .on_response_body = aws_java_http_stream_on_incoming_body_fn,
         .on_complete = aws_java_http_stream_on_stream_complete_fn,
+        .on_destroy = aws_java_http_stream_on_stream_destroy_fn,
         .user_data = stream_binding,
     };
 

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -301,6 +301,10 @@ void aws_java_http_stream_on_stream_destroy_fn(void *user_data) {
 
     /********** JNI ENV ACQUIRE **********/
     JNIEnv *env = aws_jni_acquire_thread_env(binding->jvm);
+    if (env == NULL) {
+        /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
+        return;
+    }
     /* Native stream destroyed, release the binding. */
     aws_http_stream_binding_release(env, binding);
     aws_jni_release_thread_env(binding->jvm, env);
@@ -406,7 +410,7 @@ static jobject s_make_request_general(
     return jHttpStreamBase;
 
 error:
-    aws_http_stream_release(native_request);
+    aws_http_stream_release(stream_binding->native_request);
     aws_http_stream_binding_release(stream_binding, env);
     return NULL;
 }

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -410,8 +410,8 @@ static jobject s_make_request_general(
     return jHttpStreamBase;
 
 error:
-    aws_http_stream_release(stream_binding->native_request);
-    aws_http_stream_binding_release(stream_binding, env);
+    aws_http_stream_release(stream_binding->native_stream);
+    aws_http_stream_binding_release(env, stream_binding);
     return NULL;
 }
 

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -62,50 +62,65 @@ void aws_java_http_stream_from_native_delete(JNIEnv *env, jobject jHttpStream) {
 }
 
 /*******************************************************************************
- * http_stream_binding - carries around data needed by the various http request
- * callbacks.
+ * http_stream_binding - Jni native represent of the Java HTTP stream object
  ******************************************************************************/
 
-void aws_http_stream_binding_destroy(JNIEnv *env, struct http_stream_binding *callback) {
+static void s_http_stream_binding_destroy(JNIEnv *env, struct http_stream_binding *binding) {
 
-    if (callback == NULL) {
-        return;
+    if (binding->java_http_stream_base) {
+        aws_java_http_stream_from_native_delete(env, binding->java_http_stream_base);
     }
 
-    if (callback->java_http_stream_base) {
-        aws_java_http_stream_from_native_delete(env, callback->java_http_stream_base);
+    if (binding->java_http_response_stream_handler != NULL) {
+        (*env)->DeleteGlobalRef(env, binding->java_http_response_stream_handler);
     }
 
-    if (callback->java_http_response_stream_handler != NULL) {
-        (*env)->DeleteGlobalRef(env, callback->java_http_response_stream_handler);
+    if (binding->native_request) {
+        aws_http_message_release(binding->native_request);
     }
+    aws_byte_buf_clean_up(&binding->headers_buf);
+    aws_mem_release(aws_jni_get_allocator(), binding);
+}
 
-    if (callback->native_request) {
-        aws_http_message_release(callback->native_request);
+void *aws_http_stream_binding_acquire(struct http_stream_binding *binding) {
+    if (binding == NULL) {
+        return NULL;
     }
-    aws_byte_buf_clean_up(&callback->headers_buf);
-    aws_mem_release(aws_jni_get_allocator(), callback);
+    aws_atomic_fetch_add(&binding->ref, 1);
+    return binding;
+}
+
+void *aws_http_stream_binding_release(JNIEnv *env, struct http_stream_binding *binding) {
+    if (binding == NULL) {
+        return NULL;
+    }
+    size_t pre_ref = aws_atomic_fetch_sub(&binding->ref, 1);
+    AWS_ASSERT(pre_ref > 0 && "stream binding refcount has gone negative");
+    if (pre_ref == 1) {
+        s_http_stream_binding_destroy(env, binding);
+    }
+    return NULL;
 }
 
 // If error occurs, A Java exception is thrown and NULL is returned.
-struct http_stream_binding *aws_http_stream_binding_alloc(JNIEnv *env, jobject java_callback_handler) {
+struct http_stream_binding *aws_http_stream_binding_new(JNIEnv *env, jobject java_callback_handler) {
 
     struct aws_allocator *allocator = aws_jni_get_allocator();
-    struct http_stream_binding *callback = aws_mem_calloc(allocator, 1, sizeof(struct http_stream_binding));
-    AWS_FATAL_ASSERT(callback);
+    struct http_stream_binding *binding = aws_mem_calloc(allocator, 1, sizeof(struct http_stream_binding));
+    AWS_FATAL_ASSERT(binding);
 
     // GetJavaVM() reference doesn't need a NewGlobalRef() call since it's global by default
-    jint jvmresult = (*env)->GetJavaVM(env, &callback->jvm);
+    jint jvmresult = (*env)->GetJavaVM(env, &binding->jvm);
     (void)jvmresult;
     AWS_FATAL_ASSERT(jvmresult == 0);
 
-    callback->java_http_response_stream_handler = (*env)->NewGlobalRef(env, java_callback_handler);
-    AWS_FATAL_ASSERT(callback->java_http_response_stream_handler);
-    AWS_FATAL_ASSERT(!aws_byte_buf_init(&callback->headers_buf, allocator, 1024));
+    binding->java_http_response_stream_handler = (*env)->NewGlobalRef(env, java_callback_handler);
+    AWS_FATAL_ASSERT(binding->java_http_response_stream_handler);
+    AWS_FATAL_ASSERT(!aws_byte_buf_init(&binding->headers_buf, allocator, 1024));
 
-    aws_atomic_init_int(&callback->activated, 0);
+    aws_atomic_init_int(&binding->ref, 1);
 
-    return callback;
+    return binding;
 }
 
 int aws_java_http_stream_on_incoming_headers_fn(
@@ -116,7 +131,7 @@ int aws_java_http_stream_on_incoming_headers_fn(
     void *user_data) {
     (void)block_type;
 
-    struct http_stream_binding *callback = (struct http_stream_binding *)user_data;
+    struct http_stream_binding *binding = (struct http_stream_binding *)user_data;
     int resp_status = -1;
     int err_code = aws_http_stream_get_incoming_response_status(stream, &resp_status);
     if (err_code != AWS_OP_SUCCESS) {
@@ -124,9 +139,9 @@ int aws_java_http_stream_on_incoming_headers_fn(
         return AWS_OP_ERR;
     }
 
-    callback->response_status = resp_status;
+    binding->response_status = resp_status;
 
-    if (aws_marshal_http_headers_to_dynamic_buffer(&callback->headers_buf, header_array, num_headers)) {
+    if (aws_marshal_http_headers_to_dynamic_buffer(&binding->headers_buf, header_array, num_headers)) {
         AWS_LOGF_ERROR(
             AWS_LS_HTTP_STREAM, "id=%p: Failed to allocate buffer space for incoming headers", (void *)stream);
         return AWS_OP_ERR;
@@ -141,10 +156,10 @@ int aws_java_http_stream_on_incoming_header_block_done_fn(
     void *user_data) {
     (void)stream;
 
-    struct http_stream_binding *callback = (struct http_stream_binding *)user_data;
+    struct http_stream_binding *binding = (struct http_stream_binding *)user_data;
 
     /********** JNI ENV ACQUIRE **********/
-    JNIEnv *env = aws_jni_acquire_thread_env(callback->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(binding->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return AWS_OP_ERR;
@@ -154,14 +169,14 @@ int aws_java_http_stream_on_incoming_header_block_done_fn(
     jint jni_block_type = block_type;
 
     jobject jni_headers_buf =
-        aws_jni_direct_byte_buffer_from_raw_ptr(env, callback->headers_buf.buffer, callback->headers_buf.len);
+        aws_jni_direct_byte_buffer_from_raw_ptr(env, binding->headers_buf.buffer, binding->headers_buf.len);
 
     (*env)->CallVoidMethod(
         env,
-        callback->java_http_response_stream_handler,
+        binding->java_http_response_stream_handler,
         http_stream_response_handler_properties.onResponseHeaders,
-        callback->java_http_stream_base,
-        (jint)callback->response_status,
+        binding->java_http_stream_base,
+        (jint)binding->response_status,
         (jint)block_type,
         jni_headers_buf);
 
@@ -172,14 +187,14 @@ int aws_java_http_stream_on_incoming_header_block_done_fn(
     }
 
     /* instead of cleaning it up here, reset it in case another block is encountered */
-    aws_byte_buf_reset(&callback->headers_buf, false);
+    aws_byte_buf_reset(&binding->headers_buf, false);
     (*env)->DeleteLocalRef(env, jni_headers_buf);
 
     (*env)->CallVoidMethod(
         env,
-        callback->java_http_response_stream_handler,
+        binding->java_http_response_stream_handler,
         http_stream_response_handler_properties.onResponseHeadersDone,
-        callback->java_http_stream_base,
+        binding->java_http_stream_base,
         jni_block_type);
 
     if (aws_jni_check_and_clear_exception(env)) {
@@ -191,7 +206,7 @@ int aws_java_http_stream_on_incoming_header_block_done_fn(
 
 done:
 
-    aws_jni_release_thread_env(callback->jvm, env);
+    aws_jni_release_thread_env(binding->jvm, env);
     /********** JNI ENV RELEASE **********/
 
     return result;
@@ -201,12 +216,12 @@ int aws_java_http_stream_on_incoming_body_fn(
     struct aws_http_stream *stream,
     const struct aws_byte_cursor *data,
     void *user_data) {
-    struct http_stream_binding *callback = (struct http_stream_binding *)user_data;
+    struct http_stream_binding *binding = (struct http_stream_binding *)user_data;
 
     size_t total_window_increment = 0;
 
     /********** JNI ENV ACQUIRE **********/
-    JNIEnv *env = aws_jni_acquire_thread_env(callback->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(binding->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return AWS_OP_ERR;
@@ -218,9 +233,9 @@ int aws_java_http_stream_on_incoming_body_fn(
 
     jint window_increment = (*env)->CallIntMethod(
         env,
-        callback->java_http_response_stream_handler,
+        binding->java_http_response_stream_handler,
         http_stream_response_handler_properties.onResponseBody,
-        callback->java_http_stream_base,
+        binding->java_http_stream_base,
         jni_payload);
 
     (*env)->DeleteLocalRef(env, jni_payload);
@@ -247,17 +262,17 @@ int aws_java_http_stream_on_incoming_body_fn(
 
 done:
 
-    aws_jni_release_thread_env(callback->jvm, env);
+    aws_jni_release_thread_env(binding->jvm, env);
     /********** JNI ENV RELEASE **********/
 
     return result;
 }
 
 void aws_java_http_stream_on_stream_complete_fn(struct aws_http_stream *stream, int error_code, void *user_data) {
-    struct http_stream_binding *callback = (struct http_stream_binding *)user_data;
+    struct http_stream_binding *binding = (struct http_stream_binding *)user_data;
 
     /********** JNI ENV ACQUIRE **********/
-    JNIEnv *env = aws_jni_acquire_thread_env(callback->jvm);
+    JNIEnv *env = aws_jni_acquire_thread_env(binding->jvm);
     if (env == NULL) {
         /* If we can't get an environment, then the JVM is probably shutting down.  Don't crash. */
         return;
@@ -267,9 +282,9 @@ void aws_java_http_stream_on_stream_complete_fn(struct aws_http_stream *stream, 
     jint jErrorCode = error_code;
     (*env)->CallVoidMethod(
         env,
-        callback->java_http_response_stream_handler,
+        binding->java_http_response_stream_handler,
         http_stream_response_handler_properties.onResponseComplete,
-        callback->java_http_stream_base,
+        binding->java_http_stream_base,
         jErrorCode);
 
     if (aws_jni_check_and_clear_exception(env)) {
@@ -277,7 +292,9 @@ void aws_java_http_stream_on_stream_complete_fn(struct aws_http_stream *stream, 
         aws_http_connection_close(aws_http_stream_get_connection(stream));
     }
 
-    JavaVM *jvm = callback->jvm;
+    JavaVM *jvm = binding->jvm;
+    /* Release the ref on binding for native stream */
+    aws_http_stream_binding_release(env, binding);
     aws_jni_release_thread_env(jvm, env);
     /********** JNI ENV RELEASE **********/
 }
@@ -331,57 +348,57 @@ static jobject s_make_request_general(
         return (jobject)NULL;
     }
 
-    struct http_stream_binding *callback_data = aws_http_stream_binding_alloc(env, jni_http_response_callback_handler);
-    if (!callback_data) {
+    /* initial refcount created for the Java object */
+    struct http_stream_binding *stream_binding = aws_http_stream_binding_new(env, jni_http_response_callback_handler);
+    if (!stream_binding) {
         /* Exception already thrown */
         return (jobject)NULL;
     }
 
-    callback_data->native_request =
+    stream_binding->native_request =
         aws_http_request_new_from_java_http_request(env, marshalled_request, jni_http_request_body_stream);
-    if (callback_data->native_request == NULL) {
+    if (stream_binding->native_request == NULL) {
         /* Exception already thrown */
-        aws_http_stream_binding_destroy(env, callback_data);
+        aws_http_stream_binding_release(env, stream_binding);
         return (jobject)NULL;
     }
 
     struct aws_http_make_request_options request_options = {
         .self_size = sizeof(request_options),
-        .request = callback_data->native_request,
+        .request = stream_binding->native_request,
         /* Set Callbacks */
         .on_response_headers = aws_java_http_stream_on_incoming_headers_fn,
         .on_response_header_block_done = aws_java_http_stream_on_incoming_header_block_done_fn,
         .on_response_body = aws_java_http_stream_on_incoming_body_fn,
         .on_complete = aws_java_http_stream_on_stream_complete_fn,
-        .user_data = callback_data,
+        .user_data = stream_binding,
     };
 
     jobject jHttpStreamBase = NULL;
 
-    callback_data->native_stream = aws_http_connection_make_request(native_conn, &request_options);
-    if (callback_data->native_stream) {
+    stream_binding->native_stream = aws_http_connection_make_request(native_conn, &request_options);
+    if (stream_binding->native_stream) {
         AWS_LOGF_TRACE(
             AWS_LS_HTTP_CONNECTION,
             "Opened new Stream on Connection. conn: %p, stream: %p",
             (void *)native_conn,
-            (void *)callback_data->native_stream);
+            (void *)stream_binding->native_stream);
 
-        jHttpStreamBase = aws_java_http_stream_from_native_new(env, callback_data, version);
+        jHttpStreamBase = aws_java_http_stream_from_native_new(env, stream_binding, version);
     }
 
     /* Check for errors that might have occurred while holding the lock. */
-    if (!callback_data->native_stream) {
-        /* Failed to create native aws_http_stream. Clean up callback_data. */
+    if (!stream_binding->native_stream) {
+        /* Failed to create native aws_http_stream. Clean up stream_binding. */
         AWS_LOGF_ERROR(AWS_LS_HTTP_CONNECTION, "Stream Request Failed. conn: %p", (void *)native_conn);
         aws_jni_throw_runtime_exception(env, "HttpClientConnection.MakeRequest: Unable to Execute Request");
-        aws_http_stream_binding_destroy(env, callback_data);
+        aws_http_stream_binding_release(env, stream_binding);
         return NULL;
     } else if (!jHttpStreamBase) {
-        /* Failed to create java HttpStream, but did create native aws_http_stream.
-          Close connection and mark native_stream for release.
-          callback_data will clean itself up when stream completes. */
-        aws_http_connection_close(native_conn);
-        aws_http_stream_release(callback_data->native_stream);
+        /* Failed to create java HttpStream, but did create native aws_http_stream. As we never activate the native
+         * stream, we can just release the native stream, and release the binding. */
+        aws_http_stream_release(stream_binding->native_stream);
+        aws_http_stream_binding_release(env, stream_binding);
         /* Java exception has already been raised. */
         return NULL;
     }
@@ -517,12 +534,12 @@ JNIEXPORT jint JNICALL Java_software_amazon_awssdk_crt_http_HttpStream_httpStrea
 JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpStreamBase_httpStreamBaseActivate(
     JNIEnv *env,
     jclass jni_class,
-    jlong jni_cb_data,
+    jlong jni_stream_binding,
     jobject j_http_stream_base) {
     (void)jni_class;
 
-    struct http_stream_binding *cb_data = (struct http_stream_binding *)jni_cb_data;
-    struct aws_http_stream *stream = cb_data->native_stream;
+    struct http_stream_binding *binding = (struct http_stream_binding *)jni_stream_binding;
+    struct aws_http_stream *stream = binding->native_stream;
 
     if (stream == NULL) {
         aws_jni_throw_runtime_exception(env, "HttpStream is null.");
@@ -533,25 +550,27 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpStreamBase_httpS
 
     /* global ref this because now the callbacks will be firing, and they will release their reference when the
      * stream callback sequence completes. */
-    cb_data->java_http_stream_base = (*env)->NewGlobalRef(env, j_http_stream_base);
-    aws_atomic_store_int(&cb_data->activated, 1);
+    binding->java_http_stream_base = (*env)->NewGlobalRef(env, j_http_stream_base);
     if (aws_http_stream_activate(stream)) {
-        aws_atomic_store_int(&cb_data->activated, 0);
-        (*env)->DeleteGlobalRef(env, cb_data->java_http_stream_base);
+        (*env)->DeleteGlobalRef(env, binding->java_http_stream_base);
         aws_jni_throw_runtime_exception(
             env, "HttpStream activate failed with error %s\n", aws_error_str(aws_last_error()));
+    } else {
+        /* Succeed activating the stream, holding the binding to make sure it lives across all the callbacks until
+         * stream completes */
+        aws_http_stream_binding_acquire(binding);
     }
 }
 
 JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpStreamBase_httpStreamBaseRelease(
     JNIEnv *env,
     jclass jni_class,
-    jlong jni_cb_data) {
+    jlong jni_binding) {
 
     (void)jni_class;
 
-    struct http_stream_binding *cb_data = (struct http_stream_binding *)jni_cb_data;
-    struct aws_http_stream *stream = cb_data->native_stream;
+    struct http_stream_binding *binding = (struct http_stream_binding *)jni_binding;
+    struct aws_http_stream *stream = binding->native_stream;
 
     if (stream == NULL) {
         aws_jni_throw_runtime_exception(env, "HttpStream is null.");
@@ -560,21 +579,18 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpStreamBase_httpS
     AWS_LOGF_TRACE(AWS_LS_HTTP_STREAM, "Releasing Stream. stream: %p", (void *)stream);
     aws_http_stream_release(stream);
 
-    size_t not_activated = 0;
-    if (aws_atomic_compare_exchange_int(&cb_data->activated, &not_activated, 1)) {
-        aws_http_stream_binding_destroy(env, cb_data);
-    }
+    aws_http_stream_binding_release(env, binding);
 }
 
 JNIEXPORT jint JNICALL Java_software_amazon_awssdk_crt_http_HttpStreamBase_httpStreamBaseGetResponseStatusCode(
     JNIEnv *env,
     jclass jni_class,
-    jlong jni_cb_data) {
+    jlong jni_binding) {
 
     (void)jni_class;
 
-    struct http_stream_binding *cb_data = (struct http_stream_binding *)jni_cb_data;
-    struct aws_http_stream *stream = cb_data->native_stream;
+    struct http_stream_binding *binding = (struct http_stream_binding *)jni_binding;
+    struct aws_http_stream *stream = binding->native_stream;
 
     if (stream == NULL) {
         aws_jni_throw_runtime_exception(env, "HttpStream is null.");
@@ -595,13 +611,13 @@ JNIEXPORT jint JNICALL Java_software_amazon_awssdk_crt_http_HttpStreamBase_httpS
 JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpStreamBase_httpStreamBaseIncrementWindow(
     JNIEnv *env,
     jclass jni_class,
-    jlong jni_cb_data,
+    jlong jni_binding,
     jint window_update) {
 
     (void)jni_class;
 
-    struct http_stream_binding *cb_data = (struct http_stream_binding *)jni_cb_data;
-    struct aws_http_stream *stream = cb_data->native_stream;
+    struct http_stream_binding *binding = (struct http_stream_binding *)jni_binding;
+    struct aws_http_stream *stream = binding->native_stream;
 
     if (stream == NULL) {
         aws_jni_throw_runtime_exception(env, "HttpStream is null.");
@@ -626,8 +642,8 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_Http2Stream_http2Str
 
     (void)jni_class;
 
-    struct http_stream_binding *cb_data = (struct http_stream_binding *)jni_cb_data;
-    struct aws_http_stream *stream = cb_data->native_stream;
+    struct http_stream_binding *binding = (struct http_stream_binding *)jni_cb_data;
+    struct aws_http_stream *stream = binding->native_stream;
 
     if (stream == NULL) {
         aws_jni_throw_null_pointer_exception(env, "Http2Stream is null.");

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -278,7 +278,6 @@ void aws_java_http_stream_on_stream_complete_fn(struct aws_http_stream *stream, 
     }
 
     JavaVM *jvm = callback->jvm;
-    aws_http_stream_binding_destroy(env, callback);
     aws_jni_release_thread_env(jvm, env);
     /********** JNI ENV RELEASE **********/
 }

--- a/src/native/http_request_response.h
+++ b/src/native/http_request_response.h
@@ -27,19 +27,18 @@ struct http_stream_binding {
     struct aws_byte_buf headers_buf;
     int response_status;
 
-    /*
-     * Inactivated streams must have their callback data destroyed at release time
-     */
-    struct aws_atomic_var activated;
+    /* For the native http stream and the Java stream object */
+    struct aws_atomic_var ref;
 };
 
 jobject aws_java_http_stream_from_native_new(JNIEnv *env, void *opaque, int version);
 void aws_java_http_stream_from_native_delete(JNIEnv *env, jobject jHttpStream);
 
-void aws_http_stream_binding_destroy(JNIEnv *env, struct http_stream_binding *callback);
+void *aws_http_stream_binding_release(JNIEnv *env, struct http_stream_binding *binding);
+void *aws_http_stream_binding_acquire(struct http_stream_binding *binding);
 
 // If error occurs, A Java exception is thrown and NULL is returned.
-struct http_stream_binding *aws_http_stream_binding_alloc(JNIEnv *env, jobject java_callback_handler);
+struct http_stream_binding *aws_http_stream_binding_new(JNIEnv *env, jobject java_callback_handler);
 
 /* Default callbacks using binding */
 int aws_java_http_stream_on_incoming_headers_fn(

--- a/src/native/http_request_response.h
+++ b/src/native/http_request_response.h
@@ -56,5 +56,6 @@ int aws_java_http_stream_on_incoming_body_fn(
     const struct aws_byte_cursor *data,
     void *user_data);
 void aws_java_http_stream_on_stream_complete_fn(struct aws_http_stream *stream, int error_code, void *user_data);
+void aws_java_http_stream_on_stream_destroy_fn(void *user_data);
 
 #endif /* AWS_JNI_CRT_HTTP_REQUEST_RESPONSE_H */

--- a/src/test/java/software/amazon/awssdk/crt/test/Elasticurl.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Elasticurl.java
@@ -334,12 +334,13 @@ public class Elasticurl {
                             }
                         };
                         HttpRequestBase request = buildHttpRequest(cli, conn.getVersion(), uri);
-                        HttpStreamBase stream = conn.makeRequest(request, streamHandler);
-                        stream.activate();
+                        try (HttpStreamBase stream = conn.makeRequest(request, streamHandler)) {
+                            stream.activate();
 
-                        // Give the request up to 60 seconds to complete, otherwise throw a
-                        // TimeoutException
-                        reqCompleted.get(60, TimeUnit.SECONDS);
+                            // Give the request up to 60 seconds to complete, otherwise throw a
+                            // TimeoutException
+                            reqCompleted.get(60, TimeUnit.SECONDS);
+                        }
                     }
                 } catch (Exception e) {
                     throw new RuntimeException(e);

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -198,9 +198,10 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
                     }
                 };
                 Http2Request request = getHttp2Request("GET", HOST, "/get", EMPTY_BODY);
-                Http2Stream h2Stream = conn.makeRequest(request, streamHandler);
-                h2Stream.activate();
-                streamComplete.get();
+                try (Http2Stream h2Stream = conn.makeRequest(request, streamHandler)) {
+                    h2Stream.activate();
+                    streamComplete.get();
+                }
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2StreamManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2StreamManagerTest.java
@@ -168,7 +168,6 @@ public class Http2StreamManagerTest extends HttpClientTestFixture {
         skipIfNetworkUnavailable();
         Callable<Void> fn = () -> {
             testParallelRequests(numThreads, numRequests);
-            Thread.sleep(2000); // wait for async shutdowns to complete
             return null;
         };
 

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -163,7 +163,6 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
         skipIfNetworkUnavailable();
         Callable<Void> fn = () -> {
             testParallelRequests(numThreads, numRequests);
-            Thread.sleep(2000); // wait for async shutdowns to complete
             return null;
         };
 

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseFixture.java
@@ -130,7 +130,6 @@ public class HttpRequestResponseFixture extends HttpClientTestFixture {
                     public void onResponseComplete(HttpStreamBase stream, int errorCode) {
                         response.onCompleteErrorCode = errorCode;
                         reqCompleted.complete(null);
-                        stream.close();
                     }
                 };
                 HttpStreamBase stream = conn.makeRequest(request, streamHandler);
@@ -143,6 +142,7 @@ public class HttpRequestResponseFixture extends HttpClientTestFixture {
                 // Give the request up to 60 seconds to complete, otherwise throw a
                 // TimeoutException
                 reqCompleted.get(60, TimeUnit.SECONDS);
+                stream.close();
             }
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
*Issue #, if available:*
- We destroy the HTTP stream jni binding from complete callback of the stream. However the Java Stream object is still alive from Java, and when it gets GCed from Java, it will access the jni binding again and lead to a crash.

*Description of changes:*
- Refcount the binidng as it needs to be kept alive for both the java object and the native stream callbacks.

~TODO: That's not the only structure that has the issue. We need to go through the whole code base and check for any place that has the similar issue.~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
