### PR TITLE
Added support for value armv7 for os.arch on android

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -121,6 +121,8 @@ public final class CRT {
             return "armv8";
         } else if (arch.equals("arm")) {
             return "armv6";
+        } else if (arch.equals("armv7l")) {
+            return "armv7";
         }
 
         throw new UnknownPlatformException("AWS CRT: architecture not supported: " + arch);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-java/issues/535

*Description of changes:*
Add case of "armv7l" for architecture when CRT run on 32 ARM CPUs of Android

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
