### PR TITLE
Added necessary Counters to the http connection manager for metrics emision in java sdk-v2's HTTP SPI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 
 dependencies {
     testImplementation("junit:junit:4.13.2")
+    testImplementation("commons-cli:commons-cli:1.5.0")
     testImplementation("org.mockito:mockito-core:3.11.2")
 }
 

--- a/src/main/java/software/amazon/awssdk/crt/http/Http2StreamManager.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2StreamManager.java
@@ -11,7 +11,6 @@ import software.amazon.awssdk.crt.io.TlsContext;
 import java.util.concurrent.CompletableFuture;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Manages a Pool of HTTP/2 Streams. Creates and manages HTTP/2 connections

--- a/src/main/java/software/amazon/awssdk/crt/http/Http2StreamManager.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2StreamManager.java
@@ -186,13 +186,6 @@ public class Http2StreamManager extends CrtResource {
     }
 
     /**
-     * @return max possible concurrency. This is maxConnections * maxStreams
-     */
-    public int getMaxConcurrency() {
-        return this.maxConnections * this.maxConcurrentStreamsPerConnection;
-    }
-
-    /**
      * @return concurrency metrics for the current manager
      */
     public HttpManagerMetrics getManagerMetrics() {

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnectionManager.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnectionManager.java
@@ -162,6 +162,14 @@ public class HttpClientConnectionManager extends CrtResource {
                 returnedFuture.complete(connection);
             }
         });
+
+        // Chain the cancel call on the returned future so the future passed to JNI actually gets
+        // canceled upon the user canceling.
+        returnedFuture.whenComplete((connection, error) -> {
+            if (returnedFuture.isCancelled()) {
+                thumpFuture.cancel(false);
+            }
+        });
         httpClientConnectionManagerAcquireConnection(this.getNativeHandle(), thumpFuture);
         return returnedFuture;
     }

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpManagerMetrics.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpManagerMetrics.java
@@ -3,16 +3,18 @@ package software.amazon.awssdk.crt.http;
 public class HttpManagerMetrics {
     private final long availableConcurrency;
     private final long pendingConcurrencyAcquires;
+    private final long leasedConcurrency;
 
-    HttpManagerMetrics(long availableConcurrency, long pendingConcurrencyAcquires) {
+    HttpManagerMetrics(long availableConcurrency, long pendingConcurrencyAcquires, long leasedConcurrency) {
         this.availableConcurrency = availableConcurrency;
         this.pendingConcurrencyAcquires = pendingConcurrencyAcquires;
+        this.leasedConcurrency = leasedConcurrency;
     }
 
     /**
      * @return The number of additional concurrent requests that can be supported by the HTTP manager without needing to
      * establish additional connections to the target server.
-     *
+     * <p>
      * For connection manager, this value represents idle connections.
      * For stream manager, this value represents the number of streams that are possible to be made without creating new
      * connections, although the implementation can create new connection without fully filling it.
@@ -26,5 +28,13 @@ public class HttpManagerMetrics {
      */
     public long getPendingConcurrencyAcquires() {
         return pendingConcurrencyAcquires;
+    }
+
+    /**
+     * @return the amount of concurrency units currently out for lease. For http 1.1 this will be connections while
+     * for http2 this will be number of streams leased out.
+     */
+    public long getLeasedConcurrency() {
+        return this.leasedConcurrency;
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpManagerMetrics.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpManagerMetrics.java
@@ -10,19 +10,19 @@ public class HttpManagerMetrics {
     }
 
     /**
-     * The number of additional concurrent requests that can be supported by the HTTP manager without needing to
+     * @return The number of additional concurrent requests that can be supported by the HTTP manager without needing to
      * establish additional connections to the target server.
      *
-     * For connection manager, it equals to connections that's idle.
-     * For stream manager, it equals to the number of streams that are possible to be made without creating new
-     * connection, although the implementation can create new connection without fully filling it.
+     * For connection manager, this value represents idle connections.
+     * For stream manager, this value represents the number of streams that are possible to be made without creating new
+     * connections, although the implementation can create new connection without fully filling it.
      */
     public long getAvailableConcurrency() {
         return availableConcurrency;
     }
 
     /**
-     * The number of requests that are awaiting concurrency to be made available from the HTTP manager.
+     * @return The number of requests that are awaiting concurrency to be made available from the HTTP manager.
      */
     public long getPendingConcurrencyAcquires() {
         return pendingConcurrencyAcquires;

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpManagerMetrics.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpManagerMetrics.java
@@ -1,0 +1,30 @@
+package software.amazon.awssdk.crt.http;
+
+public class HttpManagerMetrics {
+    private final long availableConcurrency;
+    private final long pendingConcurrencyAcquires;
+
+    HttpManagerMetrics(long availableConcurrency, long pendingConcurrencyAcquires) {
+        this.availableConcurrency = availableConcurrency;
+        this.pendingConcurrencyAcquires = pendingConcurrencyAcquires;
+    }
+
+    /**
+     * The number of additional concurrent requests that can be supported by the HTTP manager without needing to
+     * establish additional connections to the target server.
+     *
+     * For connection manager, it equals to connections that's idle.
+     * For stream manager, it equals to the number of streams that are possible to be made without creating new
+     * connection, although the implementation can create new connection without fully filling it.
+     */
+    public long getAvailableConcurrency() {
+        return availableConcurrency;
+    }
+
+    /**
+     * The number of requests that are awaiting concurrency to be made available from the HTTP manager.
+     */
+    public long getPendingConcurrencyAcquires() {
+        return pendingConcurrencyAcquires;
+    }
+}

--- a/src/native/http2_stream_manager.c
+++ b/src/native/http2_stream_manager.c
@@ -314,6 +314,7 @@ static void s_on_stream_acquired(struct aws_http_stream *stream, int error_code,
     } else {
         /* Acquire for the native stream. The destroy callback for native stream will release the ref. */
         aws_http_stream_binding_acquire(callback_data->stream_binding);
+
         callback_data->stream_binding->native_stream = stream;
         jobject j_http_stream =
             aws_java_http_stream_from_native_new(env, callback_data->stream_binding, AWS_HTTP_VERSION_2);
@@ -448,5 +449,6 @@ JNIEXPORT jobject JNICALL Java_software_amazon_awssdk_crt_http_Http2StreamManage
         http_manager_metrics_properties.http_manager_metrics_class,
         http_manager_metrics_properties.constructor_method_id,
         (jlong)metrics.available_concurrency,
-        (jlong)metrics.pending_concurrency_acquires);
+        (jlong)metrics.pending_concurrency_acquires,
+        (jlong)metrics.leased_concurrency);
 }

--- a/src/native/http2_stream_manager.c
+++ b/src/native/http2_stream_manager.c
@@ -22,6 +22,7 @@
 #include <aws/io/tls_channel_handler.h>
 
 #include <aws/http/connection.h>
+#include <aws/http/connection_manager.h>
 #include <aws/http/http.h>
 #include <aws/http/http2_stream_manager.h>
 #include <aws/http/proxy.h>
@@ -423,4 +424,29 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_Http2StreamManager_h
 
     AWS_LOGF_DEBUG(AWS_LS_HTTP_CONNECTION, "Releasing StreamManager: id: %p", (void *)stream_manager);
     aws_http2_stream_manager_release(stream_manager);
+}
+
+JNIEXPORT jobject JNICALL Java_software_amazon_awssdk_crt_http_Http2StreamManager_http2StreamManagerFetchMetrics(
+    JNIEnv *env,
+    jclass jni_class,
+    jlong jni_stream_manager) {
+    (void)jni_class;
+
+    struct aws_http2_stream_manager_binding *sm_binding = (struct aws_http2_stream_manager_binding *)jni_stream_manager;
+    struct aws_http2_stream_manager *stream_manager = sm_binding->stream_manager;
+
+    if (!stream_manager) {
+        aws_jni_throw_runtime_exception(env, "Stream Manager can't be null");
+        return NULL;
+    }
+
+    struct aws_http_manager_metrics metrics;
+    aws_http2_stream_manager_fetch_metrics(stream_manager, &metrics);
+
+    return (*env)->NewObject(
+        env,
+        http_manager_metrics_properties.http_manager_metrics_class,
+        http_manager_metrics_properties.constructor_method_id,
+        (jlong)metrics.available_concurrency,
+        (jlong)metrics.pending_concurrency_acquires);
 }

--- a/src/native/http_connection_manager.c
+++ b/src/native/http_connection_manager.c
@@ -484,7 +484,8 @@ JNIEXPORT jobject JNICALL
         http_manager_metrics_properties.http_manager_metrics_class,
         http_manager_metrics_properties.constructor_method_id,
         (jlong)metrics.available_concurrency,
-        (jlong)metrics.pending_concurrency_acquires);
+        (jlong)metrics.pending_concurrency_acquires,
+        (jlong)metrics.leased_concurrency);
 }
 
 #if UINTPTR_MAX == 0xffffffff

--- a/src/native/http_connection_manager.c
+++ b/src/native/http_connection_manager.c
@@ -461,7 +461,10 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnection
 }
 
 JNIEXPORT jobject JNICALL
-    Java_software_amazon_awssdk_crt_http_HttpClientConnectionManager_httpConnectionManagerFetchMetrics(JNIEnv *env, jclass jni_class, jlong jni_conn_manager_binding) {
+    Java_software_amazon_awssdk_crt_http_HttpClientConnectionManager_httpConnectionManagerFetchMetrics(
+        JNIEnv *env,
+        jclass jni_class,
+        jlong jni_conn_manager_binding) {
     (void)jni_class;
 
     struct http_connection_manager_binding *manager_binding =
@@ -476,7 +479,12 @@ JNIEXPORT jobject JNICALL
     struct aws_http_manager_metrics metrics;
     aws_http_connection_manager_fetch_metrics(conn_manager, &metrics);
 
-    return (*env)->NewObject(env, http_manager_metrics_properties.http_manager_metrics_class, http_manager_metrics_properties.constructor_method_id, (jlong)metrics.available_concurrency, (jlong)metrics.pending_concurrency_acquires);
+    return (*env)->NewObject(
+        env,
+        http_manager_metrics_properties.http_manager_metrics_class,
+        http_manager_metrics_properties.constructor_method_id,
+        (jlong)metrics.available_concurrency,
+        (jlong)metrics.pending_concurrency_acquires);
 }
 
 #if UINTPTR_MAX == 0xffffffff

--- a/src/native/http_connection_manager.c
+++ b/src/native/http_connection_manager.c
@@ -460,6 +460,25 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnection
     s_destroy_connection_binding(binding, env);
 }
 
+JNIEXPORT jobject JNICALL
+    Java_software_amazon_awssdk_crt_http_HttpClientConnectionManager_httpConnectionManagerFetchMetrics(JNIEnv *env, jclass jni_class, jlong jni_conn_manager_binding) {
+    (void)jni_class;
+
+    struct http_connection_manager_binding *manager_binding =
+        (struct http_connection_manager_binding *)jni_conn_manager_binding;
+    struct aws_http_connection_manager *conn_manager = manager_binding->manager;
+
+    if (!conn_manager) {
+        aws_jni_throw_runtime_exception(env, "Connection Manager can't be null");
+        return NULL;
+    }
+
+    struct aws_http_manager_metrics metrics;
+    aws_http_connection_manager_fetch_metrics(conn_manager, &metrics);
+
+    return (*env)->NewObject(env, http_manager_metrics_properties.http_manager_metrics_class, http_manager_metrics_properties.constructor_method_id, (jlong)metrics.available_concurrency, (jlong)metrics.pending_concurrency_acquires);
+}
+
 #if UINTPTR_MAX == 0xffffffff
 #    if defined(_MSC_VER)
 #        pragma warning(pop)

--- a/src/native/http_request_response.h
+++ b/src/native/http_request_response.h
@@ -13,7 +13,6 @@ struct aws_http_message;
 struct aws_http_stream;
 struct aws_byte_buf;
 struct aws_atomic_var;
-struct aws_http2_stream_manager;
 
 struct http_stream_binding {
     JavaVM *jvm;

--- a/src/native/http_request_response.h
+++ b/src/native/http_request_response.h
@@ -13,6 +13,7 @@ struct aws_http_message;
 struct aws_http_stream;
 struct aws_byte_buf;
 struct aws_atomic_var;
+struct aws_http2_stream_manager;
 
 struct http_stream_binding {
     JavaVM *jvm;
@@ -26,7 +27,6 @@ struct http_stream_binding {
     struct aws_http_stream *native_stream;
     struct aws_byte_buf headers_buf;
     int response_status;
-
     /* For the native http stream and the Java stream object */
     struct aws_atomic_var ref;
 };

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -749,6 +749,16 @@ static void s_cache_http_header(JNIEnv *env) {
     AWS_FATAL_ASSERT(http_header_properties.constructor_method_id);
 }
 
+struct java_http_manager_metrics_properties http_manager_metrics_properties;
+static void s_cache_http_manager_metrics(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/http/HttpManagerMetrics");
+    AWS_FATAL_ASSERT(cls);
+    http_manager_metrics_properties.http_manager_metrics_class = (*env)->NewGlobalRef(env, cls);
+
+    http_manager_metrics_properties.constructor_method_id = (*env)->GetMethodID(env, cls, "<init>", "(JJ)V");
+    AWS_FATAL_ASSERT(http_manager_metrics_properties.constructor_method_id);
+}
+
 struct java_aws_exponential_backoff_retry_options_properties exponential_backoff_retry_options_properties;
 
 static void s_cache_exponential_backoff_retry_options(JNIEnv *env) {
@@ -916,6 +926,7 @@ void cache_java_class_ids(JNIEnv *env) {
     s_cache_crt(env);
     s_cache_aws_signing_result(env);
     s_cache_http_header(env);
+    s_cache_http_manager_metrics(env);
     s_cache_exponential_backoff_retry_options(env);
     s_cache_standard_retry_options(env);
     s_cache_directory_traversal_handler(env);

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -755,7 +755,7 @@ static void s_cache_http_manager_metrics(JNIEnv *env) {
     AWS_FATAL_ASSERT(cls);
     http_manager_metrics_properties.http_manager_metrics_class = (*env)->NewGlobalRef(env, cls);
 
-    http_manager_metrics_properties.constructor_method_id = (*env)->GetMethodID(env, cls, "<init>", "(JJ)V");
+    http_manager_metrics_properties.constructor_method_id = (*env)->GetMethodID(env, cls, "<init>", "(JJJ)V");
     AWS_FATAL_ASSERT(http_manager_metrics_properties.constructor_method_id);
 }
 

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -352,6 +352,13 @@ struct java_http_header_properties {
 };
 extern struct java_http_header_properties http_header_properties;
 
+/* HtppConnectionManagerMetrics */
+struct java_http_manager_metrics_properties {
+    jclass http_manager_metrics_class;
+    jmethodID constructor_method_id;
+};
+extern struct java_http_manager_metrics_properties http_manager_metrics_properties;
+
 /* ExponentialBackoffRetryOptions */
 struct java_aws_exponential_backoff_retry_options_properties {
     jclass exponential_backoff_retry_options_class;

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2StreamManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2StreamManagerTest.java
@@ -107,6 +107,10 @@ public class Http2StreamManagerTest extends HttpClientTestFixture {
             threadPool.execute(() -> {
                 // Request a connection from the connection pool
                 int requestId = numRequestsMade.incrementAndGet();
+                // put the calls here. We already know it works, and we really just want to make sure the JNI calls don't
+                // explode.
+                streamManager.getPendingStreamAcquisitions();
+                streamManager.getAvailableStreams();
                 streamManager.acquireStream(request, new HttpStreamBaseResponseHandler() {
                     @Override
                     public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2StreamManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2StreamManagerTest.java
@@ -260,6 +260,13 @@ public class Http2StreamManagerTest extends HttpClientTestFixture {
             Assert.assertEquals(1, metrics.getPendingConcurrencyAcquires());
             // should still be 0
             Assert.assertEquals(0, metrics.getAvailableConcurrency());
+
+            Http2Stream stream = streamFuture.get();
+            stream.close();
+
+            for (Http2Stream h2Stream: receivedStreams) {
+                h2Stream.close();
+            }
         }
 
         CrtResource.logNativeResources();

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -101,11 +101,7 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
                         .whenComplete((conn, throwable) -> {
                             if (throwable != null) {
                                 numConnectionFailures.incrementAndGet();
-                                // this next line should be completely impossible to be valid.
-                                // but this test AFAIK hasn't segfaulted and there's no way
-                                // a connection setup has never failed. Conn should always be null though.
-                                // commenting out for now.
-                                //connPool.releaseConnection(conn);
+                                connPool.releaseConnection(conn);
                                 requestCompleteFuture.completeExceptionally(throwable);
                             }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -204,7 +204,7 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
 
         try (HttpClientConnectionManager connectionPool = createConnectionManager(uri, 1, maxConns)) {
             Assert.assertEquals(maxConns, connectionPool.getMaxConnections());
-            Assert.assertEquals(3, connectionPool.getAvailableConnections());
+            Assert.assertEquals(0, connectionPool.getAvailableConnections());
             Assert.assertEquals(0, connectionPool.getLeasedConnections());
             Assert.assertEquals(0, connectionPool.getPendingConnectionAcquisitions());
 
@@ -212,12 +212,12 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
             int giveUpCtr = 99;
 
             while(receivedClientConnections.size() < maxConns && giveUpCtr-- > 0) {
-                    CompletableFuture<HttpClientConnection> connectionAcquire = connectionPool.acquireConnection();
-                    try {
-                        HttpClientConnection connection = connectionAcquire.get(3, TimeUnit.SECONDS);
-                        receivedClientConnections.add(connection);
-                    } catch (CrtRuntimeException ignored) {
-                    }
+                CompletableFuture<HttpClientConnection> connectionAcquire = connectionPool.acquireConnection();
+                try {
+                    HttpClientConnection connection = connectionAcquire.get(3, TimeUnit.SECONDS);
+                    receivedClientConnections.add(connection);
+                } catch (CrtRuntimeException ignored) {
+                }
             }
 
             if (giveUpCtr < 0) {

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -241,12 +241,12 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
             HttpClientConnection conn = receivedClientConnections.remove(0);
             connectionPool.releaseConnection(conn);
 
-            connectionAcquire.get(3, TimeUnit.SECONDS);
+            conn = connectionAcquire.get(3, TimeUnit.SECONDS);
+
             Assert.assertEquals(3, connectionPool.getLeasedConnections());
             Assert.assertEquals(0, connectionPool.getAvailableConnections());
             Assert.assertEquals(0, connectionPool.getPendingConnectionAcquisitions());
 
-            conn = receivedClientConnections.remove(0);
             connectionPool.releaseConnection(conn);
             Assert.assertEquals(2, connectionPool.getLeasedConnections());
             Assert.assertEquals(1, connectionPool.getAvailableConnections());

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -311,7 +311,7 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
             firstConnection.close();
 
             // should succeed, will timeout if the second acquisition doesn't return the unused/abandoned conn to the pool
-            HttpClientConnection conn = thirdAcquisition.get(500, TimeUnit.SECONDS);
+            HttpClientConnection conn = thirdAcquisition.get(500, TimeUnit.MILLISECONDS);
             conn.close();
         }
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -311,7 +311,7 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
             firstConnection.close();
 
             // should succeed, will timeout if the second acquisition doesn't return the unused/abandoned conn to the pool
-            HttpClientConnection conn = thirdAcquisition.get(500, TimeUnit.MILLISECONDS);
+            HttpClientConnection conn = thirdAcquisition.get(500, TimeUnit.SECONDS);
             conn.close();
         }
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -101,7 +101,11 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
                         .whenComplete((conn, throwable) -> {
                             if (throwable != null) {
                                 numConnectionFailures.incrementAndGet();
-                                connPool.releaseConnection(conn);
+                                // this next line should be completely impossible to be valid.
+                                // but this test AFAIK hasn't segfaulted and there's no way
+                                // a connection setup has never failed. Conn should always be null though.
+                                // commenting out for now.
+                                //connPool.releaseConnection(conn);
                                 requestCompleteFuture.completeExceptionally(throwable);
                             }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionManagerTest.java
@@ -1,6 +1,7 @@
 package software.amazon.awssdk.crt.test;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import org.junit.Assume;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
 import software.amazon.awssdk.crt.http.HttpClientConnectionManagerOptions;
@@ -99,7 +101,11 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
                         .whenComplete((conn, throwable) -> {
                             if (throwable != null) {
                                 numConnectionFailures.incrementAndGet();
-                                connPool.releaseConnection(conn);
+                                // this next line should be completely impossible to be valid.
+                                // but this test AFAIK hasn't segfaulted and there's no way
+                                // a connection setup has never failed. Conn should always be null though.
+                                // commenting out for now.
+                                //connPool.releaseConnection(conn);
                                 requestCompleteFuture.completeExceptionally(throwable);
                             }
 
@@ -183,6 +189,84 @@ public class HttpClientConnectionManagerTest extends HttpClientTestFixture  {
     @Test
     public void testSerialRequests() throws Exception {
         testParallelRequestsWithLeakCheck(1, NUM_REQUESTS / NUM_THREADS);
+    }
+
+    /**
+     * Test that the counters for the connection manager are correct (at least when used serially).
+     */
+    @Test
+    public void testConnectionCounters() throws Exception {
+        skipIfNetworkUnavailable();
+
+        URI uri = new URI(endpoint);
+
+        int maxConns = 3;
+
+        try (HttpClientConnectionManager connectionPool = createConnectionManager(uri, 1, maxConns)) {
+            Assert.assertEquals(maxConns, connectionPool.getMaxConnections());
+            Assert.assertEquals(3, connectionPool.getAvailableConnections());
+            Assert.assertEquals(0, connectionPool.getLeasedConnections());
+            Assert.assertEquals(0, connectionPool.getPendingConnectionAcquisitions());
+
+            List<HttpClientConnection> receivedClientConnections = new ArrayList<>();
+            int giveUpCtr = 99;
+
+            while(receivedClientConnections.size() < maxConns && giveUpCtr-- > 0) {
+                    CompletableFuture<HttpClientConnection> connectionAcquire = connectionPool.acquireConnection();
+                    try {
+                        HttpClientConnection connection = connectionAcquire.get(3, TimeUnit.SECONDS);
+                        receivedClientConnections.add(connection);
+                    } catch (CrtRuntimeException ignored) {
+                    }
+            }
+
+            if (giveUpCtr < 0) {
+                Assert.fail("test connections where not acquired. Most likely you don't have a network connection.");
+            }
+
+            // case pool of 3, 3 vended connections, none in flight.
+            Assert.assertEquals(maxConns, connectionPool.getLeasedConnections());
+            Assert.assertEquals(0, connectionPool.getPendingConnectionAcquisitions());
+            Assert.assertEquals(0, connectionPool.getAvailableConnections());
+
+            // case acquire 1, pool of 3, 3 vended, thus 1 in flight
+            CompletableFuture<HttpClientConnection> connectionAcquire = connectionPool.acquireConnection();
+            Assert.assertEquals(1, connectionPool.getPendingConnectionAcquisitions());
+            // should still be 0
+            Assert.assertEquals(0, connectionPool.getAvailableConnections());
+
+
+            // case release one, pool of 3, 3 vended, 1 in flight, 0 available. When we return 1, the other should be
+            // able to complete. Pending should go back to 0.
+            HttpClientConnection conn = receivedClientConnections.remove(0);
+            connectionPool.releaseConnection(conn);
+
+            connectionAcquire.get(3, TimeUnit.SECONDS);
+            Assert.assertEquals(3, connectionPool.getLeasedConnections());
+            Assert.assertEquals(0, connectionPool.getAvailableConnections());
+            Assert.assertEquals(0, connectionPool.getPendingConnectionAcquisitions());
+
+            conn = receivedClientConnections.remove(0);
+            connectionPool.releaseConnection(conn);
+            Assert.assertEquals(2, connectionPool.getLeasedConnections());
+            Assert.assertEquals(1, connectionPool.getAvailableConnections());
+            Assert.assertEquals(0, connectionPool.getPendingConnectionAcquisitions());
+
+            conn = receivedClientConnections.remove(0);
+            connectionPool.releaseConnection(conn);
+            Assert.assertEquals(1, connectionPool.getLeasedConnections());
+            Assert.assertEquals(2, connectionPool.getAvailableConnections());
+            Assert.assertEquals(0, connectionPool.getPendingConnectionAcquisitions());
+
+            conn = receivedClientConnections.remove(0);
+            connectionPool.releaseConnection(conn);
+            Assert.assertEquals(0, connectionPool.getLeasedConnections());
+            Assert.assertEquals(3, connectionPool.getAvailableConnections());
+            Assert.assertEquals(0, connectionPool.getPendingConnectionAcquisitions());
+        }
+
+        CrtResource.logNativeResources();
+        CrtResource.waitForNoResources();
     }
 
     @Test


### PR DESCRIPTION
Assumptions:

It's better for these counters are occasionally a little off due to me using atomics than to lock in the connection manager. It is "thread safe". But the counters are not updated as a transaction.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
