### PR TITLE
Mqtt - restore tests in CI, serialize on one event loop, logging update

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
@@ -40,6 +40,8 @@ class MissingCredentialsException extends RuntimeException {
 
 public class MqttClientConnectionFixture extends CrtTestFixture {
 
+    static final boolean IS_CI = System.getProperty("aws.crt.ci") != null;
+
     MqttClientConnection connection = null;
     private boolean disconnecting = false;
 
@@ -113,6 +115,9 @@ public class MqttClientConnectionFixture extends CrtTestFixture {
         } catch (InvalidPathException ex) {
             return false;
         } catch (MissingCredentialsException ex) {
+            if (IS_CI) {
+                throw ex;
+            }
             return false;
         } catch (IOException ex) {
             return false;


### PR DESCRIPTION
* Mqtt - Log the client id when sending the connect packet
* Mqtt - serialize reconnect and io on one thread
* Mqtt - restore tests in CI, prevent MQTT tests from being accidentally skipped in the future

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
