### PR TITLE
Java keystore and Base64 support

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -358,11 +358,13 @@ public final class TlsContextOptions extends CrtResource {
 
     /**
      * Helper which creates mutual TLS (mTLS) options using a certificate and private key
-     * stored in a Java keystore. Will fail if there is no certificate and key at the given certificate alias.
+     * stored in a Java keystore.
+     * Will throw an exception if there is no certificate and key at the given certificate alias, or there is some other
+     * error accessing or using the passed-in Java keystore.
      *
-     * Note: function assumes the passed keystore has already been loaded from a file by calling "keystore.load()" or similar"
+     * Note: function assumes the passed keystore has already been loaded from a file by calling "keystore.load()" or similar.
      *
-     * @param keyStore The Java keystore to use. Assumed to be loaded with certificates and keys
+     * @param keyStore The Java keystore to use. Assumed to be loaded with the desired certificate and key
      * @param certificateAlias The alias of the certificate and key to use.
      * @param certificatePassword The password of the certificate and key to use.
      * @throws CrtRuntimeException if an error occurs, like the keystore cannot be opened or the certificate is not found.

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -383,7 +383,7 @@ public final class TlsContextOptions extends CrtResource {
             String certificateString = new String(StringUtils.base64Encode(certificateData.getEncoded()));
             certificate = "-----BEGIN CERTIFICATE-----\n" + certificateString + "-----END CERTIFICATE-----\n";
         } catch (java.security.KeyStoreException | java.security.cert.CertificateEncodingException ex) {
-            throw new RuntimeException(ex);
+            throw new RuntimeException("Failed to get certificate from Java keystore", ex);
         }
         String privateKey;
         try {
@@ -394,7 +394,7 @@ public final class TlsContextOptions extends CrtResource {
             String keyString = new String(StringUtils.base64Encode(keyData.getEncoded()));
             privateKey = "-----BEGIN RSA PRIVATE KEY-----\n" + keyString + "-----END RSA PRIVATE KEY-----\n";
         } catch (java.security.KeyStoreException | java.security.NoSuchAlgorithmException | java.security.UnrecoverableKeyException ex) {
-            throw new RuntimeException(ex);
+            throw new RuntimeException("Failed to get private key from Java keystore", ex);
         }
         options.initMtls(certificate, privateKey);
         options.verifyPeer = true;

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -380,7 +380,7 @@ public final class TlsContextOptions extends CrtResource {
             if (certificateData == null) {
                 throw new CrtRuntimeException("Certificate at given certificate alias is empty");
             }
-            String certificateString = StringUtils.simpleBase64ToString(certificateData.getEncoded());
+            String certificateString = StringUtils.simpleBase64Encode(certificateData.getEncoded());
             certificate = "-----BEGIN CERTIFICATE-----\n" + certificateString + "-----END CERTIFICATE-----\n";
         } catch (java.security.KeyStoreException | java.security.cert.CertificateEncodingException ex) {
             throw new CrtRuntimeException("Could not get certificate from Java keystore");
@@ -391,7 +391,7 @@ public final class TlsContextOptions extends CrtResource {
             if (keyData == null) {
                 throw new CrtRuntimeException("Private key at given certificate alias is empty");
             }
-            String keyString = StringUtils.simpleBase64ToString(keyData.getEncoded());
+            String keyString = StringUtils.simpleBase64Encode(keyData.getEncoded());
             privateKey = "-----BEGIN RSA PRIVATE KEY-----\n" + keyString + "-----END RSA PRIVATE KEY-----\n";
         } catch (java.security.KeyStoreException | java.security.NoSuchAlgorithmException ex) {
             throw new CrtRuntimeException("Could not get key from Java keystore");

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -380,9 +380,8 @@ public final class TlsContextOptions extends CrtResource {
             if (certificateData == null) {
                 throw new CrtRuntimeException("Certificate at given certificate alias is empty");
             }
-            certificate = "-----BEGIN CERTIFICATE-----\n" +
-                          java.util.Base64.getEncoder().encodeToString(certificateData.getEncoded()) +
-                          "-----END CERTIFICATE-----\n";
+            String certificateString = StringUtils.simpleBase64ToString(certificateData.getEncoded());
+            certificate = "-----BEGIN CERTIFICATE-----\n" + certificateString + "-----END CERTIFICATE-----\n";
         } catch (java.security.KeyStoreException | java.security.cert.CertificateEncodingException ex) {
             throw new CrtRuntimeException("Could not get certificate from Java keystore");
         }
@@ -392,9 +391,8 @@ public final class TlsContextOptions extends CrtResource {
             if (keyData == null) {
                 throw new CrtRuntimeException("Private key at given certificate alias is empty");
             }
-            privateKey = "-----BEGIN RSA PRIVATE KEY-----\n" +
-                         java.util.Base64.getEncoder().encodeToString(keyData.getEncoded()) +
-                         "-----END RSA PRIVATE KEY-----\n";
+            String keyString = StringUtils.simpleBase64ToString(keyData.getEncoded());
+            privateKey = "-----BEGIN RSA PRIVATE KEY-----\n" + keyString + "-----END RSA PRIVATE KEY-----\n";
         } catch (java.security.KeyStoreException | java.security.NoSuchAlgorithmException ex) {
             throw new CrtRuntimeException("Could not get key from Java keystore");
         } catch (java.security.UnrecoverableKeyException ex) {

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -380,7 +380,7 @@ public final class TlsContextOptions extends CrtResource {
             if (certificateData == null) {
                 throw new CrtRuntimeException("Certificate at given certificate alias does not exist or does not contain a certificate");
             }
-            String certificateString = StringUtils.simpleBase64Encode(certificateData.getEncoded());
+            String certificateString = new String(StringUtils.base64Encode(certificateData.getEncoded()));
             certificate = "-----BEGIN CERTIFICATE-----\n" + certificateString + "-----END CERTIFICATE-----\n";
         } catch (java.security.KeyStoreException | java.security.cert.CertificateEncodingException ex) {
             throw new RuntimeException(ex);
@@ -391,7 +391,7 @@ public final class TlsContextOptions extends CrtResource {
             if (keyData == null) {
                 throw new CrtRuntimeException("Private key at given certificate alias does not exist or does not identify a key-related entity");
             }
-            String keyString = StringUtils.simpleBase64Encode(keyData.getEncoded());
+            String keyString = new String(StringUtils.base64Encode(keyData.getEncoded()));
             privateKey = "-----BEGIN RSA PRIVATE KEY-----\n" + keyString + "-----END RSA PRIVATE KEY-----\n";
         } catch (java.security.KeyStoreException | java.security.NoSuchAlgorithmException | java.security.UnrecoverableKeyException ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
@@ -23,4 +23,32 @@ public class StringUtils {
         }
         return sb.toString();
     }
+
+    /**
+     * Decode Base64 byte[] array into a String in pure Java for Android and Java 7+ support.
+     * Based on: https://stackoverflow.com/a/4265472
+    */
+    private final static char[] BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
+    public static String simpleBase64ToString(byte[] buf){
+        int size = buf.length;
+        char[] ar = new char[((size + 2) / 3) * 4];
+        int a = 0;
+        int i=0;
+        while(i < size){
+            byte b0 = buf[i++];
+            byte b1 = (i < size) ? buf[i++] : 0;
+            byte b2 = (i < size) ? buf[i++] : 0;
+
+            int mask = 0x3F;
+            ar[a++] = BASE64_ALPHABET[(b0 >> 2) & mask];
+            ar[a++] = BASE64_ALPHABET[((b0 << 4) | ((b1 & 0xFF) >> 4)) & mask];
+            ar[a++] = BASE64_ALPHABET[((b1 << 2) | ((b2 & 0xFF) >> 6)) & mask];
+            ar[a++] = BASE64_ALPHABET[b2 & mask];
+        }
+        switch(size % 3){
+            case 1: ar[--a]  = '=';
+            case 2: ar[--a]  = '=';
+        }
+        return new String(ar);
+    }
 }

--- a/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
@@ -30,20 +30,30 @@ public class StringUtils {
     private final static char[] BASE64_VALID_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
     public static String simpleBase64Encode(byte[] data) {
 
+        // Empty array? Return an empty string
+        if (data.length == 0) {
+            return new String();
+        }
+
         String result = "";
         // Base64 REQUIRES each data block be 24 bits in length. This means that if the data we want to encode
         // is too short, we need to add some special padding to it.
         String padding_string = "";
         int length_remainder = data.length % 3;
-        byte[] data_padded = new byte[data.length + (3 - length_remainder)];
-        System.arraycopy(data, 0, data_padded, 0, data.length);
+        byte[] data_padded;
 
         // Add the proper amount of padding to the padding string and set the data in the data_padded array.
         if (length_remainder > 0) {
+            // Make extra room for padding. Not ideal to do a copy, but we cannot just append to an already made array
+            data_padded = new byte[data.length + (3 - length_remainder)];
+            System.arraycopy(data, 0, data_padded, 0, data.length);
+
             for (; length_remainder < 3; length_remainder++) {
                 padding_string += "=";
-                data_padded[(data.length-1) + length_remainder] = '\0';
+                data_padded[(data.length-1) + padding_string.length()] = '\0';
             }
+        } else {
+            data_padded = data;
         }
 
         // Variables we will use and override as we go through the data in the byte[] array

--- a/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
@@ -24,20 +24,24 @@ public class StringUtils {
         return sb.toString();
     }
 
-    /**
-     * Encode a byte[] array into a Base64 byte[] array
-     */
+     /**
+      * Encode a byte array into a Base64 byte array.
+      * @param data The byte array to encode
+      * @return The byte array encoded as Byte64
+      */
     public static byte[] base64Encode(byte[] data) {
         return stringUtilsBase64Encode(data);
     }
 
-    /**
-     * Encode a byte[] array into a Base64 byte[] array
-     */
+     /**
+      * Decode a Base64 byte array into a non-Base64 byte array.
+      * @param data The byte array to decode.
+      * @return Byte array decoded from Base64.
+      */
     public static byte[] base64Decode(byte[] data) {
         return stringUtilsBase64Decode(data);
     }
 
-    public static native byte[] stringUtilsBase64Encode(byte[] data_to_encode);
+    private static native byte[] stringUtilsBase64Encode(byte[] data_to_encode);
     private static native byte[] stringUtilsBase64Decode(byte[] data_to_decode);
 }

--- a/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
+++ b/src/main/java/software/amazon/awssdk/crt/utils/StringUtils.java
@@ -25,56 +25,19 @@ public class StringUtils {
     }
 
     /**
-     * Encode a byte[] array into a Base64 String in pure Java
+     * Encode a byte[] array into a Base64 byte[] array
      */
-    private final static char[] BASE64_VALID_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
-    public static String simpleBase64Encode(byte[] data) {
-
-        // Empty array? Return an empty string
-        if (data.length == 0) {
-            return new String();
-        }
-
-        String result = "";
-        // Base64 REQUIRES each data block be 24 bits in length. This means that if the data we want to encode
-        // is too short, we need to add some special padding to it.
-        String padding_string = "";
-        int length_remainder = data.length % 3;
-        byte[] data_padded;
-
-        // Add the proper amount of padding to the padding string and set the data in the data_padded array.
-        if (length_remainder > 0) {
-            // Make extra room for padding. Not ideal to do a copy, but we cannot just append to an already made array
-            data_padded = new byte[data.length + (3 - length_remainder)];
-            System.arraycopy(data, 0, data_padded, 0, data.length);
-
-            for (; length_remainder < 3; length_remainder++) {
-                padding_string += "=";
-                data_padded[(data.length-1) + padding_string.length()] = '\0';
-            }
-        } else {
-            data_padded = data;
-        }
-
-        // Variables we will use and override as we go through the data in the byte[] array
-        int character = 0;
-        int mask_offset = 63;
-        int byte_offset = 255;
-        byte byte_1 = 0;
-        byte byte_2 = 0;
-        byte byte_3 = 0;
-
-        for (character = 0; character < data_padded.length; character += 3) {
-            byte_1 = data_padded[character];
-            byte_2 = data_padded[character+1];
-            byte_3 = data_padded[character+2];
-            result += BASE64_VALID_CHARACTERS[(byte_1 >> 2) & mask_offset];
-            result += BASE64_VALID_CHARACTERS[((byte_1 << 4) | ((byte_2 & byte_offset) >> 4)) & mask_offset];
-            result += BASE64_VALID_CHARACTERS[((byte_2 << 2) | ((byte_3 & byte_offset) >> 6)) & mask_offset];
-            result += BASE64_VALID_CHARACTERS[byte_3 & mask_offset];
-        }
-        // The data we added for padding purposes ('\0') is not part of the data we were given and so we need to remove it.
-        // We can replace it with '=', which is a special character in Base64 that tells Base64 decoders this is simply padding.
-        return result.substring(0, result.length() - padding_string.length()) + padding_string;
+    public static byte[] base64Encode(byte[] data) {
+        return stringUtilsBase64Encode(data);
     }
+
+    /**
+     * Encode a byte[] array into a Base64 byte[] array
+     */
+    public static byte[] base64Decode(byte[] data) {
+        return stringUtilsBase64Decode(data);
+    }
+
+    public static native byte[] stringUtilsBase64Encode(byte[] data_to_encode);
+    private static native byte[] stringUtilsBase64Decode(byte[] data_to_decode);
 }

--- a/src/native/string_utils.c
+++ b/src/native/string_utils.c
@@ -1,0 +1,97 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <jni.h>
+
+#include <aws/common/string.h>
+#include <aws/common/encoding.h>
+
+#include "crt.h"
+
+
+JNIEXPORT
+jbyteArray JNICALL Java_software_amazon_awssdk_crt_utils_StringUtils_stringUtilsBase64Encode(
+    JNIEnv *env,
+    jclass jni_class,
+    jbyteArray jni_data) {
+    (void)jni_class;
+
+    struct aws_byte_cursor data_cursor;
+    AWS_ZERO_STRUCT(data_cursor);
+    if (jni_data != NULL) {
+        data_cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_data);
+    } else {
+        return NULL;
+    }
+
+    // Determine how much space we need
+    size_t terminated_length = 0;
+    if (aws_base64_compute_encoded_len(data_cursor.len, &terminated_length) != AWS_OP_SUCCESS) {
+        goto clean_up;
+    }
+
+    struct aws_byte_buf formatted_data;
+    AWS_ZERO_STRUCT(formatted_data);
+    aws_byte_buf_init(&formatted_data, aws_jni_get_allocator(), terminated_length);
+    int result = aws_base64_encode(&data_cursor, &formatted_data);
+    if (result != AWS_OP_SUCCESS) {
+        aws_byte_buf_clean_up(&formatted_data);
+        goto clean_up;
+    }
+
+    aws_jni_byte_cursor_from_jbyteArray_release(env, jni_data, data_cursor);
+
+    struct aws_byte_cursor formatted_data_cursor = aws_byte_cursor_from_buf(&formatted_data);
+    jbyteArray return_data = aws_jni_byte_array_from_cursor(env, &formatted_data_cursor);
+    aws_byte_buf_clean_up_secure(&formatted_data);
+
+    return return_data;
+
+clean_up:
+    aws_jni_byte_cursor_from_jbyteArray_release(env, jni_data, data_cursor);
+    return NULL;
+}
+
+JNIEXPORT
+jbyteArray JNICALL Java_software_amazon_awssdk_crt_utils_StringUtils_stringUtilsBase64Decode(
+    JNIEnv *env,
+    jclass jni_class,
+    jbyteArray jni_data) {
+    (void)jni_class;
+
+    struct aws_byte_cursor data_cursor;
+    AWS_ZERO_STRUCT(data_cursor);
+    if (jni_data != NULL) {
+        data_cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_data);
+    } else {
+        return NULL;
+    }
+
+    // Determine how much space we need
+    size_t terminated_length = 0;
+    if (aws_base64_compute_decoded_len(&data_cursor, &terminated_length) != AWS_OP_SUCCESS) {
+        goto clean_up;
+    }
+
+    struct aws_byte_buf formatted_data;
+    AWS_ZERO_STRUCT(formatted_data);
+    aws_byte_buf_init(&formatted_data, aws_jni_get_allocator(), terminated_length);
+    int result = aws_base64_decode(&data_cursor, &formatted_data);
+    if (result != AWS_OP_SUCCESS) {
+        aws_byte_buf_clean_up(&formatted_data);
+        goto clean_up;
+    }
+
+    aws_jni_byte_cursor_from_jbyteArray_release(env, jni_data, data_cursor);
+
+    struct aws_byte_cursor formatted_data_cursor = aws_byte_cursor_from_buf(&formatted_data);
+    jbyteArray return_data = aws_jni_byte_array_from_cursor(env, &formatted_data_cursor);
+    aws_byte_buf_clean_up_secure(&formatted_data);
+
+    return return_data;
+
+clean_up:
+    aws_jni_byte_cursor_from_jbyteArray_release(env, jni_data, data_cursor);
+    return NULL;
+}

--- a/src/native/string_utils.c
+++ b/src/native/string_utils.c
@@ -4,11 +4,10 @@
  */
 #include <jni.h>
 
-#include <aws/common/string.h>
 #include <aws/common/encoding.h>
+#include <aws/common/string.h>
 
 #include "crt.h"
-
 
 JNIEXPORT
 jbyteArray JNICALL Java_software_amazon_awssdk_crt_utils_StringUtils_stringUtilsBase64Encode(

--- a/src/native/string_utils.c
+++ b/src/native/string_utils.c
@@ -22,11 +22,6 @@ jbyteArray JNICALL Java_software_amazon_awssdk_crt_utils_StringUtils_stringUtils
     AWS_ZERO_STRUCT(formatted_data);
     jbyteArray return_data = NULL;
 
-    // Explicitly return NULL if the data we get is null to avoid an exception. NULL should return NULL
-    if (jni_data == NULL) {
-        return return_data;
-    }
-
     data_cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_data);
     if (data_cursor.ptr == NULL) {
         return return_data;
@@ -67,11 +62,6 @@ jbyteArray JNICALL Java_software_amazon_awssdk_crt_utils_StringUtils_stringUtils
     struct aws_byte_buf formatted_data;
     AWS_ZERO_STRUCT(formatted_data);
     jbyteArray return_data = NULL;
-
-    // Explicitly return NULL if the data we get is null to avoid an exception. NULL should return NULL
-    if (jni_data == NULL) {
-        return return_data;
-    }
 
     data_cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_data);
     if (data_cursor.ptr == NULL) {

--- a/src/native/string_utils.c
+++ b/src/native/string_utils.c
@@ -18,38 +18,41 @@ jbyteArray JNICALL Java_software_amazon_awssdk_crt_utils_StringUtils_stringUtils
 
     struct aws_byte_cursor data_cursor;
     AWS_ZERO_STRUCT(data_cursor);
-    if (jni_data != NULL) {
-        data_cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_data);
-    } else {
-        return NULL;
+    struct aws_byte_buf formatted_data;
+    AWS_ZERO_STRUCT(formatted_data);
+    jbyteArray return_data = NULL;
+
+    // Explicitly return NULL if the data we get is null to avoid an exception. NULL should return NULL
+    if (jni_data == NULL) {
+        return return_data;
+    }
+
+    data_cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_data);
+    if (data_cursor.ptr == NULL) {
+        return return_data;
     }
 
     // Determine how much space we need
     size_t terminated_length = 0;
     if (aws_base64_compute_encoded_len(data_cursor.len, &terminated_length) != AWS_OP_SUCCESS) {
+        aws_jni_throw_runtime_exception(env, "StringUtils: Could not determine length for base64 encode");
         goto clean_up;
     }
 
-    struct aws_byte_buf formatted_data;
-    AWS_ZERO_STRUCT(formatted_data);
     aws_byte_buf_init(&formatted_data, aws_jni_get_allocator(), terminated_length);
     int result = aws_base64_encode(&data_cursor, &formatted_data);
     if (result != AWS_OP_SUCCESS) {
-        aws_byte_buf_clean_up(&formatted_data);
+        aws_jni_throw_runtime_exception(env, "StringUtils: Could not perform base64 encode");
         goto clean_up;
     }
 
-    aws_jni_byte_cursor_from_jbyteArray_release(env, jni_data, data_cursor);
-
     struct aws_byte_cursor formatted_data_cursor = aws_byte_cursor_from_buf(&formatted_data);
-    jbyteArray return_data = aws_jni_byte_array_from_cursor(env, &formatted_data_cursor);
-    aws_byte_buf_clean_up_secure(&formatted_data);
-
-    return return_data;
+    return_data = aws_jni_byte_array_from_cursor(env, &formatted_data_cursor);
 
 clean_up:
     aws_jni_byte_cursor_from_jbyteArray_release(env, jni_data, data_cursor);
-    return NULL;
+    aws_byte_buf_clean_up_secure(&formatted_data);
+    return return_data;
 }
 
 JNIEXPORT
@@ -61,36 +64,39 @@ jbyteArray JNICALL Java_software_amazon_awssdk_crt_utils_StringUtils_stringUtils
 
     struct aws_byte_cursor data_cursor;
     AWS_ZERO_STRUCT(data_cursor);
-    if (jni_data != NULL) {
-        data_cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_data);
-    } else {
+    struct aws_byte_buf formatted_data;
+    AWS_ZERO_STRUCT(formatted_data);
+    jbyteArray return_data = NULL;
+
+    // Explicitly return NULL if the data we get is null to avoid an exception. NULL should return NULL
+    if (jni_data == NULL) {
+        return return_data;
+    }
+
+    data_cursor = aws_jni_byte_cursor_from_jbyteArray_acquire(env, jni_data);
+    if (data_cursor.ptr == NULL) {
         return NULL;
     }
 
     // Determine how much space we need
     size_t terminated_length = 0;
     if (aws_base64_compute_decoded_len(&data_cursor, &terminated_length) != AWS_OP_SUCCESS) {
+        aws_jni_throw_runtime_exception(env, "StringUtils: Could not determine length for base64 decode");
         goto clean_up;
     }
 
-    struct aws_byte_buf formatted_data;
-    AWS_ZERO_STRUCT(formatted_data);
     aws_byte_buf_init(&formatted_data, aws_jni_get_allocator(), terminated_length);
     int result = aws_base64_decode(&data_cursor, &formatted_data);
     if (result != AWS_OP_SUCCESS) {
-        aws_byte_buf_clean_up(&formatted_data);
+        aws_jni_throw_runtime_exception(env, "StringUtils: Could not perform base64 decode");
         goto clean_up;
     }
 
-    aws_jni_byte_cursor_from_jbyteArray_release(env, jni_data, data_cursor);
-
     struct aws_byte_cursor formatted_data_cursor = aws_byte_cursor_from_buf(&formatted_data);
-    jbyteArray return_data = aws_jni_byte_array_from_cursor(env, &formatted_data_cursor);
-    aws_byte_buf_clean_up_secure(&formatted_data);
-
-    return return_data;
+    return_data = aws_jni_byte_array_from_cursor(env, &formatted_data_cursor);
 
 clean_up:
     aws_jni_byte_cursor_from_jbyteArray_release(env, jni_data, data_cursor);
-    return NULL;
+    aws_byte_buf_clean_up_secure(&formatted_data);
+    return return_data;
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
@@ -1,12 +1,14 @@
 package software.amazon.awssdk.crt.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.utils.StringUtils;
 
 
@@ -27,28 +29,8 @@ public class StringUtilsTest extends CrtTestFixture {
     }
 
     @Test
-    public void testBase64EncodeCaseF() {
-        assertEquals("Zg==", new String(StringUtils.base64Encode("f".getBytes())));
-    }
-
-    @Test
-    public void testBase64EncodeCaseFo() {
-        assertEquals("Zm8=", new String(StringUtils.base64Encode("fo".getBytes())));
-    }
-
-    @Test
-    public void testBase64EncodeCaseFoo() {
-        assertEquals("Zm9v", new String(StringUtils.base64Encode("foo".getBytes())));
-    }
-
-    @Test
-    public void testBase64EncodeCaseFoob() {
-        assertEquals("Zm9vYg==", new String(StringUtils.base64Encode("foob".getBytes())));
-    }
-
-    @Test
-    public void testBase64EncodeCaseFooba() {
-        assertEquals("Zm9vYmE=", new String(StringUtils.base64Encode("fooba".getBytes())));
+    public void testBase64EncodeNull() {
+        assertEquals(null, StringUtils.base64Encode(null));
     }
 
     @Test
@@ -57,16 +39,13 @@ public class StringUtilsTest extends CrtTestFixture {
     }
 
     @Test
-    public void testBase64EncodeCase32bytes() {
-        assertEquals(
-            "dGhpcyBpcyBhIDMyIGJ5dGUgbG9uZyBzdHJpbmchISE=",
-            new String(StringUtils.base64Encode("this is a 32 byte long string!!!".getBytes())));
-    }
-
-    @Test
-    public void testBase64EncodeCaseZeros() {
-        byte[] data = new byte[6];
-        assertEquals("AAAAAAAA", new String(StringUtils.base64Encode(data)));
+    public void testBase64EncodeExtremelyLargeString() {
+        StringBuilder test_input = new StringBuilder();
+        for (int i = 0; i < 50000; i++) {
+            test_input.append('A');
+        }
+        byte[] output = StringUtils.base64Encode(test_input.toString().getBytes());
+        assertTrue(output != null);
     }
 
     @Test
@@ -90,28 +69,8 @@ public class StringUtilsTest extends CrtTestFixture {
     }
 
     @Test
-    public void testBase64DecodeCaseF() {
-        assertEquals("f", new String(StringUtils.base64Decode("Zg==".getBytes())));
-    }
-
-    @Test
-    public void testBase64DecodeCaseFo() {
-        assertEquals("fo", new String(StringUtils.base64Decode("Zm8=".getBytes())));
-    }
-
-    @Test
-    public void testBase64DecodeCaseFoo() {
-        assertEquals("foo", new String(StringUtils.base64Decode("Zm9v".getBytes())));
-    }
-
-    @Test
-    public void testBase64DecodeCaseFoob() {
-        assertEquals("foob", new String(StringUtils.base64Decode("Zm9vYg==".getBytes())));
-    }
-
-    @Test
-    public void testBase64DecodeCaseFooba() {
-        assertEquals("fooba", new String(StringUtils.base64Decode("Zm9vYmE=".getBytes())));
+    public void testBase64DecodeNull() {
+        assertEquals(null, StringUtils.base64Decode(null));
     }
 
     @Test
@@ -120,10 +79,13 @@ public class StringUtilsTest extends CrtTestFixture {
     }
 
     @Test
-    public void testBase64DecodeCase32bytes() {
-        assertEquals(
-            "this is a 32 byte long string!!!",
-            new String(StringUtils.base64Decode("dGhpcyBpcyBhIDMyIGJ5dGUgbG9uZyBzdHJpbmchISE=".getBytes())));
+    public void testBase64DecodeExtremelyLargeString() {
+        StringBuilder test_input = new StringBuilder();
+        for (int i = 0; i < 50000; i++) {
+            test_input.append('A');
+        }
+        byte[] output = StringUtils.base64Decode(test_input.toString().getBytes());
+        assertTrue(output != null);
     }
 
     @Test

--- a/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 import software.amazon.awssdk.crt.utils.StringUtils;
 
 
-public class StringUtilsTest {
+public class StringUtilsTest extends CrtTestFixture {
 
     @Test
     public void testJoin() {
@@ -23,48 +23,50 @@ public class StringUtilsTest {
 
     @Test
     public void testBase64EncodeEmpty() {
-        assertEquals("", StringUtils.simpleBase64Encode("".getBytes()));
+        assertEquals("", new String(StringUtils.base64Encode("".getBytes())));
     }
 
     @Test
     public void testBase64EncodeCaseF() {
-        assertEquals("Zg==", StringUtils.simpleBase64Encode("f".getBytes()));
+        assertEquals("Zg==", new String(StringUtils.base64Encode("f".getBytes())));
     }
 
     @Test
     public void testBase64EncodeCaseFo() {
-        assertEquals("Zm8=", StringUtils.simpleBase64Encode("fo".getBytes()));
+        assertEquals("Zm8=", new String(StringUtils.base64Encode("fo".getBytes())));
     }
 
     @Test
     public void testBase64EncodeCaseFoo() {
-        assertEquals("Zm9v", StringUtils.simpleBase64Encode("foo".getBytes()));
+        assertEquals("Zm9v", new String(StringUtils.base64Encode("foo".getBytes())));
     }
 
     @Test
     public void testBase64EncodeCaseFoob() {
-        assertEquals("Zm9vYg==", StringUtils.simpleBase64Encode("foob".getBytes()));
+        assertEquals("Zm9vYg==", new String(StringUtils.base64Encode("foob".getBytes())));
     }
 
     @Test
     public void testBase64EncodeCaseFooba() {
-        assertEquals("Zm9vYmE=", StringUtils.simpleBase64Encode("fooba".getBytes()));
+        assertEquals("Zm9vYmE=", new String(StringUtils.base64Encode("fooba".getBytes())));
     }
 
     @Test
     public void testBase64EncodeCaseFoobar() {
-        assertEquals("Zm9vYmFy", StringUtils.simpleBase64Encode("foobar".getBytes()));
+        assertEquals("Zm9vYmFy", new String(StringUtils.base64Encode("foobar".getBytes())));
     }
 
     @Test
     public void testBase64EncodeCase32bytes() {
-        assertEquals("dGhpcyBpcyBhIDMyIGJ5dGUgbG9uZyBzdHJpbmchISE=", StringUtils.simpleBase64Encode("this is a 32 byte long string!!!".getBytes()));
+        assertEquals(
+            "dGhpcyBpcyBhIDMyIGJ5dGUgbG9uZyBzdHJpbmchISE=",
+            new String(StringUtils.base64Encode("this is a 32 byte long string!!!".getBytes())));
     }
 
     @Test
     public void testBase64EncodeCaseZeros() {
         byte[] data = new byte[6];
-        assertEquals("AAAAAAAA", StringUtils.simpleBase64Encode(data));
+        assertEquals("AAAAAAAA", new String(StringUtils.base64Encode(data)));
     }
 
     @Test
@@ -79,6 +81,74 @@ public class StringUtilsTest {
         expected += "jY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0t";
         expected += "PU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+";
 
-        assertEquals(expected, StringUtils.simpleBase64Encode(data));
+        assertEquals(expected, new String(StringUtils.base64Encode(data)));
+    }
+
+    @Test
+    public void testBase64DecodeEmpty() {
+        assertEquals("", new String(StringUtils.base64Decode("".getBytes())));
+    }
+
+    @Test
+    public void testBase64DecodeCaseF() {
+        assertEquals("f", new String(StringUtils.base64Decode("Zg==".getBytes())));
+    }
+
+    @Test
+    public void testBase64DecodeCaseFo() {
+        assertEquals("fo", new String(StringUtils.base64Decode("Zm8=".getBytes())));
+    }
+
+    @Test
+    public void testBase64DecodeCaseFoo() {
+        assertEquals("foo", new String(StringUtils.base64Decode("Zm9v".getBytes())));
+    }
+
+    @Test
+    public void testBase64DecodeCaseFoob() {
+        assertEquals("foob", new String(StringUtils.base64Decode("Zm9vYg==".getBytes())));
+    }
+
+    @Test
+    public void testBase64DecodeCaseFooba() {
+        assertEquals("fooba", new String(StringUtils.base64Decode("Zm9vYmE=".getBytes())));
+    }
+
+    @Test
+    public void testBase64DecodeCaseFoobar() {
+        assertEquals("foobar", new String(StringUtils.base64Decode("Zm9vYmFy".getBytes())));
+    }
+
+    @Test
+    public void testBase64DecodeCase32bytes() {
+        assertEquals(
+            "this is a 32 byte long string!!!",
+            new String(StringUtils.base64Decode("dGhpcyBpcyBhIDMyIGJ5dGUgbG9uZyBzdHJpbmchISE=".getBytes())));
+    }
+
+    @Test
+    public void testBase64DecodeCaseAllValues() {
+        byte[] data = new byte[255];
+        for (int i = 0; i < 255; i++) {
+            data[i] = (byte)(i);
+        }
+
+        String input = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERU";
+        input += "ZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouM";
+        input += "jY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0t";
+        input += "PU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+";
+
+        String expected = new String(data);
+
+        assertEquals(expected, new String(StringUtils.base64Decode(input.getBytes())));
+    }
+
+    @Test
+    public void testBase64CaseFoobarRoundTrop() {
+        String data = "foobar";
+        data = new String(StringUtils.base64Encode(data.getBytes()));
+        assertEquals("Zm9vYmFy", data);
+        data = new String(StringUtils.base64Decode(data.getBytes()));
+        assertEquals("foobar", data);
     }
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
@@ -1,14 +1,15 @@
 package software.amazon.awssdk.crt.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.utils.StringUtils;
 
 
@@ -30,7 +31,12 @@ public class StringUtilsTest extends CrtTestFixture {
 
     @Test
     public void testBase64EncodeNull() {
-        assertEquals(null, StringUtils.base64Encode(null));
+        ThrowingRunnable test_runnable = new ThrowingRunnable() {
+            public void run() {
+                StringUtils.base64Encode(null);
+            }
+        };
+        assertThrows(NullPointerException.class, test_runnable);
     }
 
     @Test
@@ -70,7 +76,12 @@ public class StringUtilsTest extends CrtTestFixture {
 
     @Test
     public void testBase64DecodeNull() {
-        assertEquals(null, StringUtils.base64Decode(null));
+        ThrowingRunnable test_runnable = new ThrowingRunnable() {
+            public void run() {
+                StringUtils.base64Decode(null);
+            }
+        };
+        assertThrows(NullPointerException.class, test_runnable);
     }
 
     @Test

--- a/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/StringUtilsTest.java
@@ -20,4 +20,65 @@ public class StringUtilsTest {
         alpns.add("two");
         assertEquals("one;two", StringUtils.join(";", alpns));
     }
+
+    @Test
+    public void testBase64EncodeEmpty() {
+        assertEquals("", StringUtils.simpleBase64Encode("".getBytes()));
+    }
+
+    @Test
+    public void testBase64EncodeCaseF() {
+        assertEquals("Zg==", StringUtils.simpleBase64Encode("f".getBytes()));
+    }
+
+    @Test
+    public void testBase64EncodeCaseFo() {
+        assertEquals("Zm8=", StringUtils.simpleBase64Encode("fo".getBytes()));
+    }
+
+    @Test
+    public void testBase64EncodeCaseFoo() {
+        assertEquals("Zm9v", StringUtils.simpleBase64Encode("foo".getBytes()));
+    }
+
+    @Test
+    public void testBase64EncodeCaseFoob() {
+        assertEquals("Zm9vYg==", StringUtils.simpleBase64Encode("foob".getBytes()));
+    }
+
+    @Test
+    public void testBase64EncodeCaseFooba() {
+        assertEquals("Zm9vYmE=", StringUtils.simpleBase64Encode("fooba".getBytes()));
+    }
+
+    @Test
+    public void testBase64EncodeCaseFoobar() {
+        assertEquals("Zm9vYmFy", StringUtils.simpleBase64Encode("foobar".getBytes()));
+    }
+
+    @Test
+    public void testBase64EncodeCase32bytes() {
+        assertEquals("dGhpcyBpcyBhIDMyIGJ5dGUgbG9uZyBzdHJpbmchISE=", StringUtils.simpleBase64Encode("this is a 32 byte long string!!!".getBytes()));
+    }
+
+    @Test
+    public void testBase64EncodeCaseZeros() {
+        byte[] data = new byte[6];
+        assertEquals("AAAAAAAA", StringUtils.simpleBase64Encode(data));
+    }
+
+    @Test
+    public void testBase64EncodeCaseAllValues() {
+        byte[] data = new byte[255];
+        for (int i = 0; i < 255; i++) {
+            data[i] = (byte)(i);
+        }
+
+        String expected = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERU";
+        expected += "ZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouM";
+        expected += "jY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0t";
+        expected += "PU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+";
+
+        assertEquals(expected, StringUtils.simpleBase64Encode(data));
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

Not a CRT issue, but there is a Java V2 SDK issue: https://github.com/aws/aws-iot-device-sdk-java-v2/issues/180

*Description of changes:*

Adds a new option for making a `TlsContextOptions` that supports taking a Java keystore as input and then pulling the certificate and private key out of it. Associated sample (including CI) is in the accompanying SDK PR: https://github.com/aws/aws-iot-device-sdk-java-v2/pull/337

Edit: Also exposes Base64 encoding and decoding to the StringUtils class. This is necessary to support Android API level 24 and still encode/decode Base64 data from the Java keystore.

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
