### PR TITLE
Main sync callback adjustment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "system_error": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "system_error": "c"
-    }
-}

--- a/samples/mqtt5/src/main/java/com/example/mqtt5/Mqtt5Sample.java
+++ b/samples/mqtt5/src/main/java/com/example/mqtt5/Mqtt5Sample.java
@@ -97,13 +97,13 @@ public class Mqtt5Sample {
         }
 
         @Override
-        public void onConnectionFailure(Mqtt5Client client, int failureCode, ConnAckPacket connAckData) {
+        public void onConnectionFailure(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
             System.out.println("[Lifecycle event] Client connection failed...");
             connectedFuture.completeExceptionally(new Exception("Connection failure"));
         }
 
         @Override
-        public void onDisconnection(Mqtt5Client client, int failureCode, DisconnectPacket disconnectData) {
+        public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {
             System.out.println("[Lifecycle event] Client disconnected...");
         }
 

--- a/samples/mqtt5/src/main/java/com/example/mqtt5/Mqtt5Sample.java
+++ b/samples/mqtt5/src/main/java/com/example/mqtt5/Mqtt5Sample.java
@@ -116,7 +116,8 @@ public class Mqtt5Sample {
 
     static final class SamplePublishEvents implements Mqtt5ClientOptions.PublishEvents {
         @Override
-        public void onMessageReceived(Mqtt5Client client, PublishPacket publishPacket) {
+        public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {
+            PublishPacket publishPacket = publishResult.getPublishPacket();
             System.out.println(
                 "Message received:\n"+
                 "  Topic: " + publishPacket.getTopic() + "\n" +

--- a/samples/mqtt5/src/main/java/com/example/mqtt5/Mqtt5Sample.java
+++ b/samples/mqtt5/src/main/java/com/example/mqtt5/Mqtt5Sample.java
@@ -86,7 +86,7 @@ public class Mqtt5Sample {
         CompletableFuture<Void> stopFuture = new CompletableFuture<>();
 
         @Override
-        public void onAttemptingConnect(Mqtt5Client client) {
+        public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {
             System.out.println("[Lifecycle event] Client attempting connection...");
         }
 
@@ -108,7 +108,7 @@ public class Mqtt5Sample {
         }
 
         @Override
-        public void onStopped(Mqtt5Client client) {
+        public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {
             System.out.println("[Lifecycle event] Client stopped...");
             stopFuture.complete(null);
         }

--- a/samples/mqtt5/src/main/java/com/example/mqtt5/Mqtt5Sample.java
+++ b/samples/mqtt5/src/main/java/com/example/mqtt5/Mqtt5Sample.java
@@ -91,7 +91,7 @@ public class Mqtt5Sample {
         }
 
         @Override
-        public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData, NegotiatedSettings negotiatedSettings) {
+        public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
             System.out.println("[Lifecycle event] Client connection success...");
             connectedFuture.complete(null);
         }

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5Client.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.crt.mqtt5.packets.ConnectPacket.ConnectPacketBuild
  *
  * One Mqtt5Client class creates one connection.
  *
- * MQTT5 support is currently in <b>developer preview<b>.  We encourage feedback at all times, but feedback during the
+ * MQTT5 support is currently in <b>developer preview</b>.  We encourage feedback at all times, but feedback during the
  * preview window is especially valuable in shaping the final product.  During the preview period we may make
  * backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
  */

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5Client.java
@@ -30,9 +30,9 @@ import software.amazon.awssdk.crt.mqtt5.packets.ConnectPacket.ConnectPacketBuild
  *
  * One Mqtt5Client class creates one connection.
  *
- * !! Developer Preview !! - This class is currently in developer preview.
- * The interface is not guaranteed to be stable yet.
- * Please report any issues or make suggestions in https://github.com/awslabs/aws-crt-java/issues
+ * MQTT5 support is currently in <b>developer preview<b>.  We encourage feedback at all times, but feedback during the
+ * preview window is especially valuable in shaping the final product.  During the preview period we may make
+ * backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
  */
 public class Mqtt5Client extends CrtResource {
 

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
@@ -306,8 +306,7 @@ public class Mqtt5ClientOptions {
          * Called when the client successfully establishes an MQTT connection
          *
          * @param client The client associated with the event
-         * @param connAckData The ConnAckPacket for the connection
-         * @param negotiatedSettings The NegotiatedSettings for the connection
+         * @param onConnectionSuccessReturn The data associated with the onConnectionSuccess event.
          */
         public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn);
 
@@ -315,23 +314,17 @@ public class Mqtt5ClientOptions {
          * Called when the client fails to establish an MQTT connection
          *
          * @param client The client associated with the event
-         * @param errorCode The error code that represents the reason why the connection failed.
-         * Pass to {@link software.amazon.awssdk.crt.CRT#awsErrorString(int)} for a human readable error.
-         * @param connAckData The ConnAckPacket for the failed connection.
-         * May be null if the connection failure did not involve a ConnAckPacket.
+         * @param onConnectionFailureReturn The data associated with the onConnectionFailure event.
          */
-        public void onConnectionFailure(Mqtt5Client client, int errorCode, ConnAckPacket connAckData);
+        public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn);
 
         /**
          * Called when the client's current MQTT connection is closed
          *
          * @param client The client associated with the event
-         * @param errorCode The code that represents why the disconnection occurred
-         * Pass to {@link software.amazon.awssdk.crt.CRT#awsErrorString(int)} for a human readable error.
-         * @param disconnectData The DisconnectPacket for the disconnection.
-         * May be null if the disconnection did not involve a DisconnectPacket.
+         * @param onDisconnectionReturn The data associated with the onDisconnection event.
          */
-        public void onDisconnection(Mqtt5Client client, int errorCode, DisconnectPacket disconnectData);
+        public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn);
 
         /**
          * Called when the client reaches the 'Stopped' state as a result of the user invoking .stop()

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 /**
  * Configuration for the creation of Mqtt5Clients
  *
- * MQTT5 support is currently in <b>developer preview<b>.  We encourage feedback at all times, but feedback during the
+ * MQTT5 support is currently in <b>developer preview</b>.  We encourage feedback at all times, but feedback during the
  * preview window is especially valuable in shaping the final product.  During the preview period we may make
  * backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
  */

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
@@ -24,9 +24,9 @@ import java.util.function.Consumer;
 /**
  * Configuration for the creation of Mqtt5Clients
  *
- * !! Developer Preview !! - This class is currently in developer preview.
- * The interface is not guaranteed to be stable yet.
- * Please report any issues or make suggestions in https://github.com/awslabs/aws-crt-java/issues
+ * MQTT5 support is currently in <b>developer preview<b>.  We encourage feedback at all times, but feedback during the
+ * preview window is especially valuable in shaping the final product.  During the preview period we may make
+ * backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
  */
 public class Mqtt5ClientOptions {
 
@@ -348,9 +348,9 @@ public class Mqtt5ClientOptions {
          * Called when an MQTT PUBLISH packet is received by the client
          *
          * @param client The client that has received the message
-         * @param publishPacket The PublishPacket that was received
+         * @param publishReturn All of the data that was received from the server
          */
-        public void onMessageReceived(Mqtt5Client client, PublishPacket publishPacket);
+        public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn);
     }
 
     /*******************************************************************************

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
@@ -298,8 +298,9 @@ public class Mqtt5ClientOptions {
          * Called when the client begins a connection attempt
          *
          * @param client The client associated with the event
+         * @param onAttemptingConnectReturn The data associated with the onAttemptingConnect event.
          */
-        public void onAttemptingConnect(Mqtt5Client client);
+        public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn);
 
         /**
          * Called when the client successfully establishes an MQTT connection
@@ -336,8 +337,9 @@ public class Mqtt5ClientOptions {
          * Called when the client reaches the 'Stopped' state as a result of the user invoking .stop()
          *
          * @param client The client associated with the event
+         * @param onStoppedReturn The data associated with the onStopped event.
          */
-        public void onStopped(Mqtt5Client client);
+        public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn);
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
@@ -309,7 +309,7 @@ public class Mqtt5ClientOptions {
          * @param connAckData The ConnAckPacket for the connection
          * @param negotiatedSettings The NegotiatedSettings for the connection
          */
-        public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData, NegotiatedSettings negotiatedSettings);
+        public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn);
 
         /**
          * Called when the client fails to establish an MQTT connection

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/OnAttemptingConnectReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/OnAttemptingConnectReturn.java
@@ -5,7 +5,7 @@
 package software.amazon.awssdk.crt.mqtt5;
 
 /**
- * The data returned when a AttemptingConnect is invoked in the LifecycleEvents callback.
+ * The data returned when AttemptingConnect is invoked in the LifecycleEvents callback.
  * Currently empty, but may be used in the future for passing additional data.
  */
 public class OnAttemptingConnectReturn {

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/OnAttemptingConnectReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/OnAttemptingConnectReturn.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package software.amazon.awssdk.crt.mqtt5;
+
+/**
+ * The data returned when a AttemptingConnect is invoked in the LifecycleEvents callback.
+ * Currently empty, but may be used in the future for passing additional data.
+ */
+public class OnAttemptingConnectReturn {
+    /**
+     * This is only called in JNI to make a new OnAttemptingConnectReturn.
+     */
+    private OnAttemptingConnectReturn() {}
+}

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/OnConnectionFailureReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/OnConnectionFailureReturn.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package software.amazon.awssdk.crt.mqtt5;
+
+import software.amazon.awssdk.crt.mqtt5.packets.ConnAckPacket;
+
+/**
+ * The data returned when OnConnectionFailure is invoked in the LifecycleEvents callback.
+ * The data contained within can be gotten using the <code>get</code> functions.
+ * For example, <code>getConnAckPacket</code> will return the ConnAckPacket from the server.
+ */
+public class OnConnectionFailureReturn {
+    private int errorCode;
+    private ConnAckPacket connAckPacket;
+
+    /**
+     * Returns the error code returned from the server on the connection failure.
+     * Pass to {@link software.amazon.awssdk.crt.CRT#awsErrorString(int)} for a human readable error.
+     * @return The error code returned from the server.
+     */
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+    /**
+     * Returns the ConnAckPacket returned from the server on the connection failure, or Null if none was returned.
+     * @return The ConnAckPacket returned from the server.
+     */
+    public ConnAckPacket getConnAckPacket() {
+        return connAckPacket;
+    }
+
+    /**
+     * This is only called in JNI to make a new OnConnectionFailureReturn.
+     */
+    private OnConnectionFailureReturn(int newErrorCode, ConnAckPacket newConnAckPacket)
+    {
+        this.errorCode = newErrorCode;
+        this.connAckPacket = newConnAckPacket;
+    }
+}

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/OnConnectionSuccessReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/OnConnectionSuccessReturn.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package software.amazon.awssdk.crt.mqtt5;
+
+import software.amazon.awssdk.crt.mqtt5.packets.ConnAckPacket;
+
+/**
+ * The data returned when OnConnectionSuccess is invoked in the LifecycleEvents callback.
+ * The data contained within can be gotten using the <code>get</code> functions.
+ * For example, <code>getResultPublishPacket</code> will return the PublishPacket from the server.
+ */
+public class OnConnectionSuccessReturn {
+    private ConnAckPacket connAckPacket;
+    private NegotiatedSettings negotiatedSettings;
+
+    /**
+     * Returns the ConnAckPacket returned from the server on the connection success or Null if none was returned.
+     * @return The ConnAckPacket returned from the server.
+     */
+    public ConnAckPacket getConnAckPacket() {
+        return connAckPacket;
+    }
+
+    /**
+     * Returns the NegotiatedSettings returned from the server on the connection success or Null if none was returned.
+     * @return The NegotiatedSettings returned from the server.
+     */
+    public NegotiatedSettings getNegotiatedSettings() {
+        return negotiatedSettings;
+    }
+
+    /**
+     * This is only called in JNI to make a new OnConnectionSuccessReturn.
+     */
+    private OnConnectionSuccessReturn(ConnAckPacket newConnAckPacket, NegotiatedSettings newNegotiatedSettings)
+    {
+        this.connAckPacket = newConnAckPacket;
+        this.negotiatedSettings = newNegotiatedSettings;
+    }
+}

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/OnDisconnectionReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/OnDisconnectionReturn.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package software.amazon.awssdk.crt.mqtt5;
+
+import software.amazon.awssdk.crt.mqtt5.packets.DisconnectPacket;
+
+/**
+ * The data returned when OnDisconnect is invoked in the LifecycleEvents callback.
+ * The data contained within can be gotten using the <code>get</code> functions.
+ * For example, <code>getDisconnectPacket</code> will return the DisconnectPacket from the server.
+ */
+public class OnDisconnectionReturn {
+    private int errorCode;
+    private DisconnectPacket disconnectPacket;
+
+    /**
+     * Returns the error code returned from the server on the disconnection.
+     * Pass to {@link software.amazon.awssdk.crt.CRT#awsErrorString(int)} for a human readable error.
+     * @return The error code returned from the server.
+     */
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+    /**
+     * Returns the ConnAckPacket returned from the server on the disconnection, or Null if none was returned.
+     * @return The ConnAckPacket returned from the server.
+     */
+    public DisconnectPacket getDisconnectPacket() {
+        return disconnectPacket;
+    }
+
+    /**
+     * This is only called in JNI to make a new OnDisconnectionReturn.
+     */
+    private OnDisconnectionReturn(int newErrorCode, DisconnectPacket newDisconnectPacket)
+    {
+        this.errorCode = newErrorCode;
+        this.disconnectPacket = newDisconnectPacket;
+    }
+}

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/OnStoppedReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/OnStoppedReturn.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package software.amazon.awssdk.crt.mqtt5;
+
+/**
+ * The data returned when a OnStopped is invoked in the LifecycleEvents callback.
+ * Currently empty, but may be used in the future for passing additional data.
+ */
+public class OnStoppedReturn {
+    /**
+     * This is only called in JNI to make a new OnStoppedReturn.
+     */
+    private OnStoppedReturn() {}
+}

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/OnStoppedReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/OnStoppedReturn.java
@@ -5,7 +5,7 @@
 package software.amazon.awssdk.crt.mqtt5;
 
 /**
- * The data returned when a OnStopped is invoked in the LifecycleEvents callback.
+ * The data returned when OnStopped is invoked in the LifecycleEvents callback.
  * Currently empty, but may be used in the future for passing additional data.
  */
 public class OnStoppedReturn {

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/PublishResult.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/PublishResult.java
@@ -52,7 +52,7 @@ public class PublishResult {
         } else if (type == PublishResultType.PUBACK) {
             return getResultPubAck();
         } else {
-            Log.log(LogLevel.Error, LogSubject.MqttClient, "Cannot get value - unknown type of: " + type);
+            Log.log(LogLevel.Error, LogSubject.MqttClient, "PublishResult: Cannot get value - unknown type of: " + type);
             return null;
         }
     }

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/PublishReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/PublishReturn.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package software.amazon.awssdk.crt.mqtt5;
+
+import software.amazon.awssdk.crt.mqtt5.packets.PublishPacket;
+
+/**
+ * The type of data returned when a publish is made to a topic the MQTT5 client is subscribed to.
+ * The data contained within can be gotten using the <code>getResult</code> functions.
+ * For example, <code>getResultPublishPacket</code> will return the PublishPacket from the server.
+ */
+public class PublishReturn {
+    // The publishPacket from the server
+    private PublishPacket publishPacket;
+
+    /**
+     * Returns the PublishPacket returned from the server or Null if none was returned.
+     * @return The PublishPacket returned from the server.
+     */
+    public PublishPacket getPublishPacket() {
+        return publishPacket;
+    }
+
+    /**
+     * This is only called in JNI to make a new PublishReturn with a PUBLISH packet.
+     * @param newPublishPacket The PubAckPacket data for QoS 1 packets. Can be null if result is non QoS 1.
+     * @return A newly created PublishResult
+     */
+    private PublishReturn(PublishPacket newPublishPacket) {
+        this.publishPacket = newPublishPacket;
+    }
+}

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/PublishReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/PublishReturn.java
@@ -7,7 +7,7 @@ package software.amazon.awssdk.crt.mqtt5;
 import software.amazon.awssdk.crt.mqtt5.packets.PublishPacket;
 
 /**
- * The type of data returned when a publish is made to a topic the MQTT5 client is subscribed to.
+ * The data returned when a publish is made to a topic the MQTT5 client is subscribed to.
  * The data contained within can be gotten using the <code>getResult</code> functions.
  * For example, <code>getResultPublishPacket</code> will return the PublishPacket from the server.
  */

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/PublishReturn.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/PublishReturn.java
@@ -8,11 +8,10 @@ import software.amazon.awssdk.crt.mqtt5.packets.PublishPacket;
 
 /**
  * The data returned when a publish is made to a topic the MQTT5 client is subscribed to.
- * The data contained within can be gotten using the <code>getResult</code> functions.
- * For example, <code>getResultPublishPacket</code> will return the PublishPacket from the server.
+ * The data contained within can be gotten using the <code>get</code> functions.
+ * For example, <code>getPublishPacket</code> will return the PublishPacket received from the server.
  */
 public class PublishReturn {
-    // The publishPacket from the server
     private PublishPacket publishPacket;
 
     /**

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1856,19 +1856,22 @@ static void s_cache_mqtt5_lifecycle_events_properties(JNIEnv *env) {
         env,
         mqtt5_lifecycle_events_properties.lifecycle_events_class,
         "onAttemptingConnect",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/OnAttemptingConnectReturn;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/"
+        "OnAttemptingConnectReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_lifecycle_events_properties.lifecycle_attempting_connect_id);
     mqtt5_lifecycle_events_properties.lifecycle_connection_success_id = (*env)->GetMethodID(
         env,
         mqtt5_lifecycle_events_properties.lifecycle_events_class,
         "onConnectionSuccess",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/OnConnectionSuccessReturn;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/"
+        "OnConnectionSuccessReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_lifecycle_events_properties.lifecycle_connection_success_id);
     mqtt5_lifecycle_events_properties.lifecycle_connection_failure_id = (*env)->GetMethodID(
         env,
         mqtt5_lifecycle_events_properties.lifecycle_events_class,
         "onConnectionFailure",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/OnConnectionFailureReturn;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/"
+        "OnConnectionFailureReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_lifecycle_events_properties.lifecycle_connection_failure_id);
     mqtt5_lifecycle_events_properties.lifecycle_disconnection_id = (*env)->GetMethodID(
         env,
@@ -1927,11 +1930,8 @@ static void s_cache_mqtt5_on_stopped_return(JNIEnv *env) {
     mqtt5_on_stopped_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
     AWS_FATAL_ASSERT(mqtt5_on_stopped_return_properties.return_class);
     // Functions
-    mqtt5_on_stopped_return_properties.return_constructor_id = (*env)->GetMethodID(
-        env,
-        mqtt5_on_stopped_return_properties.return_class,
-        "<init>",
-        "()V");
+    mqtt5_on_stopped_return_properties.return_constructor_id =
+        (*env)->GetMethodID(env, mqtt5_on_stopped_return_properties.return_class, "<init>", "()V");
     AWS_FATAL_ASSERT(mqtt5_on_stopped_return_properties.return_constructor_id);
 }
 
@@ -1943,11 +1943,8 @@ static void s_cache_mqtt5_on_attempting_connect_return(JNIEnv *env) {
     mqtt5_on_attempting_connect_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
     AWS_FATAL_ASSERT(mqtt5_on_attempting_connect_return_properties.return_class);
     // Functions
-    mqtt5_on_attempting_connect_return_properties.return_constructor_id = (*env)->GetMethodID(
-        env,
-        mqtt5_on_attempting_connect_return_properties.return_class,
-        "<init>",
-        "()V");
+    mqtt5_on_attempting_connect_return_properties.return_constructor_id =
+        (*env)->GetMethodID(env, mqtt5_on_attempting_connect_return_properties.return_class, "<init>", "()V");
     AWS_FATAL_ASSERT(mqtt5_on_attempting_connect_return_properties.return_constructor_id);
 }
 
@@ -1963,7 +1960,8 @@ static void s_cache_mqtt5_on_connection_success_return(JNIEnv *env) {
         env,
         mqtt5_on_connection_success_return_properties.return_class,
         "<init>",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket;Lsoftware/amazon/awssdk/crt/mqtt5/NegotiatedSettings;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket;Lsoftware/amazon/awssdk/crt/mqtt5/"
+        "NegotiatedSettings;)V");
     AWS_FATAL_ASSERT(mqtt5_on_connection_success_return_properties.return_constructor_id);
 }
 

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1856,7 +1856,7 @@ static void s_cache_mqtt5_lifecycle_events_properties(JNIEnv *env) {
         env,
         mqtt5_lifecycle_events_properties.lifecycle_events_class,
         "onAttemptingConnect",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/OnAttemptingConnectReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_lifecycle_events_properties.lifecycle_attempting_connect_id);
     mqtt5_lifecycle_events_properties.lifecycle_connection_success_id = (*env)->GetMethodID(
         env,
@@ -1882,7 +1882,7 @@ static void s_cache_mqtt5_lifecycle_events_properties(JNIEnv *env) {
         env,
         mqtt5_lifecycle_events_properties.lifecycle_events_class,
         "onStopped",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/OnStoppedReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_lifecycle_events_properties.lifecycle_stopped_id);
 }
 
@@ -1907,7 +1907,7 @@ static void s_cache_mqtt5_puback_result(JNIEnv *env) {
 
 struct java_aws_mqtt5_publish_return_properties mqtt5_publish_return_properties;
 
-static void s_cache_mqtt5_puback_return(JNIEnv *env) {
+static void s_cache_mqtt5_publish_return(JNIEnv *env) {
     jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/mqtt5/PublishReturn");
     AWS_FATAL_ASSERT(cls);
     mqtt5_publish_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
@@ -1919,6 +1919,38 @@ static void s_cache_mqtt5_puback_return(JNIEnv *env) {
         "<init>",
         "(Lsoftware/amazon/awssdk/crt/mqtt5/packets/PublishPacket;)V");
     AWS_FATAL_ASSERT(mqtt5_publish_return_properties.return_constructor_id);
+}
+
+struct java_aws_mqtt5_on_stopped_return_properties mqtt5_on_stopped_return_properties;
+
+static void s_cache_mqtt5_on_stopped_return(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/mqtt5/OnStoppedReturn");
+    AWS_FATAL_ASSERT(cls);
+    mqtt5_on_stopped_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
+    AWS_FATAL_ASSERT(mqtt5_on_stopped_return_properties.return_class);
+    // Functions
+    mqtt5_on_stopped_return_properties.return_constructor_id = (*env)->GetMethodID(
+        env,
+        mqtt5_on_stopped_return_properties.return_class,
+        "<init>",
+        "()V");
+    AWS_FATAL_ASSERT(mqtt5_on_stopped_return_properties.return_constructor_id);
+}
+
+struct java_aws_mqtt5_on_attempting_connect_return_properties mqtt5_on_attempting_connect_return_properties;
+
+static void s_cache_mqtt5_on_attempting_connect_return(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/mqtt5/OnAttemptingConnectReturn");
+    AWS_FATAL_ASSERT(cls);
+    mqtt5_on_attempting_connect_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
+    AWS_FATAL_ASSERT(mqtt5_on_attempting_connect_return_properties.return_class);
+    // Functions
+    mqtt5_on_attempting_connect_return_properties.return_constructor_id = (*env)->GetMethodID(
+        env,
+        mqtt5_on_attempting_connect_return_properties.return_class,
+        "<init>",
+        "()V");
+    AWS_FATAL_ASSERT(mqtt5_on_attempting_connect_return_properties.return_constructor_id);
 }
 
 struct java_boxed_integer_properties boxed_integer_properties;
@@ -2067,7 +2099,9 @@ void cache_java_class_ids(JNIEnv *env) {
     s_cache_mqtt5_publish_events_properties(env);
     s_cache_mqtt5_lifecycle_events_properties(env);
     s_cache_mqtt5_puback_result(env);
-    s_cache_mqtt5_puback_return(env);
+    s_cache_mqtt5_publish_return(env);
+    s_cache_mqtt5_on_stopped_return(env);
+    s_cache_mqtt5_on_attempting_connect_return(env);
     s_cache_boxed_integer(env);
     s_cache_boxed_boolean(env);
     s_cache_boxed_list(env);

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1862,8 +1862,7 @@ static void s_cache_mqtt5_lifecycle_events_properties(JNIEnv *env) {
         env,
         mqtt5_lifecycle_events_properties.lifecycle_events_class,
         "onConnectionSuccess",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/packets/"
-        "ConnAckPacket;Lsoftware/amazon/awssdk/crt/mqtt5/NegotiatedSettings;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/OnConnectionSuccessReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_lifecycle_events_properties.lifecycle_connection_success_id);
     mqtt5_lifecycle_events_properties.lifecycle_connection_failure_id = (*env)->GetMethodID(
         env,
@@ -1951,6 +1950,22 @@ static void s_cache_mqtt5_on_attempting_connect_return(JNIEnv *env) {
         "<init>",
         "()V");
     AWS_FATAL_ASSERT(mqtt5_on_attempting_connect_return_properties.return_constructor_id);
+}
+
+struct java_aws_mqtt5_on_connection_success_return_properties mqtt5_on_connection_success_return_properties;
+
+static void s_cache_mqtt5_on_connection_success_return(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/mqtt5/OnConnectionSuccessReturn");
+    AWS_FATAL_ASSERT(cls);
+    mqtt5_on_connection_success_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
+    AWS_FATAL_ASSERT(mqtt5_on_connection_success_return_properties.return_class);
+    // Functions
+    mqtt5_on_connection_success_return_properties.return_constructor_id = (*env)->GetMethodID(
+        env,
+        mqtt5_on_connection_success_return_properties.return_class,
+        "<init>",
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket;Lsoftware/amazon/awssdk/crt/mqtt5/NegotiatedSettings;)V");
+    AWS_FATAL_ASSERT(mqtt5_on_connection_success_return_properties.return_constructor_id);
 }
 
 struct java_boxed_integer_properties boxed_integer_properties;
@@ -2102,6 +2117,7 @@ void cache_java_class_ids(JNIEnv *env) {
     s_cache_mqtt5_publish_return(env);
     s_cache_mqtt5_on_stopped_return(env);
     s_cache_mqtt5_on_attempting_connect_return(env);
+    s_cache_mqtt5_on_connection_success_return(env);
     s_cache_boxed_integer(env);
     s_cache_boxed_boolean(env);
     s_cache_boxed_list(env);

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1840,7 +1840,7 @@ static void s_cache_mqtt5_publish_events_properties(JNIEnv *env) {
         env,
         mqtt5_publish_events_properties.publish_events_class,
         "onMessageReceived",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/packets/PublishPacket;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/PublishReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_publish_events_properties.publish_events_publish_received_id);
 }
 
@@ -1903,6 +1903,22 @@ static void s_cache_mqtt5_puback_result(JNIEnv *env) {
         "<init>",
         "(Lsoftware/amazon/awssdk/crt/mqtt5/packets/PubAckPacket;)V");
     AWS_FATAL_ASSERT(mqtt5_publish_result_properties.result_puback_constructor_id);
+}
+
+struct java_aws_mqtt5_publish_return_properties mqtt5_publish_return_properties;
+
+static void s_cache_mqtt5_puback_return(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/mqtt5/PublishReturn");
+    AWS_FATAL_ASSERT(cls);
+    mqtt5_publish_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
+    AWS_FATAL_ASSERT(mqtt5_publish_return_properties.return_class);
+    // Functions
+    mqtt5_publish_return_properties.return_constructor_id = (*env)->GetMethodID(
+        env,
+        mqtt5_publish_return_properties.return_class,
+        "<init>",
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/packets/PublishPacket;)V");
+    AWS_FATAL_ASSERT(mqtt5_publish_return_properties.return_constructor_id);
 }
 
 struct java_boxed_integer_properties boxed_integer_properties;
@@ -2051,6 +2067,7 @@ void cache_java_class_ids(JNIEnv *env) {
     s_cache_mqtt5_publish_events_properties(env);
     s_cache_mqtt5_lifecycle_events_properties(env);
     s_cache_mqtt5_puback_result(env);
+    s_cache_mqtt5_puback_return(env);
     s_cache_boxed_integer(env);
     s_cache_boxed_boolean(env);
     s_cache_boxed_list(env);

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1868,14 +1868,13 @@ static void s_cache_mqtt5_lifecycle_events_properties(JNIEnv *env) {
         env,
         mqtt5_lifecycle_events_properties.lifecycle_events_class,
         "onConnectionFailure",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;ILsoftware/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/OnConnectionFailureReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_lifecycle_events_properties.lifecycle_connection_failure_id);
     mqtt5_lifecycle_events_properties.lifecycle_disconnection_id = (*env)->GetMethodID(
         env,
         mqtt5_lifecycle_events_properties.lifecycle_events_class,
         "onDisconnection",
-        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;ILsoftware/amazon/awssdk/crt/mqtt5/packets/"
-        "DisconnectPacket;)V");
+        "(Lsoftware/amazon/awssdk/crt/mqtt5/Mqtt5Client;Lsoftware/amazon/awssdk/crt/mqtt5/OnDisconnectionReturn;)V");
     AWS_FATAL_ASSERT(mqtt5_lifecycle_events_properties.lifecycle_disconnection_id);
     mqtt5_lifecycle_events_properties.lifecycle_stopped_id = (*env)->GetMethodID(
         env,
@@ -1966,6 +1965,38 @@ static void s_cache_mqtt5_on_connection_success_return(JNIEnv *env) {
         "<init>",
         "(Lsoftware/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket;Lsoftware/amazon/awssdk/crt/mqtt5/NegotiatedSettings;)V");
     AWS_FATAL_ASSERT(mqtt5_on_connection_success_return_properties.return_constructor_id);
+}
+
+struct java_aws_mqtt5_on_connection_failure_return_properties mqtt5_on_connection_failure_return_properties;
+
+static void s_cache_mqtt5_on_connection_failure_return(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/mqtt5/OnConnectionFailureReturn");
+    AWS_FATAL_ASSERT(cls);
+    mqtt5_on_connection_failure_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
+    AWS_FATAL_ASSERT(mqtt5_on_connection_failure_return_properties.return_class);
+    // Functions
+    mqtt5_on_connection_failure_return_properties.return_constructor_id = (*env)->GetMethodID(
+        env,
+        mqtt5_on_connection_failure_return_properties.return_class,
+        "<init>",
+        "(ILsoftware/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket;)V");
+    AWS_FATAL_ASSERT(mqtt5_on_connection_failure_return_properties.return_constructor_id);
+}
+
+struct java_aws_mqtt5_on_disconnection_return_properties mqtt5_on_disconnection_return_properties;
+
+static void s_cache_mqtt5_on_disconnection_return(JNIEnv *env) {
+    jclass cls = (*env)->FindClass(env, "software/amazon/awssdk/crt/mqtt5/OnDisconnectionReturn");
+    AWS_FATAL_ASSERT(cls);
+    mqtt5_on_disconnection_return_properties.return_class = (*env)->NewGlobalRef(env, cls);
+    AWS_FATAL_ASSERT(mqtt5_on_disconnection_return_properties.return_class);
+    // Functions
+    mqtt5_on_disconnection_return_properties.return_constructor_id = (*env)->GetMethodID(
+        env,
+        mqtt5_on_disconnection_return_properties.return_class,
+        "<init>",
+        "(ILsoftware/amazon/awssdk/crt/mqtt5/packets/DisconnectPacket;)V");
+    AWS_FATAL_ASSERT(mqtt5_on_disconnection_return_properties.return_constructor_id);
 }
 
 struct java_boxed_integer_properties boxed_integer_properties;
@@ -2118,6 +2149,8 @@ void cache_java_class_ids(JNIEnv *env) {
     s_cache_mqtt5_on_stopped_return(env);
     s_cache_mqtt5_on_attempting_connect_return(env);
     s_cache_mqtt5_on_connection_success_return(env);
+    s_cache_mqtt5_on_connection_failure_return(env);
+    s_cache_mqtt5_on_disconnection_return(env);
     s_cache_boxed_integer(env);
     s_cache_boxed_boolean(env);
     s_cache_boxed_list(env);

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -788,6 +788,13 @@ struct java_aws_mqtt5_publish_result_properties {
 };
 extern struct java_aws_mqtt5_publish_result_properties mqtt5_publish_result_properties;
 
+/* mqtt5.PublishReturn */
+struct java_aws_mqtt5_publish_return_properties {
+    jclass return_class;
+    jmethodID return_constructor_id;
+};
+extern struct java_aws_mqtt5_publish_return_properties mqtt5_publish_return_properties;
+
 /* java/lang/Integer */
 struct java_boxed_integer_properties {
     jclass integer_class;

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -816,6 +816,20 @@ struct java_aws_mqtt5_on_connection_success_return_properties {
 };
 extern struct java_aws_mqtt5_on_connection_success_return_properties mqtt5_on_connection_success_return_properties;
 
+/* mqtt5.OnConnectionFailureReturn */
+struct java_aws_mqtt5_on_connection_failure_return_properties {
+    jclass return_class;
+    jmethodID return_constructor_id;
+};
+extern struct java_aws_mqtt5_on_connection_failure_return_properties mqtt5_on_connection_failure_return_properties;
+
+/* mqtt5.OnDisconnectionReturn */
+struct java_aws_mqtt5_on_disconnection_return_properties {
+    jclass return_class;
+    jmethodID return_constructor_id;
+};
+extern struct java_aws_mqtt5_on_disconnection_return_properties mqtt5_on_disconnection_return_properties;
+
 /* java/lang/Integer */
 struct java_boxed_integer_properties {
     jclass integer_class;

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -795,6 +795,20 @@ struct java_aws_mqtt5_publish_return_properties {
 };
 extern struct java_aws_mqtt5_publish_return_properties mqtt5_publish_return_properties;
 
+/* mqtt5.OnStoppedReturn */
+struct java_aws_mqtt5_on_stopped_return_properties {
+    jclass return_class;
+    jmethodID return_constructor_id;
+};
+extern struct java_aws_mqtt5_on_stopped_return_properties mqtt5_on_stopped_return_properties;
+
+/* mqtt5.OnAttemptingConnectReturn */
+struct java_aws_mqtt5_on_attempting_connect_return_properties {
+    jclass return_class;
+    jmethodID return_constructor_id;
+};
+extern struct java_aws_mqtt5_on_attempting_connect_return_properties mqtt5_on_attempting_connect_return_properties;
+
 /* java/lang/Integer */
 struct java_boxed_integer_properties {
     jclass integer_class;

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -809,6 +809,13 @@ struct java_aws_mqtt5_on_attempting_connect_return_properties {
 };
 extern struct java_aws_mqtt5_on_attempting_connect_return_properties mqtt5_on_attempting_connect_return_properties;
 
+/* mqtt5.OnConnectionSuccessReturn */
+struct java_aws_mqtt5_on_connection_success_return_properties {
+    jclass return_class;
+    jmethodID return_constructor_id;
+};
+extern struct java_aws_mqtt5_on_connection_success_return_properties mqtt5_on_connection_success_return_properties;
+
 /* java/lang/Integer */
 struct java_boxed_integer_properties {
     jclass integer_class;

--- a/src/native/mqtt5_client.c
+++ b/src/native/mqtt5_client.c
@@ -1072,33 +1072,45 @@ static void s_aws_mqtt5_client_java_lifecycle_event(const struct aws_mqtt5_clien
         case AWS_MQTT5_CLET_CONNECTION_FAILURE: {
             jint error_code = (jint)event->error_code;
 
-            /* TODO: Make the OnConnectionFailureReturn struct */
+            /* Make the OnConnectionFailureReturn struct */
+            java_lifecycle_return_data = (*env)->NewObject(
+                env,
+                mqtt5_on_connection_failure_return_properties.return_class,
+                mqtt5_on_connection_failure_return_properties.return_constructor_id,
+                error_code,
+                connack_data);
+            aws_jni_check_and_clear_exception(env); // To hide JNI warning
 
             (*env)->CallObjectMethod(
                 env,
                 jni_lifecycle_events,
                 mqtt5_lifecycle_events_properties.lifecycle_connection_failure_id,
                 java_client->jni_client,
-                error_code,
-                connack_data);
+                java_lifecycle_return_data);
             break;
         }
         case AWS_MQTT5_CLET_DISCONNECTION: {
+            jint error_code = (jint)event->error_code;
 
-            /* TODO: Make the OnDisconnectionReturn struct */
+            /* Make the OnDisconnectionReturn struct */
+            java_lifecycle_return_data = (*env)->NewObject(
+                env,
+                mqtt5_on_disconnection_return_properties.return_class,
+                mqtt5_on_disconnection_return_properties.return_constructor_id,
+                error_code,
+                disconnect_data);
+            aws_jni_check_and_clear_exception(env); // To hide JNI warning
 
             // Set OnConnected BEFORE calling the callback so it is accurate in the callback itself.
             (*env)->CallBooleanMethod(
                 env, java_client->jni_client, mqtt5_client_properties.client_set_is_connected, false);
 
-            jint error_code = (jint)event->error_code;
             (*env)->CallObjectMethod(
                 env,
                 jni_lifecycle_events,
                 mqtt5_lifecycle_events_properties.lifecycle_disconnection_id,
                 java_client->jni_client,
-                error_code,
-                disconnect_data);
+                java_lifecycle_return_data);
             break;
         }
         case AWS_MQTT5_CLET_STOPPED:

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -154,8 +154,8 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         PublishPacket publishPacket = null;
 
         @Override
-        public void onMessageReceived(Mqtt5Client client, PublishPacket result) {
-            publishPacket = result;
+        public void onMessageReceived(Mqtt5Client client, PublishReturn result) {
+            publishPacket = result.getPublishPacket();
             publishReceivedFuture.complete(null);
         }
     }
@@ -167,7 +167,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         List<PublishPacket> publishPacketsRecieved = new ArrayList<PublishPacket>();
 
         @Override
-        public void onMessageReceived(Mqtt5Client client, PublishPacket result) {
+        public void onMessageReceived(Mqtt5Client client, PublishReturn result) {
             currentPublishCount += 1;
             if (currentPublishCount == desiredPublishCount) {
                 publishReceivedFuture.complete(null);
@@ -178,7 +178,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             if (publishPacketsRecieved.contains(result)) {
                 publishReceivedFuture.completeExceptionally(new Throwable("Duplicate publish packet received!"));
             }
-            publishPacketsRecieved.add(result);
+            publishPacketsRecieved.add(result.getPublishPacket());
         }
     }
 
@@ -271,7 +271,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             .withPort(mqtt5DirectMqttPort)
             .withPublishEvents(new PublishEvents() {
                 @Override
-                public void onMessageReceived(Mqtt5Client client, PublishPacket publishPacket) {}
+                public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
             })
             .withRetryJitterMode(JitterMode.Default)
             .withSessionBehavior(ClientSessionBehavior.CLEAN)
@@ -374,7 +374,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             .withPort(mqtt5DirectMqttPort)
             .withPublishEvents(new PublishEvents() {
                 @Override
-                public void onMessageReceived(Mqtt5Client client, PublishPacket publishPacket) {}
+                public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
             })
             .withRetryJitterMode(JitterMode.Default)
             .withSessionBehavior(ClientSessionBehavior.CLEAN)
@@ -594,7 +594,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             .withPort(mqtt5DirectMqttPort)
             .withPublishEvents(new PublishEvents() {
                 @Override
-                public void onMessageReceived(Mqtt5Client client, PublishPacket publishPacket) {}
+                public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
             })
             .withRetryJitterMode(JitterMode.Default)
             .withSessionBehavior(ClientSessionBehavior.CLEAN)
@@ -879,7 +879,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             .withPort(mqtt5WSMqttPort)
             .withPublishEvents(new PublishEvents() {
                 @Override
-                public void onMessageReceived(Mqtt5Client client, PublishPacket publishPacket) {}
+                public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
             })
             .withRetryJitterMode(JitterMode.Default)
             .withSessionBehavior(ClientSessionBehavior.CLEAN)

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -121,7 +121,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         DisconnectPacket disconnectPacket = null;
 
         @Override
-        public void onAttemptingConnect(Mqtt5Client client) {}
+        public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
         @Override
         public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData, NegotiatedSettings negotiatedSettings) {
@@ -144,7 +144,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         }
 
         @Override
-        public void onStopped(Mqtt5Client client) {
+        public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {
             stopFuture.complete(null);
         }
     }
@@ -247,7 +247,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             .withHostName(mqtt5DirectMqttHost)
             .withLifecycleEvents(new LifecycleEvents() {
                 @Override
-                public void onAttemptingConnect(Mqtt5Client client) {}
+                public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
                 @Override
                 public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData,
@@ -260,7 +260,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 public void onDisconnection(Mqtt5Client client, int disconnectCode, DisconnectPacket disconnectData) {}
 
                 @Override
-                public void onStopped(Mqtt5Client client) {}
+                public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
             })
             .withMaxReconnectDelayMs(1000L)
             .withMinConnectedTimeToResetReconnectDelayMs(1000L)
@@ -350,7 +350,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             .withHostName(mqtt5DirectMqttHost)
             .withLifecycleEvents(new LifecycleEvents() {
                 @Override
-                public void onAttemptingConnect(Mqtt5Client client) {}
+                public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
                 @Override
                 public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData,
@@ -363,7 +363,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 public void onDisconnection(Mqtt5Client client, int disconnectCode, DisconnectPacket disconnectData) {}
 
                 @Override
-                public void onStopped(Mqtt5Client client) {}
+                public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
             })
             .withMaxReconnectDelayMs(1000L)
             .withMinConnectedTimeToResetReconnectDelayMs(1000L)
@@ -1277,7 +1277,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         CompletableFuture<Void> disconnectedFuture = new CompletableFuture<>();
 
         @Override
-        public void onAttemptingConnect(Mqtt5Client client) {}
+        public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
         @Override
         public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData, NegotiatedSettings negotiatedSettings) {
@@ -1295,7 +1295,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         }
 
         @Override
-        public void onStopped(Mqtt5Client client) {}
+        public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
     }
 
     /* Double Client ID failure test */

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -133,16 +133,16 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         }
 
         @Override
-        public void onConnectionFailure(Mqtt5Client client, int failureCode, ConnAckPacket connAckData) {
-            connectFailureCode = failureCode;
-            connectFailurePacket = connAckData;
+        public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {
+            connectFailureCode = onConnectionFailureReturn.getErrorCode();
+            connectFailurePacket = onConnectionFailureReturn.getConnAckPacket();
             connectedFuture.completeExceptionally(new Exception("Could not connect!"));
         }
 
         @Override
-        public void onDisconnection(Mqtt5Client client, int failureCode, DisconnectPacket disconnectData) {
-            disconnectFailureCode = failureCode;
-            disconnectPacket = disconnectData;
+        public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {
+            disconnectFailureCode = onDisconnectionReturn.getErrorCode();
+            disconnectPacket = onDisconnectionReturn.getDisconnectPacket();
         }
 
         @Override
@@ -255,10 +255,10 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {}
 
                 @Override
-                public void onConnectionFailure(Mqtt5Client client, int errorCode, ConnAckPacket connAckData) {}
+                public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {}
 
                 @Override
-                public void onDisconnection(Mqtt5Client client, int disconnectCode, DisconnectPacket disconnectData) {}
+                public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {}
 
                 @Override
                 public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
@@ -357,10 +357,10 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {}
 
                 @Override
-                public void onConnectionFailure(Mqtt5Client client, int errorCode, ConnAckPacket connAckData) {}
+                public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {}
 
                 @Override
-                public void onDisconnection(Mqtt5Client client, int disconnectCode, DisconnectPacket disconnectData) {}
+                public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {}
 
                 @Override
                 public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
@@ -1285,12 +1285,12 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         }
 
         @Override
-        public void onConnectionFailure(Mqtt5Client client, int failureCode, ConnAckPacket connAckData) {
+        public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {
             connectedFuture.completeExceptionally(new Exception("Could not connect!"));
         }
 
         @Override
-        public void onDisconnection(Mqtt5Client client, int failureCode, DisconnectPacket disconnectData) {
+        public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {
             disconnectedFuture.complete(null);
         }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -124,7 +124,9 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
         @Override
-        public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData, NegotiatedSettings negotiatedSettings) {
+        public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
+            ConnAckPacket connAckData = onConnectionSuccessReturn.getConnAckPacket();
+            NegotiatedSettings negotiatedSettings = onConnectionSuccessReturn.getNegotiatedSettings();
             connectSuccessPacket = connAckData;
             connectSuccessSettings = negotiatedSettings;
             connectedFuture.complete(null);
@@ -250,8 +252,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
                 @Override
-                public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData,
-                        NegotiatedSettings negotiatedSettings) {}
+                public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {}
 
                 @Override
                 public void onConnectionFailure(Mqtt5Client client, int errorCode, ConnAckPacket connAckData) {}
@@ -353,8 +354,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
                 @Override
-                public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData,
-                        NegotiatedSettings negotiatedSettings) {}
+                public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {}
 
                 @Override
                 public void onConnectionFailure(Mqtt5Client client, int errorCode, ConnAckPacket connAckData) {}
@@ -1280,7 +1280,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
         @Override
-        public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData, NegotiatedSettings negotiatedSettings) {
+        public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
             connectedFuture.complete(null);
         }
 

--- a/utils/Canary/src/main/java/canary/mqtt5/Mqtt5Canary.java
+++ b/utils/Canary/src/main/java/canary/mqtt5/Mqtt5Canary.java
@@ -248,7 +248,7 @@ public class Mqtt5Canary {
         }
 
         @Override
-        public void onConnectionFailure(Mqtt5Client client, int failureCode, ConnAckPacket connAckData) {
+        public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {
             int clientIdx = clients.indexOf(client);
             PrintLog("[Lifecycle event] Client ID " + clientIdx + " connection failed...");
             clientsData.get(clientIdx).connectedFuture.completeExceptionally(new Exception("Connection failure"));
@@ -256,7 +256,7 @@ public class Mqtt5Canary {
         }
 
         @Override
-        public void onDisconnection(Mqtt5Client client, int failureCode, DisconnectPacket disconnectData) {
+        public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {
             int clientIdx = clients.indexOf(client);
             PrintLog("[Lifecycle event] Client ID " + clientIdx + " connection disconnected...");
             clientsData.get(clientIdx).connectedFuture = new CompletableFuture<>();

--- a/utils/Canary/src/main/java/canary/mqtt5/Mqtt5Canary.java
+++ b/utils/Canary/src/main/java/canary/mqtt5/Mqtt5Canary.java
@@ -237,7 +237,9 @@ public class Mqtt5Canary {
         public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
         @Override
-        public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData, NegotiatedSettings negotiatedSettings) {
+        public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
+            ConnAckPacket connAckData = onConnectionSuccessReturn.getConnAckPacket();
+            NegotiatedSettings negotiatedSettings = onConnectionSuccessReturn.getNegotiatedSettings();
             int clientIdx = clients.indexOf(client);
             PrintLog("[Lifecycle event] Client ID " + clientIdx + " connection success...");
             clientsData.get(clientIdx).clientId = negotiatedSettings.getAssignedClientID();

--- a/utils/Canary/src/main/java/canary/mqtt5/Mqtt5Canary.java
+++ b/utils/Canary/src/main/java/canary/mqtt5/Mqtt5Canary.java
@@ -234,7 +234,7 @@ public class Mqtt5Canary {
 
     static final class CanaryLifecycleEvents implements Mqtt5ClientOptions.LifecycleEvents {
         @Override
-        public void onAttemptingConnect(Mqtt5Client client) {}
+        public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
         @Override
         public void onConnectionSuccess(Mqtt5Client client, ConnAckPacket connAckData, NegotiatedSettings negotiatedSettings) {
@@ -262,7 +262,7 @@ public class Mqtt5Canary {
         }
 
         @Override
-        public void onStopped(Mqtt5Client client) {
+        public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {
             int clientIdx = clients.indexOf(client);
             PrintLog("[Lifecycle event] Client ID " + clientIdx + " connection stopped...");
             clientsData.get(clientIdx).connectedFuture = new CompletableFuture<>();

--- a/utils/Canary/src/main/java/canary/mqtt5/Mqtt5Canary.java
+++ b/utils/Canary/src/main/java/canary/mqtt5/Mqtt5Canary.java
@@ -273,7 +273,8 @@ public class Mqtt5Canary {
 
     static final class CanaryPublishEvents implements Mqtt5ClientOptions.PublishEvents {
         @Override
-        public void onMessageReceived(Mqtt5Client client, PublishPacket publishPacket) {
+        public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {
+            PublishPacket publishPacket = publishReturn.getPublishPacket();
             int clientIdx = clients.indexOf(client);
             PrintLog("[Publish event] Client ID " + clientIdx + " message received:\n" +
                     "  Topic: " + publishPacket.getTopic() + "\n" +

--- a/utils/mqtt5_test_setup.sh
+++ b/utils/mqtt5_test_setup.sh
@@ -18,7 +18,7 @@ else
     echo ""
     echo "Example: mqtt5_test_setup.sh s3://<bucket>/<file> cleanup"
     echo ""
-    exit 1
+    return 1
 fi
 
 # Is this just a request to clean up?
@@ -41,7 +41,7 @@ else
     rm "${PWD}/iot_privatekey.pem"
 
     echo "Success!"
-    exit 0
+    return 0
 fi
 
 # Get the file from S3
@@ -52,7 +52,7 @@ if [ "${testing_env_file}" != "" ]; then
     echo "Environment variables secret found"
 else
     echo "Could not get environment variables from secrets!"
-    exit 1
+    return 1
 fi
 
 # Make all the variables in mqtt5_environment_variables.txt exported
@@ -75,7 +75,7 @@ else
     rm "${PWD}/crt_certificate.pem"
     rm "${PWD}/crt_privatekey.pem"
 
-    exit 1
+    return 1
 fi
 # Does the private key file have data? If not, then abort!
 if [ "${crt_key_file}" != "" ]; then
@@ -89,7 +89,7 @@ else
     rm "${PWD}/crt_certificate.pem"
     rm "${PWD}/crt_privatekey.pem"
 
-    exit 1
+    return 1
 fi
 # Set the certificate and key paths (absolute paths for best compatbility)
 export AWS_TEST_MQTT5_CERTIFICATE_FILE="${PWD}/crt_certificate.pem"
@@ -116,7 +116,7 @@ else
     rm "${PWD}/iot_certificate.pem"
     rm "${PWD}/iot_privatekey.pem"
 
-    exit 1
+    return 1
 fi
 # Does the private key file have data? If not, then abort!
 if [ "${iot_key_file}" != "" ]; then
@@ -134,7 +134,7 @@ else
     rm "${PWD}/iot_certificate.pem"
     rm "${PWD}/iot_privatekey.pem"
 
-    exit 1
+    return 1
 fi
 # Set IoT certificate and key paths
 export AWS_TEST_MQTT5_IOT_CERTIFICATE_PATH="${PWD}/iot_certificate.pem"
@@ -142,4 +142,4 @@ export AWS_TEST_MQTT5_IOT_KEY_PATH="${PWD}/iot_privatekey.pem"
 
 # Everything is set
 echo "Success: Environment variables set!"
-exit 0
+return 0


### PR DESCRIPTION
*Description of changes:*

Adjusts the callbacks for LifecycleEvents and PublishEvents to return structs rather than passing the data directly. This is done for all MQTT5 lifecycle events, as well as the publish callback.

Also fixes a minor "bug" found in SDK testing where `getOnConnected` was set after the OnConnectionSuccess callback is invoked. This made it where if you checked for the connection status of the MQTT5 client in the OnConnectionSuccess callback, it would always return false even though it just connected. Now it is set before calling the callback, fixing the issue.

SDK and documentation changes will need to be made after CRT merge.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
