### PR TITLE
Only run MQTT5 tests if there is a network

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -193,6 +193,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Happy path. Minimal creation and cleanup */
     @Test
     public void New_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         try {
@@ -208,6 +209,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Maximum creation and cleanup */
     @Test
     public void New_UC2() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         Assume.assumeTrue(mqtt5BasicAuthPassword != null);
@@ -296,6 +298,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Minimal memory check */
     @Test
     public void New_UC3() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         try {
@@ -312,6 +315,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Maximum memory test */
     @Test
     public void New_UC4() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         Assume.assumeTrue(mqtt5BasicAuthPassword != null);
@@ -406,6 +410,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Happy path. Direct connection with minimal configuration */
     @Test
     public void ConnDC_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         try {
@@ -429,6 +434,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Direct connection with basic authentication */
     @Test
     public void ConnDC_UC2() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttBasicAuthHost != null);
         Assume.assumeTrue(mqtt5DirectMqttBasicAuthPort != null);
         Assume.assumeTrue(mqtt5BasicAuthUsername != null);
@@ -459,6 +465,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Direct connection with TLS */
     @Test
     public void ConnDC_UC3() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttTlsHost != null);
         Assume.assumeTrue(mqtt5DirectMqttTlsPort != null);
         Assume.assumeTrue(mqtt5CertificateFile != null);
@@ -495,6 +502,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Direct connection with HttpProxyOptions */
     @Test
     public void ConnDC_UC5() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttTlsHost != null);
         Assume.assumeTrue(mqtt5DirectMqttTlsPort != null);
         Assume.assumeTrue(mqtt5ProxyHost != null);
@@ -545,6 +553,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Maximum options set connection test */
     @Test
     public void ConnDC_UC6() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         Assume.assumeTrue(mqtt5BasicAuthPassword != null);
@@ -630,6 +639,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Happy path. Websocket connection with minimal configuration */
     @Test
     public void ConnWS_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5WSMqttHost != null);
         Assume.assumeTrue(mqtt5WSMqttPort != null);
         try {
@@ -672,6 +682,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Websocket connection with basic authentication */
     @Test
     public void ConnWS_UC2() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5WSMqttBasicAuthHost != null);
         Assume.assumeTrue(mqtt5WSMqttBasicAuthPort != null);
         Assume.assumeTrue(mqtt5BasicAuthUsername != null);
@@ -719,6 +730,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Websocket connection with TLS */
     @Test
     public void ConnWS_UC3() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5WSMqttTlsHost != null);
         Assume.assumeTrue(mqtt5WSMqttTlsPort != null);
         Assume.assumeTrue(mqtt5CertificateFile != null);
@@ -771,6 +783,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* TODO - get this test working in Codebuild CI */
     // @Test
     // public void ConnWS_UC5() {
+    //     skipIfNetworkUnavailable();
     //     Assume.assumeTrue(mqtt5ProxyHost != null);
     //     Assume.assumeTrue(mqtt5ProxyPort != null);
     //     Assume.assumeTrue(mqtt5WSMqttTlsHost != null);
@@ -830,6 +843,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Websocket connection with all options set */
     @Test
     public void ConnWS_UC6() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5WSMqttHost != null);
         Assume.assumeTrue(mqtt5WSMqttPort != null);
         Assume.assumeTrue(mqtt5BasicAuthPassword != null);
@@ -921,6 +935,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Client connect with invalid host name */
     @Test
     public void ConnNegativeID_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5WSMqttPort != null);
         boolean foundExpectedError = false;
         boolean exceptionOccurred = false;
@@ -963,6 +978,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Client connect with invalid, nonexistent port for direct connection */
     @Test
     public void ConnNegativeID_UC2() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         boolean foundExpectedError = false;
         boolean exceptionOccurred = false;
@@ -1000,6 +1016,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Client connect with invalid protocol port for direct connection */
     @Test
     public void ConnNegativeID_UC2_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5WSMqttPort != null);
         boolean foundExpectedError = false;
@@ -1038,6 +1055,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Client connect with invalid, nonexistent port for websocket connection */
     @Test
     public void ConnNegativeID_UC3() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5WSMqttHost != null);
         boolean foundExpectedError = false;
         boolean exceptionOccurred = false;
@@ -1093,6 +1111,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Client connect with invalid protocol port for websocket connection */
     @Test
     public void ConnNegativeID_UC3_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5WSMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean foundExpectedError = false;
@@ -1149,6 +1168,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Client connect with socket timeout */
     @Test
     public void ConnNegativeID_UC4() {
+        skipIfNetworkUnavailable();
         boolean foundExpectedError = false;
         boolean exceptionOccurred = false;
 
@@ -1201,6 +1221,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Websocket handshake failure test */
     @Test
     public void ConnNegativeID_UC6() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5WSMqttHost != null);
         Assume.assumeTrue(mqtt5WSMqttPort != null);
         boolean foundExpectedError = false;
@@ -1289,6 +1310,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Double Client ID failure test */
     @Test
     public void ConnNegativeID_UC7() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         String testUUID = UUID.randomUUID().toString();
@@ -1331,6 +1353,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Double Client ID disconnect and then reconnect test */
     @Test
     public void ConnNegativeID_UC7_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         String testUUID = UUID.randomUUID().toString();
@@ -1389,6 +1412,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Negative Connect Packet Properties */
     @Test
     public void NewNegative_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean clientCreationFailed = false;
@@ -1476,6 +1500,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Overflow Connect Packet Properties */
     @Test
     public void NewNegative_UC1_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean clientCreationFailed = false;
@@ -1551,6 +1576,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Negative Disconnect Packet Properties */
     @Test
     public void NewNegative_UC2() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean clientDisconnectFailed = false;
@@ -1588,6 +1614,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Overflow Disconnect Packet Properties */
     @Test
     public void NewNegative_UC2_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean clientDisconnectFailed = false;
@@ -1625,6 +1652,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Negative Publish Packet Properties */
     @Test
     public void NewNegative_UC3() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean clientPublishFailed = false;
@@ -1664,6 +1692,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Overflow Publish Packet Properties */
     @Test
     public void NewNegative_UC3_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean clientPublishFailed = false;
@@ -1703,6 +1732,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Negative Subscribe Packet Properties */
     @Test
     public void NewNegative_UC4() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean clientSubscribeFailed = false;
@@ -1742,6 +1772,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Overflow Subscribe Packet Properties */
     @Test
     public void NewNegative_UC4_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean clientSubscribeFailed = false;
@@ -1787,6 +1818,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Happy path, minimal success test */
     @Test
     public void Negotiated_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
 
@@ -1819,6 +1851,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Maximum success test */
     @Test
     public void Negotiated_UC2() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         String testUUID = UUID.randomUUID().toString();
@@ -1869,6 +1902,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Sub-UnSub happy path */
     @Test
     public void Op_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         String testUUID = UUID.randomUUID().toString();
@@ -1924,6 +1958,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Sub-UnSub happy path */
     @Test
     public void Op_UC2() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         String testUUID = UUID.randomUUID().toString();
@@ -1981,6 +2016,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Binary Publish Test */
     @Test
     public void Op_UC3() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         String testUUID = UUID.randomUUID().toString();
@@ -2035,6 +2071,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Null Publish Test */
     @Test
     public void ErrorOp_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean didExceptionOccur = false;
@@ -2071,6 +2108,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Publish with empty builder test */
     @Test
     public void ErrorOp_UC1_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean didExceptionOccur = false;
@@ -2107,6 +2145,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Null Subscribe Test */
     @Test
     public void ErrorOp_UC2() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean didExceptionOccur = false;
@@ -2143,6 +2182,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Empty Subscribe Test */
     @Test
     public void ErrorOp_UC2_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean didExceptionOccur = false;
@@ -2179,6 +2219,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Null Unsubscribe Test */
     @Test
     public void ErrorOp_UC3() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean didExceptionOccur = false;
@@ -2215,6 +2256,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Empty Unsubscribe Test */
     @Test
     public void ErrorOp_UC3_ALT() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean didExceptionOccur = false;
@@ -2253,6 +2295,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /*
     @Test
     public void ErrorOp_UC4() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         boolean didExceptionOccur = false;
@@ -2301,6 +2344,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     /* Happy path. No drop in connection, no retry, no reconnect */
     @Test
     public void QoS1_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         int messageCount = 10;
@@ -2361,6 +2405,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
      /* Happy path. No drop in connection, no retry, no reconnect */
     @Test
     public void Retain_UC1() {
+        skipIfNetworkUnavailable();
         Assume.assumeTrue(mqtt5DirectMqttHost != null);
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         String testUUID = UUID.randomUUID().toString();


### PR DESCRIPTION
*Description of changes:*

Adjusts MQTT5 tests so they only run when a network is present by calling `skipIfNetworkUnavailable()` at the beginning of each test.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
