### PR TITLE
Add tests to make sure interrupting operations works

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -287,11 +287,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
                     assertNotNull(client);
                 }
-
-                elg.close();
-                hr.close();
-                bootstrap.close();
-                socketOptions.close();
             }
 
         } catch (Exception ex) {
@@ -426,7 +421,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 events.connectedFuture.get(60, TimeUnit.SECONDS);
                 DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
                 client.stop(disconnect.build());
-                client.close();
             }
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -457,7 +451,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 events.connectedFuture.get(60, TimeUnit.SECONDS);
                 DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
                 client.stop(disconnect.build());
-                client.close();
             }
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1313,9 +1306,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
                 clientOne.stop(disconnect);
                 clientTwo.stop(disconnect);
-
-                clientOne.close();
-                clientTwo.close();
             }
         } catch (Exception ex) {
             fail(ex.getMessage());

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -198,9 +198,9 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         try {
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            assertNotNull(client);
-            client.close();
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                assertNotNull(client);
+            }
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -218,77 +218,81 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5ProxyPort != null);
 
         try {
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            SocketOptions socketOptions = new SocketOptions();
 
-            PublishPacketBuilder willPacketBuilder = new PublishPacketBuilder();
-            willPacketBuilder.withQOS(QOS.AT_LEAST_ONCE).withPayload("Hello World".getBytes()).withTopic("test/topic");
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+                SocketOptions socketOptions = new SocketOptions();
+            ) {
 
-            ConnectPacketBuilder connectBuilder = new ConnectPacketBuilder();
-            connectBuilder.withClientId("MQTT5 CRT")
-            .withKeepAliveIntervalSeconds(1000L)
-            .withMaximumPacketSizeBytes(1000L)
-            .withPassword(mqtt5BasicAuthPassword.getBytes())
-            .withReceiveMaximum(1000L)
-            .withRequestProblemInformation(true)
-            .withRequestResponseInformation(true)
-            .withSessionExpiryIntervalSeconds(1000L)
-            .withUsername(mqtt5BasicAuthUsername)
-            .withWill(willPacketBuilder.build())
-            .withWillDelayIntervalSeconds(1000L);
+                PublishPacketBuilder willPacketBuilder = new PublishPacketBuilder();
+                willPacketBuilder.withQOS(QOS.AT_LEAST_ONCE).withPayload("Hello World".getBytes()).withTopic("test/topic");
 
-            ArrayList<UserProperty> userProperties = new ArrayList<UserProperty>();
-            userProperties.add(new UserProperty("Hello", "World"));
-            connectBuilder.withUserProperties(userProperties);
+                ConnectPacketBuilder connectBuilder = new ConnectPacketBuilder();
+                connectBuilder.withClientId("MQTT5 CRT")
+                .withKeepAliveIntervalSeconds(1000L)
+                .withMaximumPacketSizeBytes(1000L)
+                .withPassword(mqtt5BasicAuthPassword.getBytes())
+                .withReceiveMaximum(1000L)
+                .withRequestProblemInformation(true)
+                .withRequestResponseInformation(true)
+                .withSessionExpiryIntervalSeconds(1000L)
+                .withUsername(mqtt5BasicAuthUsername)
+                .withWill(willPacketBuilder.build())
+                .withWillDelayIntervalSeconds(1000L);
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
-            builder.withBootstrap(bootstrap)
-            .withConnackTimeoutMs(100L)
-            .withConnectOptions(connectBuilder.build())
-            .withExtendedValidationAndFlowControlOptions(ExtendedValidationAndFlowControlOptions.NONE)
-            .withHostName(mqtt5DirectMqttHost)
-            .withLifecycleEvents(new LifecycleEvents() {
-                @Override
-                public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
+                ArrayList<UserProperty> userProperties = new ArrayList<UserProperty>();
+                userProperties.add(new UserProperty("Hello", "World"));
+                connectBuilder.withUserProperties(userProperties);
 
-                @Override
-                public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {}
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
+                builder.withBootstrap(bootstrap)
+                .withConnackTimeoutMs(100L)
+                .withConnectOptions(connectBuilder.build())
+                .withExtendedValidationAndFlowControlOptions(ExtendedValidationAndFlowControlOptions.NONE)
+                .withHostName(mqtt5DirectMqttHost)
+                .withLifecycleEvents(new LifecycleEvents() {
+                    @Override
+                    public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
-                @Override
-                public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {}
+                    @Override
+                    public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {}
 
-                @Override
-                public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {}
+                    @Override
+                    public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {}
 
-                @Override
-                public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
-            })
-            .withMaxReconnectDelayMs(1000L)
-            .withMinConnectedTimeToResetReconnectDelayMs(1000L)
-            .withMinReconnectDelayMs(1000L)
-            .withOfflineQueueBehavior(ClientOfflineQueueBehavior.FAIL_ALL_ON_DISCONNECT)
-            .withAckTimeoutSeconds(1000L)
-            .withPingTimeoutMs(1000L)
-            .withPort(mqtt5DirectMqttPort)
-            .withPublishEvents(new PublishEvents() {
-                @Override
-                public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
-            })
-            .withRetryJitterMode(JitterMode.Default)
-            .withSessionBehavior(ClientSessionBehavior.CLEAN)
-            .withSocketOptions(socketOptions);
-            // Skip websocket, proxy options, and TLS options - those are all different tests
+                    @Override
+                    public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {}
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            assertNotNull(client);
+                    @Override
+                    public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
+                })
+                .withMaxReconnectDelayMs(1000L)
+                .withMinConnectedTimeToResetReconnectDelayMs(1000L)
+                .withMinReconnectDelayMs(1000L)
+                .withOfflineQueueBehavior(ClientOfflineQueueBehavior.FAIL_ALL_ON_DISCONNECT)
+                .withAckTimeoutSeconds(1000L)
+                .withPingTimeoutMs(1000L)
+                .withPort(mqtt5DirectMqttPort)
+                .withPublishEvents(new PublishEvents() {
+                    @Override
+                    public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
+                })
+                .withRetryJitterMode(JitterMode.Default)
+                .withSessionBehavior(ClientSessionBehavior.CLEAN)
+                .withSocketOptions(socketOptions);
+                // Skip websocket, proxy options, and TLS options - those are all different tests
 
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            socketOptions.close();
-            client.close();
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    assertNotNull(client);
+                }
+
+                elg.close();
+                hr.close();
+                bootstrap.close();
+                socketOptions.close();
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -303,9 +307,9 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5DirectMqttPort != null);
         try {
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            assertNotNull(client);
-            client.close();
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                assertNotNull(client);
+            }
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -322,77 +326,74 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5BasicAuthUsername != null);
 
         try {
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            SocketOptions socketOptions = new SocketOptions();
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+                SocketOptions socketOptions = new SocketOptions();
+            ) {
+                PublishPacketBuilder willPacketBuilder = new PublishPacketBuilder();
+                willPacketBuilder.withQOS(QOS.AT_LEAST_ONCE).withPayload("Hello World".getBytes()).withTopic("test/topic");
 
-            PublishPacketBuilder willPacketBuilder = new PublishPacketBuilder();
-            willPacketBuilder.withQOS(QOS.AT_LEAST_ONCE).withPayload("Hello World".getBytes()).withTopic("test/topic");
+                ConnectPacketBuilder connectBuilder = new ConnectPacketBuilder();
+                connectBuilder.withClientId("MQTT5 CRT");
+                connectBuilder.withKeepAliveIntervalSeconds(1000L);
+                connectBuilder.withMaximumPacketSizeBytes(1000L);
+                connectBuilder.withPassword(mqtt5BasicAuthPassword.getBytes());
+                connectBuilder.withReceiveMaximum(1000L);
+                connectBuilder.withRequestProblemInformation(true);
+                connectBuilder.withRequestResponseInformation(true);
+                connectBuilder.withSessionExpiryIntervalSeconds(1000L);
+                connectBuilder.withUsername(mqtt5BasicAuthUsername);
+                connectBuilder.withWill(willPacketBuilder.build());
+                connectBuilder.withWillDelayIntervalSeconds(1000L);
 
-            ConnectPacketBuilder connectBuilder = new ConnectPacketBuilder();
-            connectBuilder.withClientId("MQTT5 CRT");
-            connectBuilder.withKeepAliveIntervalSeconds(1000L);
-            connectBuilder.withMaximumPacketSizeBytes(1000L);
-            connectBuilder.withPassword(mqtt5BasicAuthPassword.getBytes());
-            connectBuilder.withReceiveMaximum(1000L);
-            connectBuilder.withRequestProblemInformation(true);
-            connectBuilder.withRequestResponseInformation(true);
-            connectBuilder.withSessionExpiryIntervalSeconds(1000L);
-            connectBuilder.withUsername(mqtt5BasicAuthUsername);
-            connectBuilder.withWill(willPacketBuilder.build());
-            connectBuilder.withWillDelayIntervalSeconds(1000L);
+                ArrayList<UserProperty> userProperties = new ArrayList<UserProperty>();
+                userProperties.add(new UserProperty("Hello", "World"));
+                connectBuilder.withUserProperties(userProperties);
 
-            ArrayList<UserProperty> userProperties = new ArrayList<UserProperty>();
-            userProperties.add(new UserProperty("Hello", "World"));
-            connectBuilder.withUserProperties(userProperties);
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
+                builder.withBootstrap(bootstrap)
+                .withConnackTimeoutMs(1000L)
+                .withConnectOptions(connectBuilder.build())
+                .withExtendedValidationAndFlowControlOptions(ExtendedValidationAndFlowControlOptions.NONE)
+                .withHostName(mqtt5DirectMqttHost)
+                .withLifecycleEvents(new LifecycleEvents() {
+                    @Override
+                    public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
-            builder.withBootstrap(bootstrap)
-            .withConnackTimeoutMs(1000L)
-            .withConnectOptions(connectBuilder.build())
-            .withExtendedValidationAndFlowControlOptions(ExtendedValidationAndFlowControlOptions.NONE)
-            .withHostName(mqtt5DirectMqttHost)
-            .withLifecycleEvents(new LifecycleEvents() {
-                @Override
-                public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
+                    @Override
+                    public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {}
 
-                @Override
-                public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {}
+                    @Override
+                    public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {}
 
-                @Override
-                public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {}
+                    @Override
+                    public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {}
 
-                @Override
-                public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {}
+                    @Override
+                    public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
+                })
+                .withMaxReconnectDelayMs(1000L)
+                .withMinConnectedTimeToResetReconnectDelayMs(1000L)
+                .withMinReconnectDelayMs(1000L)
+                .withOfflineQueueBehavior(ClientOfflineQueueBehavior.FAIL_ALL_ON_DISCONNECT)
+                .withAckTimeoutSeconds(1000L)
+                .withPingTimeoutMs(1000L)
+                .withPort(mqtt5DirectMqttPort)
+                .withPublishEvents(new PublishEvents() {
+                    @Override
+                    public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
+                })
+                .withRetryJitterMode(JitterMode.Default)
+                .withSessionBehavior(ClientSessionBehavior.CLEAN)
+                .withSocketOptions(socketOptions);
+                // Skip websocket, proxy options, and TLS options - those are all different tests
 
-                @Override
-                public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {}
-            })
-            .withMaxReconnectDelayMs(1000L)
-            .withMinConnectedTimeToResetReconnectDelayMs(1000L)
-            .withMinReconnectDelayMs(1000L)
-            .withOfflineQueueBehavior(ClientOfflineQueueBehavior.FAIL_ALL_ON_DISCONNECT)
-            .withAckTimeoutSeconds(1000L)
-            .withPingTimeoutMs(1000L)
-            .withPort(mqtt5DirectMqttPort)
-            .withPublishEvents(new PublishEvents() {
-                @Override
-                public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
-            })
-            .withRetryJitterMode(JitterMode.Default)
-            .withSessionBehavior(ClientSessionBehavior.CLEAN)
-            .withSocketOptions(socketOptions);
-            // Skip websocket, proxy options, and TLS options - those are all different tests
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            assertNotNull(client);
-
-            bootstrap.close();
-            hr.close();
-            elg.close();
-            socketOptions.close();
-            client.close();
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    assertNotNull(client);
+                }
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -419,13 +420,14 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             builder.withLifecycleEvents(events);
             builder.withPort(mqtt5DirectMqttPort);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-            client.close();
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
+                DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                client.stop(disconnect.build());
+                client.close();
+            }
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -450,13 +452,13 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             connectOptions.withUsername(mqtt5BasicAuthUsername).withPassword(mqtt5BasicAuthPassword.getBytes());
             builder.withConnectOptions(connectOptions.build());
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-            client.close();
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
+                DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                client.stop(disconnect.build());
+                client.close();
+            }
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -474,24 +476,21 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
-            tlsOptions.withVerifyPeer(false);
-            TlsContext tlsContext = new TlsContext(tlsOptions);
+            try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
+                tlsOptions.withVerifyPeer(false);
+                try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
+                    Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
+                    builder.withLifecycleEvents(events);
+                    builder.withTlsContext(tlsContext);
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
-            builder.withLifecycleEvents(events);
-            builder.withTlsContext(tlsContext);
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-
-            tlsContext.close();
-            tlsOptions.close();
-            client.close();
+                    try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                        client.start();
+                        events.connectedFuture.get(60, TimeUnit.SECONDS);
+                        DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                        client.stop(disconnect.build());
+                    }
+                }
+            }
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -509,41 +508,38 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5ProxyPort != null);
 
         try {
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
 
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
+                LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
-            builder.withLifecycleEvents(events);
-            builder.withBootstrap(bootstrap);
+                HttpProxyOptions proxyOptions = new HttpProxyOptions();
+                proxyOptions.setHost(mqtt5ProxyHost);
+                proxyOptions.setPort((mqtt5ProxyPort.intValue()));
+                proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
 
-            HttpProxyOptions proxyOptions = new HttpProxyOptions();
-            proxyOptions.setHost(mqtt5ProxyHost);
-            proxyOptions.setPort((mqtt5ProxyPort.intValue()));
-            proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
+                try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
+                    tlsOptions.withVerifyPeer(false);
+                    try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
+                        builder.withTlsContext(tlsContext);
 
-            TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
-            tlsOptions.withVerifyPeer(false);
-            TlsContext tlsContext = new TlsContext(tlsOptions);
-            builder.withTlsContext(tlsContext);
+                        builder.withHttpProxyOptions(proxyOptions);
 
-            builder.withHttpProxyOptions(proxyOptions);
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            tlsContext.close();
-            tlsOptions.close();
-            client.close();
+                        try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                            client.start();
+                            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                            client.stop(disconnect.build());
+                        }
+                    }
+                }
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -562,66 +558,62 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            SocketOptions socketOptions = new SocketOptions();
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+                SocketOptions socketOptions = new SocketOptions();
+            ) {
+                PublishPacketBuilder willPacketBuilder = new PublishPacketBuilder();
+                willPacketBuilder.withQOS(QOS.AT_LEAST_ONCE).withPayload("Hello World".getBytes()).withTopic("test/topic");
 
-            PublishPacketBuilder willPacketBuilder = new PublishPacketBuilder();
-            willPacketBuilder.withQOS(QOS.AT_LEAST_ONCE).withPayload("Hello World".getBytes()).withTopic("test/topic");
+                ConnectPacketBuilder connectBuilder = new ConnectPacketBuilder();
+                connectBuilder.withClientId("MQTT5 CRT");
+                connectBuilder.withKeepAliveIntervalSeconds(1000L);
+                connectBuilder.withMaximumPacketSizeBytes(1000L);
+                connectBuilder.withPassword(mqtt5BasicAuthPassword.getBytes());
+                connectBuilder.withReceiveMaximum(1000L);
+                connectBuilder.withRequestProblemInformation(true);
+                connectBuilder.withRequestResponseInformation(true);
+                connectBuilder.withSessionExpiryIntervalSeconds(1000L);
+                connectBuilder.withUsername(mqtt5BasicAuthUsername);
+                connectBuilder.withWill(willPacketBuilder.build());
+                connectBuilder.withWillDelayIntervalSeconds(1000L);
 
-            ConnectPacketBuilder connectBuilder = new ConnectPacketBuilder();
-            connectBuilder.withClientId("MQTT5 CRT");
-            connectBuilder.withKeepAliveIntervalSeconds(1000L);
-            connectBuilder.withMaximumPacketSizeBytes(1000L);
-            connectBuilder.withPassword(mqtt5BasicAuthPassword.getBytes());
-            connectBuilder.withReceiveMaximum(1000L);
-            connectBuilder.withRequestProblemInformation(true);
-            connectBuilder.withRequestResponseInformation(true);
-            connectBuilder.withSessionExpiryIntervalSeconds(1000L);
-            connectBuilder.withUsername(mqtt5BasicAuthUsername);
-            connectBuilder.withWill(willPacketBuilder.build());
-            connectBuilder.withWillDelayIntervalSeconds(1000L);
+                ArrayList<UserProperty> userProperties = new ArrayList<UserProperty>();
+                userProperties.add(new UserProperty("Hello", "World"));
+                connectBuilder.withUserProperties(userProperties);
 
-            ArrayList<UserProperty> userProperties = new ArrayList<UserProperty>();
-            userProperties.add(new UserProperty("Hello", "World"));
-            connectBuilder.withUserProperties(userProperties);
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
+                builder.withBootstrap(bootstrap)
+                .withConnackTimeoutMs(1000L)
+                .withConnectOptions(connectBuilder.build())
+                .withExtendedValidationAndFlowControlOptions(ExtendedValidationAndFlowControlOptions.NONE)
+                .withHostName(mqtt5DirectMqttHost)
+                .withLifecycleEvents(events)
+                .withMaxReconnectDelayMs(1000L)
+                .withMinConnectedTimeToResetReconnectDelayMs(1000L)
+                .withMinReconnectDelayMs(1000L)
+                .withOfflineQueueBehavior(ClientOfflineQueueBehavior.FAIL_ALL_ON_DISCONNECT)
+                .withAckTimeoutSeconds(1000L)
+                .withPingTimeoutMs(1000L)
+                .withPort(mqtt5DirectMqttPort)
+                .withPublishEvents(new PublishEvents() {
+                    @Override
+                    public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
+                })
+                .withRetryJitterMode(JitterMode.Default)
+                .withSessionBehavior(ClientSessionBehavior.CLEAN)
+                .withSocketOptions(socketOptions);
+                // Skip websocket, proxy options, and TLS options - those are all different tests
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
-            builder.withBootstrap(bootstrap)
-            .withConnackTimeoutMs(1000L)
-            .withConnectOptions(connectBuilder.build())
-            .withExtendedValidationAndFlowControlOptions(ExtendedValidationAndFlowControlOptions.NONE)
-            .withHostName(mqtt5DirectMqttHost)
-            .withLifecycleEvents(events)
-            .withMaxReconnectDelayMs(1000L)
-            .withMinConnectedTimeToResetReconnectDelayMs(1000L)
-            .withMinReconnectDelayMs(1000L)
-            .withOfflineQueueBehavior(ClientOfflineQueueBehavior.FAIL_ALL_ON_DISCONNECT)
-            .withAckTimeoutSeconds(1000L)
-            .withPingTimeoutMs(1000L)
-            .withPort(mqtt5DirectMqttPort)
-            .withPublishEvents(new PublishEvents() {
-                @Override
-                public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
-            })
-            .withRetryJitterMode(JitterMode.Default)
-            .withSessionBehavior(ClientSessionBehavior.CLEAN)
-            .withSocketOptions(socketOptions);
-            // Skip websocket, proxy options, and TLS options - those are all different tests
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-
-            bootstrap.close();
-            hr.close();
-            elg.close();
-            socketOptions.close();
-            client.close();
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+                    events.connectedFuture.get(60, TimeUnit.SECONDS);
+                    DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                    client.stop(disconnect.build());
+                }
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -643,36 +635,35 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5WSMqttHost != null);
         Assume.assumeTrue(mqtt5WSMqttPort != null);
         try {
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
 
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
-            builder.withLifecycleEvents(events);
-            builder.withBootstrap(bootstrap);
+                LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                @Override
-                public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                    t.complete(t.getHttpRequest());
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
+
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.complete(t.getHttpRequest());
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
+                builder.withPort(mqtt5WSMqttPort);
+
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+                    events.connectedFuture.get(60, TimeUnit.SECONDS);
+                    DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                    client.stop(disconnect.build());
                 }
-            };
-            builder.withWebsocketHandshakeTransform(websocketTransform);
-            builder.withPort(mqtt5WSMqttPort);
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            client.close();
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -691,37 +682,34 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttBasicAuthHost, mqtt5WSMqttBasicAuthPort);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttBasicAuthHost, mqtt5WSMqttBasicAuthPort);
-            builder.withLifecycleEvents(events);
-            builder.withBootstrap(bootstrap);
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.complete(t.getHttpRequest());
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
 
-            Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                @Override
-                public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                    t.complete(t.getHttpRequest());
+                ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+                connectOptions.withUsername(mqtt5BasicAuthUsername).withPassword(mqtt5BasicAuthPassword.getBytes());
+                builder.withConnectOptions(connectOptions.build());
+
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+                    events.connectedFuture.get(60, TimeUnit.SECONDS);
+                    DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                    client.stop(disconnect.build());
                 }
-            };
-            builder.withWebsocketHandshakeTransform(websocketTransform);
-
-            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-            connectOptions.withUsername(mqtt5BasicAuthUsername).withPassword(mqtt5BasicAuthPassword.getBytes());
-            builder.withConnectOptions(connectOptions.build());
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            client.close();
+            }
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -739,40 +727,37 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
 
-            TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
-            tlsOptions.withVerifyPeer(false);
-            TlsContext tlsContext = new TlsContext(tlsOptions);
+                try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
+                    tlsOptions.withVerifyPeer(false);
+                    try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
+                        Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttTlsHost, mqtt5WSMqttTlsPort);
+                        builder.withLifecycleEvents(events);
+                        builder.withBootstrap(bootstrap);
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttTlsHost, mqtt5WSMqttTlsPort);
-            builder.withLifecycleEvents(events);
-            builder.withBootstrap(bootstrap);
+                        Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                            @Override
+                            public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                                t.complete(t.getHttpRequest());
+                            }
+                        };
+                        builder.withWebsocketHandshakeTransform(websocketTransform);
+                        builder.withTlsContext(tlsContext);
 
-            Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                @Override
-                public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                    t.complete(t.getHttpRequest());
+                        try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                            client.start();
+                            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                            client.stop(disconnect.build());
+                        }
+                    }
                 }
-            };
-            builder.withWebsocketHandshakeTransform(websocketTransform);
-            builder.withTlsContext(tlsContext);
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            tlsOptions.close();
-            tlsContext.close();
-            client.close();
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -852,73 +837,69 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            SocketOptions socketOptions = new SocketOptions();
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+                SocketOptions socketOptions = new SocketOptions();
+            ) {
+                PublishPacketBuilder willPacketBuilder = new PublishPacketBuilder();
+                willPacketBuilder.withQOS(QOS.AT_LEAST_ONCE).withPayload("Hello World".getBytes()).withTopic("test/topic");
 
-            PublishPacketBuilder willPacketBuilder = new PublishPacketBuilder();
-            willPacketBuilder.withQOS(QOS.AT_LEAST_ONCE).withPayload("Hello World".getBytes()).withTopic("test/topic");
+                ConnectPacketBuilder connectBuilder = new ConnectPacketBuilder();
+                connectBuilder.withClientId("MQTT5 CRT");
+                connectBuilder.withKeepAliveIntervalSeconds(1000L);
+                connectBuilder.withMaximumPacketSizeBytes(1000L);
+                connectBuilder.withPassword(mqtt5BasicAuthPassword.getBytes());
+                connectBuilder.withReceiveMaximum(1000L);
+                connectBuilder.withRequestProblemInformation(true);
+                connectBuilder.withRequestResponseInformation(true);
+                connectBuilder.withSessionExpiryIntervalSeconds(1000L);
+                connectBuilder.withUsername(mqtt5BasicAuthUsername);
+                connectBuilder.withWill(willPacketBuilder.build());
+                connectBuilder.withWillDelayIntervalSeconds(1000L);
 
-            ConnectPacketBuilder connectBuilder = new ConnectPacketBuilder();
-            connectBuilder.withClientId("MQTT5 CRT");
-            connectBuilder.withKeepAliveIntervalSeconds(1000L);
-            connectBuilder.withMaximumPacketSizeBytes(1000L);
-            connectBuilder.withPassword(mqtt5BasicAuthPassword.getBytes());
-            connectBuilder.withReceiveMaximum(1000L);
-            connectBuilder.withRequestProblemInformation(true);
-            connectBuilder.withRequestResponseInformation(true);
-            connectBuilder.withSessionExpiryIntervalSeconds(1000L);
-            connectBuilder.withUsername(mqtt5BasicAuthUsername);
-            connectBuilder.withWill(willPacketBuilder.build());
-            connectBuilder.withWillDelayIntervalSeconds(1000L);
+                ArrayList<UserProperty> userProperties = new ArrayList<UserProperty>();
+                userProperties.add(new UserProperty("Hello", "World"));
+                connectBuilder.withUserProperties(userProperties);
 
-            ArrayList<UserProperty> userProperties = new ArrayList<UserProperty>();
-            userProperties.add(new UserProperty("Hello", "World"));
-            connectBuilder.withUserProperties(userProperties);
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
+                builder.withBootstrap(bootstrap)
+                .withConnackTimeoutMs(1000L)
+                .withConnectOptions(connectBuilder.build())
+                .withExtendedValidationAndFlowControlOptions(ExtendedValidationAndFlowControlOptions.NONE)
+                .withHostName(mqtt5WSMqttHost)
+                .withLifecycleEvents(events)
+                .withMaxReconnectDelayMs(1000L)
+                .withMinConnectedTimeToResetReconnectDelayMs(1000L)
+                .withMinReconnectDelayMs(1000L)
+                .withOfflineQueueBehavior(ClientOfflineQueueBehavior.FAIL_ALL_ON_DISCONNECT)
+                .withAckTimeoutSeconds(1000L)
+                .withPingTimeoutMs(1000L)
+                .withPort(mqtt5WSMqttPort)
+                .withPublishEvents(new PublishEvents() {
+                    @Override
+                    public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
+                })
+                .withRetryJitterMode(JitterMode.Default)
+                .withSessionBehavior(ClientSessionBehavior.CLEAN)
+                .withSocketOptions(socketOptions);
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
-            builder.withBootstrap(bootstrap)
-            .withConnackTimeoutMs(1000L)
-            .withConnectOptions(connectBuilder.build())
-            .withExtendedValidationAndFlowControlOptions(ExtendedValidationAndFlowControlOptions.NONE)
-            .withHostName(mqtt5WSMqttHost)
-            .withLifecycleEvents(events)
-            .withMaxReconnectDelayMs(1000L)
-            .withMinConnectedTimeToResetReconnectDelayMs(1000L)
-            .withMinReconnectDelayMs(1000L)
-            .withOfflineQueueBehavior(ClientOfflineQueueBehavior.FAIL_ALL_ON_DISCONNECT)
-            .withAckTimeoutSeconds(1000L)
-            .withPingTimeoutMs(1000L)
-            .withPort(mqtt5WSMqttPort)
-            .withPublishEvents(new PublishEvents() {
-                @Override
-                public void onMessageReceived(Mqtt5Client client, PublishReturn publishReturn) {}
-            })
-            .withRetryJitterMode(JitterMode.Default)
-            .withSessionBehavior(ClientSessionBehavior.CLEAN)
-            .withSocketOptions(socketOptions);
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.complete(t.getHttpRequest());
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
 
-            Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                @Override
-                public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                    t.complete(t.getHttpRequest());
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+                    events.connectedFuture.get(60, TimeUnit.SECONDS);
+                    DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                    client.stop(disconnect.build());
                 }
-            };
-            builder.withWebsocketHandshakeTransform(websocketTransform);
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-
-            bootstrap.close();
-            hr.close();
-            elg.close();
-            socketOptions.close();
-            client.close();
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -946,30 +927,28 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("_test", mqtt5DirectMqttPort);
             builder.withLifecycleEvents(events);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
 
-            client.start();
+                try {
+                    events.connectedFuture.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    exceptionOccurred = true;
+                    if (events.connectFailureCode == 1059) {
+                        foundExpectedError = true;
+                    } else {
+                        System.out.println("EXCEPTION: " + ex);
+                        System.out.println(ex.getMessage() + " \n");
+                    }
+                }
 
-            try {
-                events.connectedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                exceptionOccurred = true;
-                if (events.connectFailureCode == 1059) {
-                    foundExpectedError = true;
-                } else {
-                    System.out.println("EXCEPTION: " + ex);
-                    System.out.println(ex.getMessage() + " \n");
+                if (foundExpectedError == false) {
+                    System.out.println("Error code was not AWS_IO_DNS_INVALID_NAME like expected! There was an exception though");
+                }
+                if (exceptionOccurred == false) {
+                    fail("No exception occurred!");
                 }
             }
-
-            if (foundExpectedError == false) {
-                System.out.println("Error code was not AWS_IO_DNS_INVALID_NAME like expected! There was an exception though");
-            }
-            if (exceptionOccurred == false) {
-                fail("No exception occurred!");
-            }
-
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -987,27 +966,27 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, 65535L);
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            client.start();
 
-            try {
-                System.out.println("NOTE: Exception due to using incorrect port expected below!");
-                events.connectedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                exceptionOccurred = true;
-                if (events.connectFailureCode == 1047) {
-                    foundExpectedError = true;
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+
+                try {
+                    System.out.println("NOTE: Exception due to using incorrect port expected below!");
+                    events.connectedFuture.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    exceptionOccurred = true;
+                    if (events.connectFailureCode == 1047) {
+                        foundExpectedError = true;
+                    }
+                }
+
+                if (foundExpectedError == false) {
+                    System.out.println("Error code was not AWS_IO_SOCKET_CONNECTION_REFUSED like expected! There was an exception though");
+                }
+                if (exceptionOccurred == false) {
+                    fail("No exception occurred!");
                 }
             }
-
-            if (foundExpectedError == false) {
-                System.out.println("Error code was not AWS_IO_SOCKET_CONNECTION_REFUSED like expected! There was an exception though");
-            }
-            if (exceptionOccurred == false) {
-                fail("No exception occurred!");
-            }
-
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -1026,27 +1005,27 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5WSMqttPort);
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            client.start();
 
-            try {
-                System.out.println("NOTE: Exception due to invalid port for protocol used expected below!");
-                events.connectedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                exceptionOccurred = true;
-                if (events.connectFailureCode == 5149) {
-                    foundExpectedError = true;
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+
+                try {
+                    System.out.println("NOTE: Exception due to invalid port for protocol used expected below!");
+                    events.connectedFuture.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    exceptionOccurred = true;
+                    if (events.connectFailureCode == 5149) {
+                        foundExpectedError = true;
+                    }
+                }
+
+                if (foundExpectedError == false) {
+                    System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
+                }
+                if (exceptionOccurred == false) {
+                    fail("No exception occurred!");
                 }
             }
-
-            if (foundExpectedError == false) {
-                System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
-            }
-            if (exceptionOccurred == false) {
-                fail("No exception occurred!");
-            }
-
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -1063,46 +1042,44 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, 444L);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, 444L);
-            builder.withLifecycleEvents(events);
-            builder.withBootstrap(bootstrap);
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.complete(t.getHttpRequest());
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
 
-            Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                @Override
-                public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                    t.complete(t.getHttpRequest());
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+
+                    try {
+                        System.out.println("NOTE: Exception due to using non-existent port expected below!");
+                        events.connectedFuture.get(60, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        exceptionOccurred = true;
+                        if (events.connectFailureCode == 1047) {
+                            foundExpectedError = true;
+                        }
+                    }
+
+                    if (foundExpectedError == false) {
+                        System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
+                    }
+                    if (exceptionOccurred == false) {
+                        fail("No exception occurred!");
+                    }
                 }
-            };
-            builder.withWebsocketHandshakeTransform(websocketTransform);
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            client.start();
-
-            try {
-                System.out.println("NOTE: Exception due to using non-existent port expected below!");
-                events.connectedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                exceptionOccurred = true;
-                if (events.connectFailureCode == 1047) {
-                    foundExpectedError = true;
-                }
             }
-
-            if (foundExpectedError == false) {
-                System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
-            }
-            if (exceptionOccurred == false) {
-                fail("No exception occurred!");
-            }
-
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -1120,46 +1097,45 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5DirectMqttPort);
-            builder.withLifecycleEvents(events);
-            builder.withBootstrap(bootstrap);
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5DirectMqttPort);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
 
-            Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                @Override
-                public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                    t.complete(t.getHttpRequest());
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.complete(t.getHttpRequest());
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
+
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+
+                    try {
+                        System.out.println("NOTE: Exception due to invalid port expected below!");
+                        events.connectedFuture.get(60, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        exceptionOccurred = true;
+                        if (events.connectFailureCode == 46) {
+                            foundExpectedError = true;
+                        }
+                    }
+
+                    if (foundExpectedError == false) {
+                        System.out.println("Error code was not AWS_ERROR_SYS_CALL_FAILURE (occurs right after AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR for Websockets) like expected! There was an exception though");
+                    }
+                    if (exceptionOccurred == false) {
+                        fail("No exception occurred!");
+                    }
                 }
-            };
-            builder.withWebsocketHandshakeTransform(websocketTransform);
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            client.start();
-
-            try {
-                System.out.println("NOTE: Exception due to invalid port expected below!");
-                events.connectedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                exceptionOccurred = true;
-                if (events.connectFailureCode == 46) {
-                    foundExpectedError = true;
-                }
             }
-
-            if (foundExpectedError == false) {
-                System.out.println("Error code was not AWS_ERROR_SYS_CALL_FAILURE (occurs right after AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR for Websockets) like expected! There was an exception though");
-            }
-            if (exceptionOccurred == false) {
-                fail("No exception occurred!");
-            }
-
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -1175,43 +1151,40 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+                SocketOptions options = new SocketOptions();
+            ) {
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("www.example.com", 81L);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("www.example.com", 81L);
-            builder.withLifecycleEvents(events);
-            builder.withBootstrap(bootstrap);
+                options.connectTimeoutMs = 100;
+                builder.withSocketOptions(options);
 
-            SocketOptions options = new SocketOptions();
-            options.connectTimeoutMs = 100;
-            builder.withSocketOptions(options);
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-            client.start();
+                    try {
+                        System.out.println("NOTE: Exception due to socket timeout expected below!");
+                        events.connectedFuture.get(60, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        exceptionOccurred = true;
+                        if (events.connectFailureCode == 1048) {
+                            foundExpectedError = true;
+                        }
+                    }
 
-            try {
-                System.out.println("NOTE: Exception due to socket timeout expected below!");
-                events.connectedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                exceptionOccurred = true;
-                if (events.connectFailureCode == 1048) {
-                    foundExpectedError = true;
+                    if (foundExpectedError == false) {
+                        System.out.println("Error code was not AWS_IO_SOCKET_TIMEOUT like expected! There was an exception though");
+                    }
+                    if (exceptionOccurred == false) {
+                        fail("No exception occurred!");
+                    }
                 }
             }
-
-            if (foundExpectedError == false) {
-                System.out.println("Error code was not AWS_IO_SOCKET_TIMEOUT like expected! There was an exception though");
-            }
-            if (exceptionOccurred == false) {
-                fail("No exception occurred!");
-            }
-
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            options.close();
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1230,51 +1203,49 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
-            EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
 
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
-            builder.withLifecycleEvents(events);
-            builder.withBootstrap(bootstrap);
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
 
-            Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                @Override
-                public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                    t.completeExceptionally(new Throwable("Intentional failure!"));
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.completeExceptionally(new Throwable("Intentional failure!"));
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
+                builder.withPort(mqtt5WSMqttPort);
+
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+
+                    try {
+                        System.out.println("NOTE: Exception due to websocket handshake failure expected below!");
+                        events.connectedFuture.get(60, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        exceptionOccurred = true;
+                        if (events.connectFailureCode == 3) {
+                            foundExpectedError = true;
+                        }
+                    }
+
+                    if (foundExpectedError == false) {
+                        System.out.println("Error code was not AWS_ERROR_UNKNOWN like expected! There was an exception though");
+                    }
+                    if (exceptionOccurred == false) {
+                        fail("No exception occurred!");
+                    }
+
+                    DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                    client.stop(disconnect.build());
                 }
-            };
-            builder.withWebsocketHandshakeTransform(websocketTransform);
-            builder.withPort(mqtt5WSMqttPort);
-
-            Mqtt5Client client = new Mqtt5Client(builder.build());
-
-            client.start();
-
-            try {
-                System.out.println("NOTE: Exception due to websocket handshake failure expected below!");
-                events.connectedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                exceptionOccurred = true;
-                if (events.connectFailureCode == 3) {
-                    foundExpectedError = true;
-                }
             }
-
-            if (foundExpectedError == false) {
-                System.out.println("Error code was not AWS_ERROR_UNKNOWN like expected! There was an exception though");
-            }
-            if (exceptionOccurred == false) {
-                fail("No exception occurred!");
-            }
-
-            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-            client.stop(disconnect.build());
-
-            elg.close();
-            hr.close();
-            bootstrap.close();
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -1323,28 +1294,29 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
             builder.withConnectOptions(connectOptions.build());
 
-            Mqtt5Client clientOne = new Mqtt5Client(builder.build());
-            Mqtt5Client clientTwo = new Mqtt5Client(builder.build());
+            try (
+                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+                Mqtt5Client clientTwo = new Mqtt5Client(builder.build());
+            ) {
+                clientOne.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            clientOne.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                clientTwo.start();
+                events.connectedFuture = new CompletableFuture<>();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            clientTwo.start();
-            events.connectedFuture = new CompletableFuture<>();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                // Make sure a disconnection happened
+                events.disconnectedFuture.get(60, TimeUnit.SECONDS);
 
-            // Make sure a disconnection happened
-            events.disconnectedFuture.get(60, TimeUnit.SECONDS);
+                // Stop the clients from disconnecting each other. If we do not do this, then the clients will
+                // attempt to reconnect endlessly, making a never ending loop.
+                DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
+                clientOne.stop(disconnect);
+                clientTwo.stop(disconnect);
 
-            // Stop the clients from disconnecting each other. If we do not do this, then the clients will
-            // attempt to reconnect endlessly, making a never ending loop.
-            DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
-            clientOne.stop(disconnect);
-            clientTwo.stop(disconnect);
-
-            clientOne.close();
-            clientTwo.close();
-
+                clientOne.close();
+                clientTwo.close();
+            }
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -1366,37 +1338,37 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             builder.withLifecycleEvents(events);
             ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
             builder.withConnectOptions(connectOptions.build());
-            Mqtt5Client clientOne = new Mqtt5Client(builder.build());
 
             Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             builderTwo.withLifecycleEvents(eventsTwo);
             builderTwo.withConnectOptions(connectOptions.build());
-            Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
 
-            clientOne.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (
+                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+                Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
+            ) {
+                clientOne.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            clientTwo.start();
-            eventsTwo.connectedFuture.get(60, TimeUnit.SECONDS);
+                clientTwo.start();
+                eventsTwo.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            // Make sure the first client was disconnected
-            events.disconnectedFuture.get(60, TimeUnit.SECONDS);
-            // Disconnect the second client so the first can reconnect
-            clientTwo.stop(new DisconnectPacketBuilder().build());
+                // Make sure the first client was disconnected
+                events.disconnectedFuture.get(60, TimeUnit.SECONDS);
+                // Disconnect the second client so the first can reconnect
+                clientTwo.stop(new DisconnectPacketBuilder().build());
 
-            // Wait until the first client has reconnected
-            events.connectedFuture = new CompletableFuture<>();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                // Wait until the first client has reconnected
+                events.connectedFuture = new CompletableFuture<>();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            assertTrue(clientOne.getIsConnected() == true);
+                assertTrue(clientOne.getIsConnected() == true);
 
-            // Stop the clients from disconnecting each other. If we do not do this, then the clients will
-            // attempt to reconnect endlessly, making a never ending loop.
-            DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
-            clientOne.stop(disconnect);
-
-            clientOne.close();
-            clientTwo.close();
+                // Stop the clients from disconnecting each other. If we do not do this, then the clients will
+                // attempt to reconnect endlessly, making a never ending loop.
+                DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
+                clientOne.stop(disconnect);
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1418,7 +1390,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         boolean clientCreationFailed = false;
 
         try {
-            Mqtt5Client client;
+            Mqtt5Client client = null;
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
 
@@ -1492,6 +1464,11 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             }
             connectOptions.withWillDelayIntervalSeconds(100L);
 
+            // Make sure everything is closed
+            if (client != null) {
+                client.close();
+            }
+
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -1506,7 +1483,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         boolean clientCreationFailed = false;
 
         try {
-            Mqtt5Client client;
+            Mqtt5Client client = null;
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
 
@@ -1568,6 +1545,11 @@ public class Mqtt5ClientTest extends CrtTestFixture {
 
             // WillDelayIntervalSeconds is an unsigned 64 bit Long, so it cannot overflow it from Java
 
+            // Make sure everything is closed
+            if (client != null) {
+                client.close();
+            }
+
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -1585,26 +1567,26 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
-            disconnectBuilder.withSessionExpiryIntervalSeconds(-100L);
-            try {
-                System.out.println("NOTE: Exception due to negative session expiry expected below!");
-                client.stop(disconnectBuilder.build());
-            } catch (Exception ex) {
-                clientDisconnectFailed = true;
+                DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
+                disconnectBuilder.withSessionExpiryIntervalSeconds(-100L);
+                try {
+                    System.out.println("NOTE: Exception due to negative session expiry expected below!");
+                    client.stop(disconnectBuilder.build());
+                } catch (Exception ex) {
+                    clientDisconnectFailed = true;
+                }
+
+                if (clientDisconnectFailed == false) {
+                    fail("Client disconnect packet creation did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (clientDisconnectFailed == false) {
-                fail("Client disconnect packet creation did not fail!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1623,26 +1605,26 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
-            disconnectBuilder.withSessionExpiryIntervalSeconds(9223372036854775807L);
-            try {
-                System.out.println("NOTE: Exception due to session expiry interval being too large expected below!");
-                client.stop(disconnectBuilder.build());
-            } catch (Exception ex) {
-                clientDisconnectFailed = true;
+                DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
+                disconnectBuilder.withSessionExpiryIntervalSeconds(9223372036854775807L);
+                try {
+                    System.out.println("NOTE: Exception due to session expiry interval being too large expected below!");
+                    client.stop(disconnectBuilder.build());
+                } catch (Exception ex) {
+                    clientDisconnectFailed = true;
+                }
+
+                if (clientDisconnectFailed == false) {
+                    fail("Client disconnect did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (clientDisconnectFailed == false) {
-                fail("Client disconnect did not fail!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1661,28 +1643,28 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
-            publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
-            publishBuilder.withMessageExpiryIntervalSeconds(-100L);
-            try {
-                System.out.println("NOTE: Exception due to negative interval seconds expected below!");
-                CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
-                future.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                clientPublishFailed = true;
+                PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
+                publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
+                publishBuilder.withMessageExpiryIntervalSeconds(-100L);
+                try {
+                    System.out.println("NOTE: Exception due to negative interval seconds expected below!");
+                    CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
+                    future.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    clientPublishFailed = true;
+                }
+
+                if (clientPublishFailed == false) {
+                    fail("Client publish did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (clientPublishFailed == false) {
-                fail("Client publish did not fail!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1701,28 +1683,28 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
-            publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
-            publishBuilder.withMessageExpiryIntervalSeconds(9223372036854775807L);
-            try {
-                System.out.println("NOTE: Exception due to expiry interval seconds being too large expected below!");
-                CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
-                future.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                clientPublishFailed = true;
+                PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
+                publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
+                publishBuilder.withMessageExpiryIntervalSeconds(9223372036854775807L);
+                try {
+                    System.out.println("NOTE: Exception due to expiry interval seconds being too large expected below!");
+                    CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
+                    future.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    clientPublishFailed = true;
+                }
+
+                if (clientPublishFailed == false) {
+                    fail("Client publish did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (clientPublishFailed == false) {
-                fail("Client publish did not fail!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1741,28 +1723,28 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
-            subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
-            subscribeBuilder.withSubscriptionIdentifier(-100L);
-            try {
-                System.out.println("NOTE: Exception due to negative subscription identifier expected below!");
-                CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
-                future.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                clientSubscribeFailed = true;
+                SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
+                subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
+                subscribeBuilder.withSubscriptionIdentifier(-100L);
+                try {
+                    System.out.println("NOTE: Exception due to negative subscription identifier expected below!");
+                    CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
+                    future.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    clientSubscribeFailed = true;
+                }
+
+                if (clientSubscribeFailed == false) {
+                    fail("Client subscribe did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (clientSubscribeFailed == false) {
-                fail("Client subscribe did not fail!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1781,28 +1763,28 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
-            subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
-            subscribeBuilder.withSubscriptionIdentifier(9223372036854775807L);
-            try {
-                System.out.println("NOTE: Exception due to subscription identifier being too large expected below!");
-                CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
-                future.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                clientSubscribeFailed = true;
+                SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
+                subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
+                subscribeBuilder.withSubscriptionIdentifier(9223372036854775807L);
+                try {
+                    System.out.println("NOTE: Exception due to subscription identifier being too large expected below!");
+                    CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
+                    future.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    clientSubscribeFailed = true;
+                }
+
+                if (clientSubscribeFailed == false) {
+                    fail("Client subscribe did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (clientSubscribeFailed == false) {
-                fail("Client subscribe did not fail!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1830,18 +1812,17 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             optionsBuilder.withSessionExpiryIntervalSeconds(600000L);
             builder.withConnectOptions(optionsBuilder.build());
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                assertEquals(
+                    "Negotiated Settings session expiry interval does not match sent session expiry interval",
+                    events.connectSuccessSettings.getSessionExpiryInterval(),
+                    600000L);
 
-            assertEquals(
-                "Negotiated Settings session expiry interval does not match sent session expiry interval",
-                events.connectSuccessSettings.getSessionExpiryInterval(),
-                600000L);
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
+                client.stop(new DisconnectPacketBuilder().build());
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1867,26 +1848,25 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             optionsBuilder.withKeepAliveIntervalSeconds(360L);
             builder.withConnectOptions(optionsBuilder.build());
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                assertEquals(
+                    "Negotiated Settings client ID does not match sent client ID",
+                    events.connectSuccessSettings.getAssignedClientID(),
+                    "test/MQTT5_Binding_Java_" + testUUID);
+                assertEquals(
+                    "Negotiated Settings session expiry interval does not match sent session expiry interval",
+                    events.connectSuccessSettings.getSessionExpiryInterval(),
+                    0L);
+                assertEquals(
+                    "Negotiated Settings keep alive result does not match sent keep alive",
+                    events.connectSuccessSettings.getServerKeepAlive(),
+                    360);
 
-            assertEquals(
-                "Negotiated Settings client ID does not match sent client ID",
-                events.connectSuccessSettings.getAssignedClientID(),
-                "test/MQTT5_Binding_Java_" + testUUID);
-            assertEquals(
-                "Negotiated Settings session expiry interval does not match sent session expiry interval",
-                events.connectSuccessSettings.getSessionExpiryInterval(),
-                0L);
-            assertEquals(
-                "Negotiated Settings keep alive result does not match sent keep alive",
-                events.connectSuccessSettings.getServerKeepAlive(),
-                360);
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
+                client.stop(new DisconnectPacketBuilder().build());
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1927,28 +1907,27 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
             unsubscribePacketBuilder.withSubscription(testTopic);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                client.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
 
-            client.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                client.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                publishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
 
-            client.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
-            publishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
+                publishEvents.publishReceivedFuture = new CompletableFuture<>();
+                publishEvents.publishPacket = null;
+                client.unsubscribe(unsubscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                client.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
 
-            publishEvents.publishReceivedFuture = new CompletableFuture<>();
-            publishEvents.publishPacket = null;
-            client.unsubscribe(unsubscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
-            client.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                assertEquals(
+                    "Publish after unsubscribe still arrived!",
+                    publishEvents.publishPacket,
+                    null);
 
-            assertEquals(
-                "Publish after unsubscribe still arrived!",
-                publishEvents.publishPacket,
-                null);
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
+                client.stop(new DisconnectPacketBuilder().build());
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -1978,8 +1957,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             connectOptions.withWillDelayIntervalSeconds(0L);
             builder.withConnectOptions(connectOptions.build());
 
-            Mqtt5Client clientOne = new Mqtt5Client(builder.build());
-
             Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
             builderTwo.withLifecycleEvents(eventsTwo);
@@ -1987,26 +1964,28 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             builderTwo.withPublishEvents(publishEvents);
             SubscribePacketBuilder subscribeOptions = new SubscribePacketBuilder();
             subscribeOptions.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-            Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
 
-            clientOne.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            clientTwo.start();
-            eventsTwo.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (
+                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+                Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
+            ) {
+                clientOne.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
+                clientTwo.start();
+                eventsTwo.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            clientTwo.subscribe(subscribeOptions.build()).get(60, TimeUnit.SECONDS);
+                clientTwo.subscribe(subscribeOptions.build()).get(60, TimeUnit.SECONDS);
 
-            DisconnectPacketBuilder disconnectOptions = new DisconnectPacketBuilder();
-            disconnectOptions.withReasonCode(DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE);
-            clientOne.stop(disconnectOptions.build());
+                DisconnectPacketBuilder disconnectOptions = new DisconnectPacketBuilder();
+                disconnectOptions.withReasonCode(DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE);
+                clientOne.stop(disconnectOptions.build());
 
-            // Did we get a publish message?
-            publishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
-            assertTrue(publishEvents.publishPacket != null);
+                // Did we get a publish message?
+                publishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
+                assertTrue(publishEvents.publishPacket != null);
 
-            clientTwo.stop(new DisconnectPacketBuilder().build());
-            clientOne.close();
-            clientTwo.close();
+                clientTwo.stop(new DisconnectPacketBuilder().build());
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -2041,21 +2020,20 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
             subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                client.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
 
-            client.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                client.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                publishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
 
-            client.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
-            publishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
+                assertTrue(java.util.Arrays.equals(publishEvents.publishPacket.getPayload(), randomBytes));
 
-            assertTrue(java.util.Arrays.equals(publishEvents.publishPacket.getPayload(), randomBytes));
-
-            client.stop(new DisconnectPacketBuilder().build());
-            events.stopFuture.get(60, TimeUnit.SECONDS);
-            client.close();
+                client.stop(new DisconnectPacketBuilder().build());
+                events.stopFuture.get(60, TimeUnit.SECONDS);
+            }
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -2081,24 +2059,22 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                try {
+                    System.out.println("NOTE: Exception due to null publish packet expected below!");
+                    client.publish(null).get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
 
-            try {
-                System.out.println("NOTE: Exception due to null publish packet expected below!");
-                client.publish(null).get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                didExceptionOccur = true;
+                if (didExceptionOccur == false) {
+                    fail("Null publish packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (didExceptionOccur == false) {
-                fail("Null publish packet did not cause exception with error!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -2118,25 +2094,23 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                try {
+                    System.out.println("NOTE: Exception due to empty publish packet expected below!");
+                    client.publish(new PublishPacketBuilder().build()).get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
 
-            try {
-                System.out.println("NOTE: Exception due to empty publish packet expected below!");
-                client.publish(new PublishPacketBuilder().build()).get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                didExceptionOccur = true;
+                if (didExceptionOccur == false) {
+                    fail("Empty publish packet did not cause exception with error!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (didExceptionOccur == false) {
-                fail("Empty publish packet did not cause exception with error!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
-
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -2155,25 +2129,22 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                try {
+                    System.out.println("NOTE: Exception due to null subscribe packet expected below!");
+                    client.subscribe(null).get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
 
-            try {
-                System.out.println("NOTE: Exception due to null subscribe packet expected below!");
-                client.subscribe(null).get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                didExceptionOccur = true;
+                if (didExceptionOccur == false) {
+                    fail("Null subscribe packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (didExceptionOccur == false) {
-                fail("Null subscribe packet did not cause exception with error!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
-
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -2192,24 +2163,22 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                try {
+                    System.out.println("NOTE: Exception due to empty subscribe packet expected below!");
+                    client.subscribe(new SubscribePacketBuilder().build()).get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
 
-            try {
-                System.out.println("NOTE: Exception due to empty subscribe packet expected below!");
-                client.subscribe(new SubscribePacketBuilder().build()).get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                didExceptionOccur = true;
+                if (didExceptionOccur == false) {
+                    fail("Empty subscribe packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (didExceptionOccur == false) {
-                fail("Empty subscribe packet did not cause exception with error!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -2229,24 +2198,22 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                try {
+                    System.out.println("NOTE: Exception due to null unsubscribe packet expected below!");
+                    client.unsubscribe(null).get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
 
-            try {
-                System.out.println("NOTE: Exception due to null unsubscribe packet expected below!");
-                client.unsubscribe(null).get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                didExceptionOccur = true;
+                if (didExceptionOccur == false) {
+                    fail("Null unsubscribe packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (didExceptionOccur == false) {
-                fail("Null unsubscribe packet did not cause exception with error!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -2266,24 +2233,22 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
 
-            Mqtt5Client client = new Mqtt5Client(builder.build());
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+                try {
+                    System.out.println("NOTE: Exception due to empty unsubscribe packet expected below!");
+                    client.unsubscribe(new UnsubscribePacketBuilder().build()).get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
 
-            try {
-                System.out.println("NOTE: Exception due to empty unsubscribe packet expected below!");
-                client.unsubscribe(new UnsubscribePacketBuilder().build()).get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                didExceptionOccur = true;
+                if (didExceptionOccur == false) {
+                    fail("Empty unsubscribe packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
             }
-
-            if (didExceptionOccur == false) {
-                fail("Empty unsubscribe packet did not cause exception with error!");
-            }
-
-            client.stop(new DisconnectPacketBuilder().build());
-            client.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -2355,7 +2320,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
-            Mqtt5Client publisher = new Mqtt5Client(builder.build());
 
             Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
@@ -2363,33 +2327,35 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             PublishEvents_Futured_Counted publishEvents = new PublishEvents_Futured_Counted();
             publishEvents.desiredPublishCount = messageCount;
             builderTwo.withPublishEvents(publishEvents);
-            Mqtt5Client subscriber = new Mqtt5Client(builderTwo.build());
 
-            publisher.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
-            subscriber.start();
-            eventsTwo.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (
+                Mqtt5Client publisher = new Mqtt5Client(builder.build());
+                Mqtt5Client subscriber = new Mqtt5Client(builderTwo.build());
+            ) {
+                publisher.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
+                subscriber.start();
+                eventsTwo.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-            subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-            subscriber.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+                subscriber.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
 
-            PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-            publishPacketBuilder.withTopic(testTopic);
-            publishPacketBuilder.withPayload("Hello World".getBytes());
-            publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
+                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+                publishPacketBuilder.withTopic(testTopic);
+                publishPacketBuilder.withPayload("Hello World".getBytes());
+                publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
 
-            for (int i = 0; i < messageCount; i++) {
-                publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                for (int i = 0; i < messageCount; i++) {
+                    publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                }
+
+                // Did we get all the messages?
+                publishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
+
+                subscriber.stop(new DisconnectPacketBuilder().build());
+                publisher.stop(new DisconnectPacketBuilder().build());
             }
-
-            // Did we get all the messages?
-            publishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
-
-            subscriber.stop(new DisconnectPacketBuilder().build());
-            publisher.stop(new DisconnectPacketBuilder().build());
-            subscriber.close();
-            publisher.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -2412,100 +2378,100 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         String testTopic = "test/retained_topic/MQTT5_Binding_Java_" + testUUID;
 
         try {
-            Mqtt5ClientOptionsBuilder clientBuilder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
-
+            Mqtt5ClientOptionsBuilder publisherEventsBuilder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured publisherEvents = new LifecycleEvents_Futured();
-            clientBuilder.withLifecycleEvents(publisherEvents);
-            Mqtt5Client publisher = new Mqtt5Client(clientBuilder.build());
+            publisherEventsBuilder.withLifecycleEvents(publisherEvents);
 
+            Mqtt5ClientOptionsBuilder successSubscriberBuilder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured successSubscriberEvents = new LifecycleEvents_Futured();
             PublishEvents_Futured successSubscriberPublishEvents = new PublishEvents_Futured();
-            clientBuilder.withLifecycleEvents(successSubscriberEvents);
-            clientBuilder.withPublishEvents(successSubscriberPublishEvents);
-            Mqtt5Client successSubscriber = new Mqtt5Client(clientBuilder.build());
+            successSubscriberBuilder.withLifecycleEvents(successSubscriberEvents);
+            successSubscriberBuilder.withPublishEvents(successSubscriberPublishEvents);
 
+            Mqtt5ClientOptionsBuilder unsuccessSubscriberBuilder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured unsuccessfulSubscriberEvents = new LifecycleEvents_Futured();
             PublishEvents_Futured unsuccessfulSubscriberPublishEvents = new PublishEvents_Futured();
-            clientBuilder.withLifecycleEvents(unsuccessfulSubscriberEvents);
-            clientBuilder.withPublishEvents(unsuccessfulSubscriberPublishEvents);
-            Mqtt5Client unsuccessfulSubscriber = new Mqtt5Client(clientBuilder.build());
+            unsuccessSubscriberBuilder.withLifecycleEvents(unsuccessfulSubscriberEvents);
+            unsuccessSubscriberBuilder.withPublishEvents(unsuccessfulSubscriberPublishEvents);
 
-            // Connect and publish a retained message
-            publisher.start();
-            publisherEvents.connectedFuture.get(60, TimeUnit.SECONDS);
-            PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-            publishPacketBuilder.withTopic(testTopic)
-                .withPayload("Hello World".getBytes())
-                .withQOS(QOS.AT_LEAST_ONCE)
-                .withRetain(true);
-            publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+            try (
+                Mqtt5Client publisher = new Mqtt5Client(publisherEventsBuilder.build());
+                Mqtt5Client successSubscriber = new Mqtt5Client(successSubscriberBuilder.build());
+                Mqtt5Client unsuccessfulSubscriber = new Mqtt5Client(unsuccessSubscriberBuilder.build());
+            ) {
 
-            // Setup for clearing the retained message
-            publishPacketBuilder.withPayload(null);
+                // Connect and publish a retained message
+                publisher.start();
+                publisherEvents.connectedFuture.get(60, TimeUnit.SECONDS);
+                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+                publishPacketBuilder.withTopic(testTopic)
+                    .withPayload("Hello World".getBytes())
+                    .withQOS(QOS.AT_LEAST_ONCE)
+                    .withRetain(true);
+                publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
 
-            // Connect the successful subscriber
-            successSubscriber.start();
-            try {
-                successSubscriberEvents.connectedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
+                // Setup for clearing the retained message
+                publishPacketBuilder.withPayload(null);
+
+                // Connect the successful subscriber
+                successSubscriber.start();
+                try {
+                    successSubscriberEvents.connectedFuture.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    // Clear the retained message
+                    publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                    fail("Success subscriber could not connect!");
+                }
+
+                // Subscribe and verify the retained message
+                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE, false, true, RetainHandlingType.SEND_ON_SUBSCRIBE);
+                try {
+                    successSubscriber.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    // Clear the retained message
+                    publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                    fail("Success subscriber could not subscribe!");
+                }
+                try {
+                    successSubscriberPublishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    // Clear the retained message
+                    publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                    fail("Success subscriber did not get retained message!");
+                }
+
                 // Clear the retained message
                 publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
-                fail("Success subscriber could not connect!");
+
+                // Wait 5 seconds to give the server time to clear everything out
+                Thread.sleep(5000);
+
+                // Connect the unsuccessful subscriber
+                unsuccessfulSubscriber.start();
+                unsuccessfulSubscriberEvents.connectedFuture.get(60, TimeUnit.SECONDS);
+                unsuccessfulSubscriber.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
+                // Make sure we do NOT get a publish
+                boolean didExceptionOccur = false;
+                try {
+                    unsuccessfulSubscriberPublishEvents.publishReceivedFuture.get(30, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Unsuccessful subscriber got retained message even though it should be cleared!");
+                }
+
+                // Disconnect all clients
+                DisconnectPacketBuilder disconnectPacketBuilder = new DisconnectPacketBuilder();
+                publisher.stop(disconnectPacketBuilder.build());
+                publisherEvents.stopFuture.get(60, TimeUnit.SECONDS);
+                successSubscriber.stop(disconnectPacketBuilder.build());
+                successSubscriberEvents.stopFuture.get(60, TimeUnit.SECONDS);
+                unsuccessfulSubscriber.stop(disconnectPacketBuilder.build());
+                unsuccessfulSubscriberEvents.stopFuture.get(60, TimeUnit.SECONDS);
             }
-
-            // Subscribe and verify the retained message
-            SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-            subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE, false, true, RetainHandlingType.SEND_ON_SUBSCRIBE);
-            try {
-                successSubscriber.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                // Clear the retained message
-                publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
-                fail("Success subscriber could not subscribe!");
-            }
-            try {
-                successSubscriberPublishEvents.publishReceivedFuture.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                // Clear the retained message
-                publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
-                fail("Success subscriber did not get retained message!");
-            }
-
-            // Clear the retained message
-            publisher.publish(publishPacketBuilder.build()).get(60, TimeUnit.SECONDS);
-
-            // Wait 5 seconds to give the server time to clear everything out
-            Thread.sleep(5000);
-
-            // Connect the unsuccessful subscriber
-            unsuccessfulSubscriber.start();
-            unsuccessfulSubscriberEvents.connectedFuture.get(60, TimeUnit.SECONDS);
-            unsuccessfulSubscriber.subscribe(subscribePacketBuilder.build()).get(60, TimeUnit.SECONDS);
-            // Make sure we do NOT get a publish
-            boolean didExceptionOccur = false;
-            try {
-                unsuccessfulSubscriberPublishEvents.publishReceivedFuture.get(30, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                didExceptionOccur = true;
-            }
-
-            if (didExceptionOccur == false) {
-                fail("Unsuccessful subscriber got retained message even though it should be cleared!");
-            }
-
-            // Disconnect all clients
-            DisconnectPacketBuilder disconnectPacketBuilder = new DisconnectPacketBuilder();
-            publisher.stop(disconnectPacketBuilder.build());
-            publisherEvents.stopFuture.get(60, TimeUnit.SECONDS);
-            successSubscriber.stop(disconnectPacketBuilder.build());
-            successSubscriberEvents.stopFuture.get(60, TimeUnit.SECONDS);
-            unsuccessfulSubscriber.stop(disconnectPacketBuilder.build());
-            unsuccessfulSubscriberEvents.stopFuture.get(60, TimeUnit.SECONDS);
-
-            // Close all clients
-            publisher.close();;
-            successSubscriber.close();
-            unsuccessfulSubscriber.close();
 
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -2532,28 +2498,28 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-            subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
 
-            try {
-                CompletableFuture<SubAckPacket> subscribeResult = client.subscribe(subscribePacketBuilder.build());
-                client.stop(new DisconnectPacketBuilder().build());
-                SubAckPacket packet = subscribeResult.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                if (ex.getCause().getClass() == CrtRuntimeException.class) {
-                    CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-                    if (exCrt.errorCode != 5153) {
-                        System.out.println("Exception ocurred when stopping subscribe" +
-                            "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                try {
+                    CompletableFuture<SubAckPacket> subscribeResult = client.subscribe(subscribePacketBuilder.build());
+                    client.stop(new DisconnectPacketBuilder().build());
+                    SubAckPacket packet = subscribeResult.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                        if (exCrt.errorCode != 5153) {
+                            System.out.println("Exception ocurred when stopping subscribe" +
+                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                        }
                     }
                 }
             }
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -2573,28 +2539,28 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
-            unsubscribePacketBuilder.withSubscription(testTopic);
+                UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
+                unsubscribePacketBuilder.withSubscription(testTopic);
 
-            try {
-                CompletableFuture<UnsubAckPacket> unsubscribeResult = client.unsubscribe(unsubscribePacketBuilder.build());
-                client.stop(new DisconnectPacketBuilder().build());
-                UnsubAckPacket packet = unsubscribeResult.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                if (ex.getCause().getClass() == CrtRuntimeException.class) {
-                    CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-                    if (exCrt.errorCode != 5153) {
-                        System.out.println("Exception ocurred when stopping unsubscribe" +
-                            "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                try {
+                    CompletableFuture<UnsubAckPacket> unsubscribeResult = client.unsubscribe(unsubscribePacketBuilder.build());
+                    client.stop(new DisconnectPacketBuilder().build());
+                    UnsubAckPacket packet = unsubscribeResult.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                        if (exCrt.errorCode != 5153) {
+                            System.out.println("Exception ocurred when stopping unsubscribe" +
+                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                        }
                     }
                 }
             }
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -2614,31 +2580,30 @@ public class Mqtt5ClientTest extends CrtTestFixture {
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
             builder.withLifecycleEvents(events);
-            Mqtt5Client client = new Mqtt5Client(builder.build());
 
-            client.start();
-            events.connectedFuture.get(60, TimeUnit.SECONDS);
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
 
-            PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-            publishPacketBuilder.withTopic(testTopic).withQOS(QOS.AT_LEAST_ONCE).withPayload("null".getBytes());
+                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+                publishPacketBuilder.withTopic(testTopic).withQOS(QOS.AT_LEAST_ONCE).withPayload("null".getBytes());
 
-            try {
-                CompletableFuture<PublishResult> publishResult = client.publish(publishPacketBuilder.build());
-                client.stop(new DisconnectPacketBuilder().build());
-                PublishResult publishData = publishResult.get(60, TimeUnit.SECONDS);
-            } catch (Exception ex) {
-                if (ex.getCause().getClass() == CrtRuntimeException.class) {
-                    CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-                    if (exCrt.errorCode != 5153) {
-                        System.out.println("Exception ocurred when stopping publish" +
-                            "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                try {
+                    CompletableFuture<PublishResult> publishResult = client.publish(publishPacketBuilder.build());
+                    client.stop(new DisconnectPacketBuilder().build());
+                    PublishResult publishData = publishResult.get(60, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                        if (exCrt.errorCode != 5153) {
+                            System.out.println("Exception ocurred when stopping publish" +
+                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                        }
                     }
                 }
             }
-            client.close();
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
     }
-
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -2512,5 +2512,133 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         }
     }
 
+    /**
+     * ============================================================
+     * Operation Interrupt Tests
+     * ============================================================
+     */
+
+    // Subscribe interrupt test
+    @Test
+    public void Interrupt_Sub_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5DirectMqttHost != null);
+        Assume.assumeTrue(mqtt5DirectMqttPort != null);
+        int messageCount = 10;
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+            Mqtt5Client client = new Mqtt5Client(builder.build());
+
+            client.start();
+            events.connectedFuture.get(60, TimeUnit.SECONDS);
+
+            SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+            subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+            try {
+                CompletableFuture<SubAckPacket> subscribeResult = client.subscribe(subscribePacketBuilder.build());
+                client.stop(new DisconnectPacketBuilder().build());
+                SubAckPacket packet = subscribeResult.get(60, TimeUnit.SECONDS);
+            } catch (Exception ex) {
+                if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                    CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                    if (exCrt.errorCode != 5153) {
+                        System.out.println("Exception ocurred when stopping subscribe" +
+                            "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                    }
+                }
+            }
+            client.close();
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    // Unsubscribe interrupt test
+    @Test
+    public void Interrupt_Unsub_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5DirectMqttHost != null);
+        Assume.assumeTrue(mqtt5DirectMqttPort != null);
+        int messageCount = 10;
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+            Mqtt5Client client = new Mqtt5Client(builder.build());
+
+            client.start();
+            events.connectedFuture.get(60, TimeUnit.SECONDS);
+
+            UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
+            unsubscribePacketBuilder.withSubscription(testTopic);
+
+            try {
+                CompletableFuture<UnsubAckPacket> unsubscribeResult = client.unsubscribe(unsubscribePacketBuilder.build());
+                client.stop(new DisconnectPacketBuilder().build());
+                UnsubAckPacket packet = unsubscribeResult.get(60, TimeUnit.SECONDS);
+            } catch (Exception ex) {
+                if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                    CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                    if (exCrt.errorCode != 5153) {
+                        System.out.println("Exception ocurred when stopping unsubscribe" +
+                            "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                    }
+                }
+            }
+            client.close();
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    // Publish interrupt test
+    @Test
+    public void Interrupt_Publish_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5DirectMqttHost != null);
+        Assume.assumeTrue(mqtt5DirectMqttPort != null);
+        int messageCount = 10;
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+            Mqtt5Client client = new Mqtt5Client(builder.build());
+
+            client.start();
+            events.connectedFuture.get(60, TimeUnit.SECONDS);
+
+            PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+            publishPacketBuilder.withTopic(testTopic).withQOS(QOS.AT_LEAST_ONCE).withPayload("null".getBytes());
+
+            try {
+                CompletableFuture<PublishResult> publishResult = client.publish(publishPacketBuilder.build());
+                client.stop(new DisconnectPacketBuilder().build());
+                PublishResult publishData = publishResult.get(60, TimeUnit.SECONDS);
+            } catch (Exception ex) {
+                if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                    CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                    if (exCrt.errorCode != 5153) {
+                        System.out.println("Exception ocurred when stopping publish" +
+                            "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                    }
+                }
+            }
+            client.close();
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
 
 }


### PR DESCRIPTION
*Description of changes:*

Adds MQTT5 tests to make sure that interrupting operations works as expected and does not cause crashes. With the current behavior, when you interrupt an operation you get an exception, with the cause of that exception being a CRT exception of `AWS_ERROR_MQTT5_USER_REQUESTED_STOP`.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
