### PR TITLE
Rejoin always option and tests

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5ClientOptions.java
@@ -372,7 +372,15 @@ public class Mqtt5ClientOptions {
          *
          * Session rejoin requires an appropriate non-zero session expiry interval in the client's CONNECT options.
          */
-        REJOIN_POST_SUCCESS(2);
+        REJOIN_POST_SUCCESS(2),
+
+        /**
+         * Always attempt to rejoin an existing session.  Since the client does not yet support durable session persistence,
+         * this option is not guaranteed to be spec compliant because any unacknowledged qos1 publishes (which are
+         * part of the client session state) will not be present on the initial connection.  Until we support
+         * durable session resumption, this option is technically spec-breaking, but useful.
+         */
+        REJOIN_ALWAYS(3);
 
         private int type;
 

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -1810,6 +1810,10 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                     "Negotiated Settings session expiry interval does not match sent session expiry interval",
                     events.connectSuccessSettings.getSessionExpiryInterval(),
                     600000L);
+                assertEquals(
+                        "Negotiated Settings rejoined session does not match expected value",
+                        false,
+                        events.connectSuccessSettings.getRejoinedSession());
 
                 client.stop(new DisconnectPacketBuilder().build());
             }
@@ -1854,6 +1858,74 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                     "Negotiated Settings keep alive result does not match sent keep alive",
                     events.connectSuccessSettings.getServerKeepAlive(),
                     360);
+                assertEquals(
+                        "Negotiated Settings rejoined session does not match expected value",
+                        false,
+                        events.connectSuccessSettings.getRejoinedSession());
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Rejoin always session resumption test */
+    @Test
+    public void Negotiated_Rejoin_Always() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5DirectMqttHost != null);
+        Assume.assumeTrue(mqtt5DirectMqttPort != null);
+        String testUUID = UUID.randomUUID().toString();
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5DirectMqttPort);
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
+            optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
+            optionsBuilder.withSessionExpiryIntervalSeconds(3600L);
+            optionsBuilder.withKeepAliveIntervalSeconds(360L);
+            builder.withConnectOptions(optionsBuilder.build());
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(60, TimeUnit.SECONDS);
+
+                assertEquals(
+                        "Negotiated Settings client ID does not match sent client ID",
+                        events.connectSuccessSettings.getAssignedClientID(),
+                        "test/MQTT5_Binding_Java_" + testUUID);
+                assertEquals(
+                        "Negotiated Settings session expiry interval does not match sent session expiry interval",
+                        events.connectSuccessSettings.getSessionExpiryInterval(),
+                        3600L);
+                assertEquals(
+                        "Negotiated Settings keep alive result does not match sent keep alive",
+                        events.connectSuccessSettings.getServerKeepAlive(),
+                        360);
+                assertEquals(
+                        "Negotiated Settings rejoined session does not match expected value",
+                        false,
+                        events.connectSuccessSettings.getRejoinedSession());
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            builder.withSessionBehavior(ClientSessionBehavior.REJOIN_ALWAYS);
+            LifecycleEvents_Futured rejoinEvents = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(rejoinEvents);
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                rejoinEvents.connectedFuture.get(60, TimeUnit.SECONDS);
+
+                assertEquals(
+                        "Negotiated Settings rejoined session does not match expected value",
+                        true,
+                        rejoinEvents.connectSuccessSettings.getRejoinedSession());
 
                 client.stop(new DisconnectPacketBuilder().build());
             }


### PR DESCRIPTION
* Adds support for a new session behavior type that always attempts to rejoin a session, even if existing session state is unknown.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
