### PR TITLE
Mosquttio in Codebuild CI

### DIFF
--- a/codebuild/common-linux-setup-mosquitto.sh
+++ b/codebuild/common-linux-setup-mosquitto.sh
@@ -7,7 +7,7 @@ mkdir -p MosquittoInstall
 cd MosquittoInstall
 
 # mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
-echo "Setup mosquitto dependencies - OpenSSL (may take a couple minutes - should take no more than 6 minutes)"
+echo "Setup mosquitto dependencies from source - OpenSSL (may take a couple minutes - should take no more than 6 minutes)"
 # Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
 {
     git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
@@ -19,7 +19,7 @@ echo "Setup mosquitto dependencies - OpenSSL (may take a couple minutes - should
 
 # And we have to install libwebsockets from source for mosquitto too
 # Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
-echo "Setup mosquitto dependencies - LibWebsockets (may take a couple minutes - should take no more than 6 minutes)"
+echo "Setup mosquitto dependencies from source - LibWebsockets (may take a couple minutes - should take no more than 6 minutes)"
 {
     git clone https://github.com/warmcat/libwebsockets.git --branch v4.3.2
     cd libwebsockets
@@ -33,7 +33,7 @@ cd ../..
 
 # Install mosquitto from source
 # Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
-echo "Setup mosquitto - Mosquitto from source (may take a couple minutes - should take no more than 6 minutes)"
+echo "Setup mosquitto from source - Mosquitto (may take a couple minutes - should take no more than 6 minutes)"
 {
     git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
     cd mosquitto
@@ -43,7 +43,7 @@ echo "Setup mosquitto - Mosquitto from source (may take a couple minutes - shoul
 } > /dev/null
 
 # Get the config file and run it
-echo "Setup mosquitto - configure mosquitto and start it running"
+echo "Setup mosquitto from source - configure mosquitto and start it running"
 aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
 sudo chmod a+xr ./setup_mosquitto_test_env.sh
 ./setup_mosquitto_test_env.sh

--- a/codebuild/common-linux-setup-mosquitto.sh
+++ b/codebuild/common-linux-setup-mosquitto.sh
@@ -49,11 +49,5 @@ sudo chmod a+xr ./setup_mosquitto_test_env.sh
 ./setup_mosquitto_test_env.sh
 mosquitto -d -c /etc/mosquitto/mosquitto.conf
 
-# For HTTP proxy tests, we need Squid too
-sudo apt update -y
-sudo apt install squid -y
-# Make sure it is running
-systemctl status squid.service
-
 # Done!
 cd ..

--- a/codebuild/common-linux-setup-mosquitto.sh
+++ b/codebuild/common-linux-setup-mosquitto.sh
@@ -50,8 +50,8 @@ sudo chmod a+xr ./setup_mosquitto_test_env.sh
 mosquitto -d -c /etc/mosquitto/mosquitto.conf
 
 # For HTTP proxy tests, we need Squid too
-sudo apt update
-sudo apt install squid
+sudo apt update -y
+sudo apt install squid -y
 # Make sure it is running
 systemctl status squid.service
 

--- a/codebuild/common-linux-setup-mosquitto.sh
+++ b/codebuild/common-linux-setup-mosquitto.sh
@@ -7,34 +7,43 @@ mkdir -p MosquittoInstall
 cd MosquittoInstall
 
 # mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
-echo "Setup mosquitto dependencies - OpenSSL"
-git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
-cd openssl
-./config --prefix=/usr/local --openssldir=/usr/local
-make
-sudo make install
+echo "Setup mosquitto dependencies - OpenSSL (may take a couple minutes - should take no more than 6 minutes)"
+# Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
+{
+    git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
+    cd openssl
+    ./config --prefix=/usr/local --openssldir=/usr/local
+    make
+    sudo make install
+} > /dev/null
 
 # And we have to install libwebsockets from source for mosquitto too
-echo Setup mosquitto dependencies - LibWebsockets
-git clone https://github.com/warmcat/libwebsockets.git --branch v4.3.2
-cd libwebsockets
-mkdir build
-cd build
-cmake .. -DLWS_WITH_EXTERNAL_POLL=ON
-make
-sudo make install
+# Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
+echo "Setup mosquitto dependencies - LibWebsockets (may take a couple minutes - should take no more than 6 minutes)"
+{
+    git clone https://github.com/warmcat/libwebsockets.git --branch v4.3.2
+    cd libwebsockets
+    mkdir build
+    cd build
+    cmake .. -DLWS_WITH_EXTERNAL_POLL=ON
+    make
+    sudo make install
 cd ../..
+} > /dev/null
 
 # Install mosquitto from source
-echo Setup mosquitto - Mosquitto from source
-git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
-cd mosquitto
-make install WITH_DOCS=no WITH_CJSON=no WITH_WEBSOCKETS=yes LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
-cd ..
-sudo ldconfig
+# Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
+echo "Setup mosquitto - Mosquitto from source (may take a couple minutes - should take no more than 6 minutes)"
+{
+    git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
+    cd mosquitto
+    make install WITH_DOCS=no WITH_CJSON=no WITH_WEBSOCKETS=yes LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
+    cd ..
+    sudo ldconfig
+} > /dev/null
 
 # Get the config file and run it
-echo Setup mosquitto - configure mosquitto and start it running
+echo "Setup mosquitto - configure mosquitto and start it running"
 aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
 sudo chmod a+xr ./setup_mosquitto_test_env.sh
 ./setup_mosquitto_test_env.sh

--- a/codebuild/common-linux-setup-mosquitto.sh
+++ b/codebuild/common-linux-setup-mosquitto.sh
@@ -17,7 +17,7 @@ echo "Setup mosquitto dependencies from source - OpenSSL (may take a couple minu
     sudo make install
 } > /dev/null
 
-# And we have to install libwebsockets from source for mosquitto too
+# We have to install libwebsockets from source for mosquitto too for websockets support
 # Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
 echo "Setup mosquitto dependencies from source - LibWebsockets (may take a couple minutes - should take no more than 6 minutes)"
 {
@@ -31,7 +31,7 @@ echo "Setup mosquitto dependencies from source - LibWebsockets (may take a coupl
 cd ../..
 } > /dev/null
 
-# Install mosquitto from source
+# Install mosquitto from source (apt-get version is too old)
 # Note: 99% of the time we do not care for the output, so let's hide it to reduce console spam!
 echo "Setup mosquitto from source - Mosquitto (may take a couple minutes - should take no more than 6 minutes)"
 {
@@ -42,7 +42,7 @@ echo "Setup mosquitto from source - Mosquitto (may take a couple minutes - shoul
     sudo ldconfig
 } > /dev/null
 
-# Get the config file and run it
+# Get the Mosquttio config file and run it
 echo "Setup mosquitto from source - configure mosquitto and start it running"
 aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
 sudo chmod a+xr ./setup_mosquitto_test_env.sh

--- a/codebuild/common-linux-setup-mosquitto.sh
+++ b/codebuild/common-linux-setup-mosquitto.sh
@@ -49,5 +49,11 @@ sudo chmod a+xr ./setup_mosquitto_test_env.sh
 ./setup_mosquitto_test_env.sh
 mosquitto -d -c /etc/mosquitto/mosquitto.conf
 
+# For HTTP proxy tests, we need Squid too
+sudo apt update
+sudo apt install squid
+# Make sure it is running
+systemctl status squid.service
+
 # Done!
 cd ..

--- a/codebuild/common-linux-setup-mosquitto.sh
+++ b/codebuild/common-linux-setup-mosquitto.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+# Make a directory to install all of the mosquitto stuff into
+mkdir -p MosquittoInstall
+cd MosquittoInstall
+
+# mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
+echo "Setup mosquitto dependencies - OpenSSL"
+git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
+cd openssl
+./config --prefix=/usr/local --openssldir=/usr/local
+make
+sudo make install
+
+# And we have to install libwebsockets from source for mosquitto too
+echo Setup mosquitto dependencies - LibWebsockets
+git clone https://github.com/warmcat/libwebsockets.git --branch v4.3.2
+cd libwebsockets
+mkdir build
+cd build
+cmake .. -DLWS_WITH_EXTERNAL_POLL=ON
+make
+sudo make install
+cd ../..
+
+# Install mosquitto from source
+echo Setup mosquitto - Mosquitto from source
+git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
+cd mosquitto
+make install WITH_DOCS=no WITH_CJSON=no WITH_WEBSOCKETS=yes LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
+cd ..
+sudo ldconfig
+
+# Get the config file and run it
+echo Setup mosquitto - configure mosquitto and start it running
+aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
+sudo chmod a+xr ./setup_mosquitto_test_env.sh
+./setup_mosquitto_test_env.sh
+mosquitto -d -c /etc/mosquitto/mosquitto.conf
+
+# Done!
+cd ..

--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -37,6 +37,6 @@ mvn -B test $* \
     -Dcmake.s2nNoPqAsm=ON
 
 # Run the MQTT5 tests again, but connecting to Codebuild Mosquitto
-source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/IotProdMQTT5EnvironmentVariables.txt us-east-1
+source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/CodebuildMosquittoIotProdMQTT5EnvironmentVariables.txt us-east-1
 mvn -B test -Dtest=Mqtt5ClientTest -Daws.crt.debugnative=true -DreuseForks=false -DredirectTestOutputToFile=true
-source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/IotProdMQTT5EnvironmentVariables.txt cleanup
+source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/CodebuildMosquittoIotProdMQTT5EnvironmentVariables.txt cleanup

--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -23,18 +23,18 @@ cd $CODEBUILD_SRC_DIR
 
 # Build and run all the tests!
 ulimit -c unlimited
-# mvn -B test $* \
-#     -DredirectTestOutputToFile=true \
-#     -DreuseForks=false \
-#     -Dendpoint=$ENDPOINT \
-#     -Dcertificate=/tmp/certificate.pem \
-#     -Dprivatekey=/tmp/privatekey.pem \
-#     -Decc_certificate=/tmp/ecc_certificate.pem \
-#     -Decc_privatekey=/tmp/ecc_privatekey.pem \
-#     -Drootca=/tmp/AmazonRootCA1.pem \
-#     -Dprivatekey_p8=/tmp/privatekey_p8.pem \
-#     -Daws.crt.debugnative=true \
-#     -Dcmake.s2nNoPqAsm=ON
+mvn -B test $* \
+    -DredirectTestOutputToFile=true \
+    -DreuseForks=false \
+    -Dendpoint=$ENDPOINT \
+    -Dcertificate=/tmp/certificate.pem \
+    -Dprivatekey=/tmp/privatekey.pem \
+    -Decc_certificate=/tmp/ecc_certificate.pem \
+    -Decc_privatekey=/tmp/ecc_privatekey.pem \
+    -Drootca=/tmp/AmazonRootCA1.pem \
+    -Dprivatekey_p8=/tmp/privatekey_p8.pem \
+    -Daws.crt.debugnative=true \
+    -Dcmake.s2nNoPqAsm=ON
 
 # Run the MQTT5 tests again, but connecting to Codebuild Mosquitto
 source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/CodebuildMosquittoIotProdMQTT5EnvironmentVariables.txt us-east-1

--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -23,18 +23,18 @@ cd $CODEBUILD_SRC_DIR
 
 # Build and run all the tests!
 ulimit -c unlimited
-mvn -B test $* \
-    -DredirectTestOutputToFile=true \
-    -DreuseForks=false \
-    -Dendpoint=$ENDPOINT \
-    -Dcertificate=/tmp/certificate.pem \
-    -Dprivatekey=/tmp/privatekey.pem \
-    -Decc_certificate=/tmp/ecc_certificate.pem \
-    -Decc_privatekey=/tmp/ecc_privatekey.pem \
-    -Drootca=/tmp/AmazonRootCA1.pem \
-    -Dprivatekey_p8=/tmp/privatekey_p8.pem \
-    -Daws.crt.debugnative=true \
-    -Dcmake.s2nNoPqAsm=ON
+# mvn -B test $* \
+#     -DredirectTestOutputToFile=true \
+#     -DreuseForks=false \
+#     -Dendpoint=$ENDPOINT \
+#     -Dcertificate=/tmp/certificate.pem \
+#     -Dprivatekey=/tmp/privatekey.pem \
+#     -Decc_certificate=/tmp/ecc_certificate.pem \
+#     -Decc_privatekey=/tmp/ecc_privatekey.pem \
+#     -Drootca=/tmp/AmazonRootCA1.pem \
+#     -Dprivatekey_p8=/tmp/privatekey_p8.pem \
+#     -Daws.crt.debugnative=true \
+#     -Dcmake.s2nNoPqAsm=ON
 
 # Run the MQTT5 tests again, but connecting to Codebuild Mosquitto
 source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/CodebuildMosquittoIotProdMQTT5EnvironmentVariables.txt us-east-1

--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -6,6 +6,10 @@ if test -f "/tmp/setup_proxy_test_env.sh"; then
     source /tmp/setup_proxy_test_env.sh
 fi
 
+if test -f "/tmp/setup_mosquitto_test_env.sh"; then
+    source /tmp/setup_mosquitto_test_env.sh
+fi
+
 env
 
 git submodule update --init

--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -23,20 +23,20 @@ cd $CODEBUILD_SRC_DIR
 
 # Build and run all the tests!
 ulimit -c unlimited
-mvn -B test $* \
-    -DredirectTestOutputToFile=true \
-    -DreuseForks=false \
-    -Dendpoint=$ENDPOINT \
-    -Dcertificate=/tmp/certificate.pem \
-    -Dprivatekey=/tmp/privatekey.pem \
-    -Decc_certificate=/tmp/ecc_certificate.pem \
-    -Decc_privatekey=/tmp/ecc_privatekey.pem \
-    -Drootca=/tmp/AmazonRootCA1.pem \
-    -Dprivatekey_p8=/tmp/privatekey_p8.pem \
-    -Daws.crt.debugnative=true \
-    -Dcmake.s2nNoPqAsm=ON
+# mvn -B test $* \
+#     -DredirectTestOutputToFile=true \
+#     -DreuseForks=false \
+#     -Dendpoint=$ENDPOINT \
+#     -Dcertificate=/tmp/certificate.pem \
+#     -Dprivatekey=/tmp/privatekey.pem \
+#     -Decc_certificate=/tmp/ecc_certificate.pem \
+#     -Decc_privatekey=/tmp/ecc_privatekey.pem \
+#     -Drootca=/tmp/AmazonRootCA1.pem \
+#     -Dprivatekey_p8=/tmp/privatekey_p8.pem \
+#     -Daws.crt.debugnative=true \
+#     -Dcmake.s2nNoPqAsm=ON
 
-# Run the MQTT5 tests again, but connecting to Codebuild Mosquttio
+# Run the MQTT5 tests again, but connecting to Codebuild Mosquitto
 source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/IotProdMQTT5EnvironmentVariables.txt us-east-1
 mvn -B test -Dtest=Mqtt5ClientTest -Daws.crt.debugnative=true -DreuseForks=false -DredirectTestOutputToFile=true
 source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/IotProdMQTT5EnvironmentVariables.txt cleanup

--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -36,8 +36,7 @@ mvn -B test $* \
     -Daws.crt.debugnative=true \
     -Dcmake.s2nNoPqAsm=ON
 
-# NOTE: Skip for now and just test against IoT Core.
-# Run the MQTT5 tests again, but connecting to Codebuild
-# source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/TestIotProdMQTT5EnvironmentVariables.txt us-east-1
-# mvn -B test -Dtest=Mqtt5ClientTest -Daws.crt.debugnative=true -DreuseForks=false -DredirectTestOutputToFile=true
-# source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/TestIotProdMQTT5EnvironmentVariables.txt cleanup
+# Run the MQTT5 tests again, but connecting to Codebuild Mosquttio
+source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/IotProdMQTT5EnvironmentVariables.txt us-east-1
+mvn -B test -Dtest=Mqtt5ClientTest -Daws.crt.debugnative=true -DreuseForks=false -DredirectTestOutputToFile=true
+source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/IotProdMQTT5EnvironmentVariables.txt cleanup

--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -6,10 +6,6 @@ if test -f "/tmp/setup_proxy_test_env.sh"; then
     source /tmp/setup_proxy_test_env.sh
 fi
 
-if test -f "/tmp/setup_mosquitto_test_env.sh"; then
-    source /tmp/setup_mosquitto_test_env.sh
-fi
-
 env
 
 git submodule update --init

--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -23,18 +23,18 @@ cd $CODEBUILD_SRC_DIR
 
 # Build and run all the tests!
 ulimit -c unlimited
-# mvn -B test $* \
-#     -DredirectTestOutputToFile=true \
-#     -DreuseForks=false \
-#     -Dendpoint=$ENDPOINT \
-#     -Dcertificate=/tmp/certificate.pem \
-#     -Dprivatekey=/tmp/privatekey.pem \
-#     -Decc_certificate=/tmp/ecc_certificate.pem \
-#     -Decc_privatekey=/tmp/ecc_privatekey.pem \
-#     -Drootca=/tmp/AmazonRootCA1.pem \
-#     -Dprivatekey_p8=/tmp/privatekey_p8.pem \
-#     -Daws.crt.debugnative=true \
-#     -Dcmake.s2nNoPqAsm=ON
+mvn -B test $* \
+    -DredirectTestOutputToFile=true \
+    -DreuseForks=false \
+    -Dendpoint=$ENDPOINT \
+    -Dcertificate=/tmp/certificate.pem \
+    -Dprivatekey=/tmp/privatekey.pem \
+    -Decc_certificate=/tmp/ecc_certificate.pem \
+    -Decc_privatekey=/tmp/ecc_privatekey.pem \
+    -Drootca=/tmp/AmazonRootCA1.pem \
+    -Dprivatekey_p8=/tmp/privatekey_p8.pem \
+    -Daws.crt.debugnative=true \
+    -Dcmake.s2nNoPqAsm=ON
 
 # Run the MQTT5 tests again, but connecting to Codebuild Mosquitto
 source ./utils/mqtt5_test_setup.sh s3://aws-crt-test-stuff/IotProdMQTT5EnvironmentVariables.txt us-east-1

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -5,14 +5,20 @@ phases:
     commands:
       - sudo add-apt-repository ppa:openjdk-r/ppa
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+      - sudo add-apt-repository ppa:mosquitto-dev/mosquitto-ppa
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
+      - sudo apt-get install mosquitto mosquitto-clients
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install
   pre_build:
     commands:
       - export CC=gcc-7
+  mosquttio_setup:
+    commands:
+      - echo "TODO: Setup mosquttio certificate, key, and settings. For now, just test install"
+      - mosquttio -d # run mosquttio as a daemon
   build:
     commands:
       - echo Build started on `date`

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -21,6 +21,9 @@ phases:
       - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
       - $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
       - cd $CODEBUILD_SRC_DIR # assure we are in the correct directory again
+      # For MQTT5, we need Squid installed too
+      - sudo apt update -y
+      - sudo apt install squid -y
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -9,6 +9,7 @@ phases:
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
       # - sudo apt-get install mosquitto mosquitto-clients -y
+      - sudo apt-get install libwebsockets-dev cjson -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install
@@ -23,7 +24,7 @@ phases:
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
-      - make install
+      - make install WITH_DOCS=no
       - cd ..
       # Get the config file and run it
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -45,7 +45,8 @@ phases:
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       - ./setup_mosquitto_test_env.sh
-      - mosquitto -d -c /etc/mosquitto/mosquitto.conf
+      # - mosquitto -d -c /etc/mosquitto/mosquitto.conf -v
+      - sudo systemctl restart mosquitto
       # make sure we are in the right directory again
       - cd $CODEBUILD_SRC_DIR
 

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -24,8 +24,7 @@ phases:
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       # Start mosquitto
       - ./setup_mosquitto_test_env.sh
-      - sudo service mosquitto stop
-      - sudo service mosquitto start
+      - sudo service mosquitto restart
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -46,7 +46,7 @@ phases:
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       - ./setup_mosquitto_test_env.sh
-      - mosquitto -d -c /etc/mosquitto/mosquitto.conf -v
+      - mosquitto -d -c /etc/mosquitto/mosquitto.conf
       # make sure we are in the right directory again
       - cd $CODEBUILD_SRC_DIR
 
@@ -58,4 +58,4 @@ phases:
       - echo Build completed on `date`
 
       - echo Print Mosquitto log
-      - cat /var/log/mosquitto/mosquitto.log
+      - [ -f /var/log/mosquitto/mosquitto.log ] && cat /var/log/mosquitto/mosquitto.log

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -28,7 +28,7 @@ phases:
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
-      - make install WITH_DOCS=no WITH_CJSON=no WITH_STATIC_LIBRARIES=yes
+      - make install WITH_DOCS=no WITH_CJSON=no LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
       - cd ..
       # Get the config file and run it
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -30,8 +30,8 @@ phases:
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       - ./setup_mosquitto_test_env.sh
-      # (Re)Start mosquitto
-      - sudo service mosquitto restart
+      # Start mosquitto
+      - mosquitto
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -28,7 +28,7 @@ phases:
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
-      - make install WITH_DOCS=no WITH_CJSON=no LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
+      - make install WITH_DOCS=no WITH_CJSON=no WITH_WEBSOCKETS=yes LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
       - cd ..
       # Get the config file and run it
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -58,4 +58,4 @@ phases:
       - echo Build completed on `date`
 
       - echo Print Mosquitto log
-      - [ -f /var/log/mosquitto/mosquitto.log ] && cat /var/log/mosquitto/mosquitto.log
+      - if (test -a /var/log/mosquitto/mosquitto.log); then cat /var/log/mosquitto/mosquitto.log; fi

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -19,8 +19,11 @@ phases:
     commands:
       - echo Build started on `date`
 
-      - echo "TODO - test running mosquttio"
-      - mosquttio -d # run mosquttio as a daemon
+      - echo "TODO - test running mosquitto"
+      - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh /tmp/setup_mosquitto_test_env.sh
+      - sudo chmod a+xr /tmp/setup_mosquitto_test_env.sh
+      # Start mosquitto
+      - sudo systemctl restart mosquitto
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -22,12 +22,11 @@ phases:
       - $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
       - cd $CODEBUILD_SRC_DIR # assure we are in the correct directory again
       # For MQTT5, we need Squid installed too
-      - sudo apt update -y
-      - sudo apt install squid -y
+      - sudo apt-get install squid -y
       # We need a special Squid config
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
       - # Restart squid
-      - service squid restart
+      - service squid3 restart
 
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -32,3 +32,6 @@ phases:
   post_build:
     commands:
       - echo Build completed on `date`
+
+      - echo Print Mosquitto log
+      - cat /var/log/mosquitto/mosquitto.log

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -15,13 +15,13 @@ phases:
   pre_build:
     commands:
       - export CC=gcc-7
-  mosquttio_setup:
-    commands:
-      - echo "TODO: Setup mosquttio certificate, key, and settings. For now, just test install"
-      - mosquttio -d # run mosquttio as a daemon
   build:
     commands:
       - echo Build started on `date`
+
+      - echo "TODO - test running mosquttio"
+      - mosquttio -d # run mosquttio as a daemon
+
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh
       - $CODEBUILD_SRC_DIR/codebuild/common-linux.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -22,7 +22,7 @@ phases:
       # mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
       - git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
       - cd openssl
-      - ./config --prefix=/usr/local/openssl --openssldir=/usr/local/openssl
+      - ./config --prefix=/usr/local/ --openssldir=/usr/local/
       - make
       - sudo make install
       # Install mosquitto from source

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -9,7 +9,7 @@ phases:
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
       # - sudo apt-get install mosquitto mosquitto-clients -y
-      - sudo apt-get install libwebsockets-dev libcjson-dev -y
+      - sudo apt-get install libwebsockets-dev -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install
@@ -24,7 +24,7 @@ phases:
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
-      - make install WITH_DOCS=no
+      - make install WITH_DOCS=no WITH_CJSON=no
       - cd ..
       # Get the config file and run it
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -20,10 +20,10 @@ phases:
       - echo Build started on `date`
 
       - echo "TODO - test running mosquitto"
-      - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh /tmp/setup_mosquitto_test_env.sh
-      - sudo chmod a+xr /tmp/setup_mosquitto_test_env.sh
+      - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
+      - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       # Start mosquitto
-      - source /tmp/setup_mosquitto_test_env.sh
+      - source ./setup_mosquitto_test_env.sh
       - sudo service mosquitto start
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -26,7 +26,7 @@ phases:
       # We need a special Squid config
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
       - # Restart squid
-      - service squid3 restart
+      - /etc/init.d/squid restart
 
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -9,7 +9,7 @@ phases:
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
       # - sudo apt-get install mosquitto mosquitto-clients -y
-      - sudo apt-get install libwebsockets-dev -y
+      - sudo apt-get install libwebsockets-dev libssl-dev -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -25,7 +25,7 @@ phases:
       - ./config
       - make
       - sudo make install
-      - openssl version
+      # - openssl version
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -9,7 +9,7 @@ phases:
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
       # - sudo apt-get install mosquitto mosquitto-clients -y
-      - sudo apt-get install libwebsockets-dev cjson -y
+      - sudo apt-get install libwebsockets-dev libcjson-dev -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -19,7 +19,7 @@ phases:
     commands:
       - echo Build started on `date`
 
-      - echo "TODO - test running mosquitto"
+      - echo Setup mosquitto
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       # Start mosquitto

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -17,18 +17,10 @@ phases:
     commands:
       - echo Build started on `date`
 
-      # For now, disable Squid.
-      # # Install Squid proxy for MQTT5 testing
-      # - sudo apt-get install squid3 -y
-      # # We need a special Squid config
-      # - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
-      # - # Start squid now that we have changed the config
-      # - sudo service squid3 start
-
       # Install Mosquitto
       - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
       - $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
-      - cd $CODEBUILD_SRC_DIR # assure we are in the correct directory again
+      - cd $CODEBUILD_SRC_DIR # just make sure we are in the correct directory
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -21,7 +21,7 @@ phases:
       - echo Setup mosquitto dependencies - OpenSSL
       - git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
       - cd openssl
-      - ./config --prefix=/usr/local/ --openssldir=/usr/local/
+      - ./config --prefix=/usr/local --openssldir=/usr/local
       - make
       - sudo make install
       # And we have to install libwebsockets from source for mosquitto too
@@ -40,13 +40,13 @@ phases:
       - cd mosquitto
       - make install WITH_DOCS=no WITH_CJSON=no WITH_WEBSOCKETS=yes LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
       - cd ..
+      - sudo ldconfig
       # Get the config file and run it
       - echo Setup mosquitto - configure mosquitto and start it running
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       - ./setup_mosquitto_test_env.sh
-      # - mosquitto -d -c /etc/mosquitto/mosquitto.conf -v
-      - sudo systemctl restart mosquitto
+      - mosquitto -d -c /etc/mosquitto/mosquitto.conf -v
       # make sure we are in the right directory again
       - cd $CODEBUILD_SRC_DIR
 

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -17,17 +17,17 @@ phases:
     commands:
       - echo Build started on `date`
 
+      # Install Squid proxy for MQTT5 testing
+      - sudo apt-get install squid -y
+      # We need a special Squid config
+      - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
+      - # Restart squid now that we have changed the config
+      - sudo service squid restart
+
       # Install Mosquitto
       - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
       - $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
       - cd $CODEBUILD_SRC_DIR # assure we are in the correct directory again
-      # For MQTT5, we need Squid installed too
-      - sudo apt-get install squid -y
-      # We need a special Squid config
-      - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
-      - # Restart squid
-      - sudo service squid3 restart
-
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -9,7 +9,7 @@ phases:
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
       # - sudo apt-get install mosquitto mosquitto-clients -y
-      - sudo apt-get install libwebsockets-dev libssl-dev -y
+      - sudo apt-get install libwebsockets-dev -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install
@@ -24,7 +24,7 @@ phases:
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
-      - make install WITH_DOCS=no WITH_CJSON=no
+      - make install WITH_DOCS=no WITH_CJSON=no WITH_TLS=no
       - cd ..
       # Get the config file and run it
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -7,7 +7,7 @@ phases:
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
-      - sudo apt-get install libwebsockets-dev -y
+      - sudo apt-get install libwebsockets-dev openssl libssl-dev -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install
@@ -19,10 +19,12 @@ phases:
       - echo Build started on `date`
 
       - echo Setup mosquitto
+      # TEMP - print OpenSSL version
+      - openssl version
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
-      - make install WITH_DOCS=no WITH_CJSON=no WITH_TLS=no
+      - make install WITH_DOCS=no WITH_CJSON=no
       - cd ..
       # Get the config file and run it
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -20,8 +20,7 @@ phases:
       # Install Mosquitto
       - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
       - $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
-      # make sure we are in the right directory again
-      - cd $CODEBUILD_SRC_DIR
+      - cd $CODEBUILD_SRC_DIR # assure we are in the correct directory again
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh
@@ -29,6 +28,3 @@ phases:
   post_build:
     commands:
       - echo Build completed on `date`
-
-      - echo Print Mosquitto log if it exists
-      - cat /var/log/mosquitto/mosquitto.log 2>/dev/null

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -8,7 +8,7 @@ phases:
       - sudo add-apt-repository ppa:mosquitto-dev/mosquitto-ppa
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
-      - sudo apt-get install mosquitto mosquitto-clients
+      - sudo apt-get install mosquitto mosquitto-clients -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -23,7 +23,7 @@ phases:
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       # Start mosquitto
-      - source ./setup_mosquitto_test_env.sh
+      - ./setup_mosquitto_test_env.sh
       - sudo service mosquitto start
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -25,13 +25,10 @@ phases:
       - ./config --prefix=/usr/local/openssl --openssldir=/usr/local/openssl
       - make
       - sudo make install
-      # Apparently we need to remove this folder?
-      - sudo rm -r /usr/local/include/openssl
-      # - openssl version
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
-      - make install WITH_DOCS=no WITH_CJSON=no
+      - make install WITH_DOCS=no WITH_CJSON=no WITH_STATIC_LIBRARIES=yes
       - cd ..
       # Get the config file and run it
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -23,7 +23,8 @@ phases:
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh /tmp/setup_mosquitto_test_env.sh
       - sudo chmod a+xr /tmp/setup_mosquitto_test_env.sh
       # Start mosquitto
-      - sudo systemctl restart mosquitto
+      - source /tmp/setup_mosquitto_test_env.sh
+      - sudo service mosquitto start
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -24,6 +24,11 @@ phases:
       # For MQTT5, we need Squid installed too
       - sudo apt update -y
       - sudo apt install squid -y
+      # We need a special Squid config
+      - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
+      - # Restart squid
+      - service squid restart
+
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -26,7 +26,7 @@ phases:
       # We need a special Squid config
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
       - # Restart squid
-      - /etc/init.d/squid restart
+      - sudo service squid3 restart
 
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -20,9 +20,8 @@ phases:
 
       - echo Setup mosquitto
       # mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
-      - wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz
-      - tar xzvf openssl-1.1.1s.tar.gz
-      - cd openssl-1.1.1s
+      - git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
+      - cd openssl
       - ./config
       - make
       - sudo make install

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -17,32 +17,34 @@ phases:
     commands:
       - echo Build started on `date`
 
-      - echo Setup mosquitto
       # mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
+      - echo Setup mosquitto dependencies - OpenSSL
       - git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
       - cd openssl
       - ./config --prefix=/usr/local/ --openssldir=/usr/local/
       - make
       - sudo make install
-      # And we have to install libwebsockets from source for mosquttio too
+      # And we have to install libwebsockets from source for mosquitto too
+      - echo Setup mosquitto dependencies - LibWebsockets
       - git clone https://github.com/warmcat/libwebsockets.git --branch v4.3.2
       - cd libwebsockets
       - mkdir build
       - cd build
-      - cmake .. -DCMAKE_C_COMPILER=/usr/bin/gcc
+      - cmake .. -DLWS_WITH_EXTERNAL_POLL=ON
       - make
       - sudo make install
       - cd ../..
       # Install mosquitto from source
+      - echo Setup mosquitto - Mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
       - make install WITH_DOCS=no WITH_CJSON=no WITH_WEBSOCKETS=yes LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
       - cd ..
       # Get the config file and run it
+      - echo Setup mosquitto - configure mosquitto and start it running
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       - ./setup_mosquitto_test_env.sh
-      # Start mosquitto
       - mosquitto -d -c /etc/mosquitto/mosquitto.conf
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -18,11 +18,11 @@ phases:
       - echo Build started on `date`
 
       # Install Squid proxy for MQTT5 testing
-      - sudo apt-get install squid -y
+      - sudo apt-get install squid3 -y
       # We need a special Squid config
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
-      - # Restart squid now that we have changed the config
-      - sudo service squid restart
+      - # Start squid now that we have changed the config
+      - sudo service squid3 start
 
       # Install Mosquitto
       - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -17,12 +17,13 @@ phases:
     commands:
       - echo Build started on `date`
 
-      # Install Squid proxy for MQTT5 testing
-      - sudo apt-get install squid3 -y
-      # We need a special Squid config
-      - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
-      - # Start squid now that we have changed the config
-      - sudo service squid3 start
+      # For now, disable Squid.
+      # # Install Squid proxy for MQTT5 testing
+      # - sudo apt-get install squid3 -y
+      # # We need a special Squid config
+      # - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_squid.conf /etc/squid/squid.conf
+      # - # Start squid now that we have changed the config
+      # - sudo service squid3 start
 
       # Install Mosquitto
       - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -17,36 +17,9 @@ phases:
     commands:
       - echo Build started on `date`
 
-      # mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
-      - echo Setup mosquitto dependencies - OpenSSL
-      - git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
-      - cd openssl
-      - ./config --prefix=/usr/local --openssldir=/usr/local
-      - make
-      - sudo make install
-      # And we have to install libwebsockets from source for mosquitto too
-      - echo Setup mosquitto dependencies - LibWebsockets
-      - git clone https://github.com/warmcat/libwebsockets.git --branch v4.3.2
-      - cd libwebsockets
-      - mkdir build
-      - cd build
-      - cmake .. -DLWS_WITH_EXTERNAL_POLL=ON
-      - make
-      - sudo make install
-      - cd ../..
-      # Install mosquitto from source
-      - echo Setup mosquitto - Mosquitto from source
-      - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
-      - cd mosquitto
-      - make install WITH_DOCS=no WITH_CJSON=no WITH_WEBSOCKETS=yes LDFLAGS="-L/usr/local/lib/  -Wl,-rpath,/usr/local/lib/"
-      - cd ..
-      - sudo ldconfig
-      # Get the config file and run it
-      - echo Setup mosquitto - configure mosquitto and start it running
-      - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
-      - sudo chmod a+xr ./setup_mosquitto_test_env.sh
-      - ./setup_mosquitto_test_env.sh
-      - mosquitto -d -c /etc/mosquitto/mosquitto.conf
+      # Install Mosquitto
+      - sudo chmod a+xr $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
+      - $CODEBUILD_SRC_DIR/codebuild/common-linux-setup-mosquitto.sh
       # make sure we are in the right directory again
       - cd $CODEBUILD_SRC_DIR
 
@@ -57,5 +30,5 @@ phases:
     commands:
       - echo Build completed on `date`
 
-      - echo Print Mosquitto log
-      - if (test -a /var/log/mosquitto/mosquitto.log); then cat /var/log/mosquitto/mosquitto.log; fi
+      - echo Print Mosquitto log if it exists
+      - cat /var/log/mosquitto/mosquitto.log 2>/dev/null

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -7,7 +7,7 @@ phases:
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
-      - sudo apt-get install libwebsockets-dev openssl libssl-dev -y
+      - sudo apt-get install libwebsockets-dev -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install
@@ -19,7 +19,13 @@ phases:
       - echo Build started on `date`
 
       - echo Setup mosquitto
-      # TEMP - print OpenSSL version
+      # mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
+      - wget https://www.openssl.org/source/openssl-1.1.1s.tar.gz
+      - tar xzvf openssl-1.1.1s.tar.gz
+      - cd openssl-1.1.1s
+      - ./config
+      - make
+      - sudo make install
       - openssl version
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -24,6 +24,7 @@ phases:
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       # Start mosquitto
       - ./setup_mosquitto_test_env.sh
+      - sudo service mosquitto stop
       - sudo service mosquitto start
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -5,10 +5,10 @@ phases:
     commands:
       - sudo add-apt-repository ppa:openjdk-r/ppa
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-      - sudo add-apt-repository ppa:mosquitto-dev/mosquitto-ppa
+      # - sudo add-apt-repository ppa:mosquitto-dev/mosquitto-ppa
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
-      - sudo apt-get install mosquitto mosquitto-clients -y
+      # - sudo apt-get install mosquitto mosquitto-clients -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install
@@ -20,10 +20,16 @@ phases:
       - echo Build started on `date`
 
       - echo Setup mosquitto
+      # Install mosquitto from source
+      - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
+      - cd mosquitto
+      - make install
+      - cd ..
+      # Get the config file and run it
       - aws s3 cp s3://aws-crt-test-stuff/setup_mosquitto_test_env.sh ./setup_mosquitto_test_env.sh
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
-      # Start mosquitto
       - ./setup_mosquitto_test_env.sh
+      # (Re)Start mosquitto
       - sudo service mosquitto restart
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -5,10 +5,8 @@ phases:
     commands:
       - sudo add-apt-repository ppa:openjdk-r/ppa
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-      # - sudo add-apt-repository ppa:mosquitto-dev/mosquitto-ppa
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
-      # - sudo apt-get install mosquitto mosquitto-clients -y
       - sudo apt-get install libwebsockets-dev -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
@@ -31,7 +29,7 @@ phases:
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       - ./setup_mosquitto_test_env.sh
       # Start mosquitto
-      - mosquitto
+      - mosquitto -d -c /etc/mosquitto/mosquitto.conf
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -22,11 +22,9 @@ phases:
       # mosquitto needs OpenSSL at version 1.1.0+, so we have to install from source
       - git clone https://github.com/openssl/openssl.git --branch OpenSSL_1_1_1s
       - cd openssl
-      - ./config
+      - ./config --prefix=/usr/local/openssl --openssldir=/usr/local/openssl
       - make
       - sudo make install
-      - sudo ln -s /usr/local/bin/openssl /usr/bin/openssl
-      - sudo ldconfig
       # - openssl version
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -29,6 +29,7 @@ phases:
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
+      - LD_LIBRARY_PATH=/usr/local/lib
       - make install WITH_DOCS=no WITH_CJSON=no
       - cd ..
       # Get the config file and run it

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -7,7 +7,6 @@ phases:
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - sudo apt-get update -y
       - sudo apt-get install gcc-7 cmake3 ninja-build -y
-      - sudo apt-get install libwebsockets-dev -y
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
       - unzip -q -d /tmp /tmp/awscliv2.zip
       - sudo /tmp/aws/install
@@ -25,6 +24,15 @@ phases:
       - ./config --prefix=/usr/local/ --openssldir=/usr/local/
       - make
       - sudo make install
+      # And we have to install libwebsockets from source for mosquttio too
+      - git clone https://github.com/warmcat/libwebsockets.git --branch v4.3.2
+      - cd libwebsockets
+      - mkdir build
+      - cd build
+      - cmake .. -DCMAKE_C_COMPILER=/usr/bin/gcc
+      - make
+      - sudo make install
+      - cd ../..
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -46,6 +46,8 @@ phases:
       - sudo chmod a+xr ./setup_mosquitto_test_env.sh
       - ./setup_mosquitto_test_env.sh
       - mosquitto -d -c /etc/mosquitto/mosquitto.conf
+      # make sure we are in the right directory again
+      - cd $CODEBUILD_SRC_DIR
 
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - sudo chmod a+xr /tmp/setup_proxy_test_env.sh

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -25,6 +25,8 @@ phases:
       - ./config --prefix=/usr/local/openssl --openssldir=/usr/local/openssl
       - make
       - sudo make install
+      # Apparently we need to remove this folder?
+      - sudo rm -r /usr/local/include/openssl
       # - openssl version
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -25,11 +25,12 @@ phases:
       - ./config
       - make
       - sudo make install
+      - sudo ln -s /usr/local/bin/openssl /usr/bin/openssl
+      - sudo ldconfig
       # - openssl version
       # Install mosquitto from source
       - git clone https://github.com/eclipse/mosquitto.git --branch v2.0.15
       - cd mosquitto
-      - LD_LIBRARY_PATH=/usr/local/lib
       - make install WITH_DOCS=no WITH_CJSON=no
       - cd ..
       # Get the config file and run it

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -621,6 +621,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     }
 
     /* Direct connection with HttpProxyOptions */
+    /* NOTE: Might not work initially on Codebuild Mosquitto - will need to test on its own */
     // @Test
     // public void ConnDC_UC5() {
     //     skipIfNetworkUnavailable();
@@ -1035,2086 +1036,2086 @@ public class Mqtt5ClientTest extends CrtTestFixture {
      * ============================================================
      */
 
-    // /* Client connect with invalid host name */
-    // @Test
-    // public void ConnNegativeID_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean foundExpectedError = false;
-    //     boolean exceptionOccurred = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("_test", getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-    //         builder.withMinReconnectDelayMs(1000L);
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-
-    //             try {
-    //                 events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 exceptionOccurred = true;
-    //                 if (events.connectFailureCode == 1059) {
-    //                     foundExpectedError = true;
-    //                 } else {
-    //                     System.out.println("EXCEPTION: " + ex);
-    //                     System.out.println(ex.getMessage() + " \n");
-    //                 }
-    //             }
-
-    //             if (foundExpectedError == false) {
-    //                 System.out.println("Error code was not AWS_IO_DNS_INVALID_NAME like expected! There was an exception though");
-    //             }
-    //             if (exceptionOccurred == false) {
-    //                 fail("No exception occurred!");
-    //             }
-    //         }
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Client connect with invalid, nonexistent port for direct connection */
-    // @Test
-    // public void ConnNegativeID_UC2() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean foundExpectedError = false;
-    //     boolean exceptionOccurred = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), 65535L);
-    //         builder.withLifecycleEvents(events);
-    //         builder.withMinReconnectDelayMs(1000L);
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-
-    //             try {
-    //                 events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 exceptionOccurred = true;
-    //                 if (events.connectFailureCode == 1047) {
-    //                     foundExpectedError = true;
-    //                 }
-    //             }
-
-    //             if (foundExpectedError == false) {
-    //                 System.out.println("Error code was not AWS_IO_SOCKET_CONNECTION_REFUSED like expected! There was an exception though");
-    //             }
-    //             if (exceptionOccurred == false) {
-    //                 fail("No exception occurred!");
-    //             }
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Client connect with invalid protocol port for direct connection */
-    // @Test
-    // public void ConnNegativeID_UC2_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(mqtt5DirectMqttHost != null);
-    //     Assume.assumeTrue(mqtt5WSMqttPort != null);
-    //     boolean foundExpectedError = false;
-    //     boolean exceptionOccurred = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5WSMqttPort);
-    //         builder.withLifecycleEvents(events);
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-
-    //             try {
-    //                 events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 exceptionOccurred = true;
-    //                 if (events.connectFailureCode == 5149) {
-    //                     foundExpectedError = true;
-    //                 }
-    //             }
-
-    //             if (foundExpectedError == false) {
-    //                 System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
-    //             }
-    //             if (exceptionOccurred == false) {
-    //                 fail("No exception occurred!");
-    //             }
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Client connect with invalid, nonexistent port for websocket connection */
-    // @Test
-    // public void ConnNegativeID_UC3() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(mqtt5WSMqttHost != null);
-    //     boolean foundExpectedError = false;
-    //     boolean exceptionOccurred = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-    //         try (
-    //             EventLoopGroup elg = new EventLoopGroup(1);
-    //             HostResolver hr = new HostResolver(elg);
-    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-    //         ) {
-    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, 444L);
-    //             builder.withLifecycleEvents(events);
-    //             builder.withBootstrap(bootstrap);
-
-    //             Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-    //                 @Override
-    //                 public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-    //                     t.complete(t.getHttpRequest());
-    //                 }
-    //             };
-    //             builder.withWebsocketHandshakeTransform(websocketTransform);
-
-    //             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //                 client.start();
-
-    //                 try {
-    //                     events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //                 } catch (Exception ex) {
-    //                     exceptionOccurred = true;
-    //                     if (events.connectFailureCode == 1047) {
-    //                         foundExpectedError = true;
-    //                     }
-    //                 }
-
-    //                 if (foundExpectedError == false) {
-    //                     System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
-    //                 }
-    //                 if (exceptionOccurred == false) {
-    //                     fail("No exception occurred!");
-    //                 }
-    //             }
-    //         }
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Client connect with invalid protocol port for websocket connection */
-    // @Test
-    // public void ConnNegativeID_UC3_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(mqtt5WSMqttHost != null);
-    //     Assume.assumeTrue(mqtt5DirectMqttPort != null);
-    //     boolean foundExpectedError = false;
-    //     boolean exceptionOccurred = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-    //         try (
-    //             EventLoopGroup elg = new EventLoopGroup(1);
-    //             HostResolver hr = new HostResolver(elg);
-    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-    //         ) {
-
-    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5DirectMqttPort);
-    //             builder.withLifecycleEvents(events);
-    //             builder.withBootstrap(bootstrap);
-
-    //             Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-    //                 @Override
-    //                 public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-    //                     t.complete(t.getHttpRequest());
-    //                 }
-    //             };
-    //             builder.withWebsocketHandshakeTransform(websocketTransform);
-
-    //             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //                 client.start();
-    //                 try {
-    //                     events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //                 } catch (Exception ex) {
-    //                     exceptionOccurred = true;
-    //                     if (events.connectFailureCode == 46) {
-    //                         foundExpectedError = true;
-    //                     }
-    //                 }
-
-    //                 if (foundExpectedError == false) {
-    //                     System.out.println("Error code was not AWS_ERROR_SYS_CALL_FAILURE (occurs right after AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR for Websockets) like expected! There was an exception though");
-    //                 }
-    //                 if (exceptionOccurred == false) {
-    //                     fail("No exception occurred!");
-    //                 }
-    //             }
-    //         }
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Client connect with socket timeout */
-    // @Test
-    // public void ConnNegativeID_UC4() {
-    //     skipIfNetworkUnavailable();
-    //     boolean foundExpectedError = false;
-    //     boolean exceptionOccurred = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-    //         try (
-    //             EventLoopGroup elg = new EventLoopGroup(1);
-    //             HostResolver hr = new HostResolver(elg);
-    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-    //             SocketOptions options = new SocketOptions();
-    //         ) {
-    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("www.example.com", 81L);
-    //             builder.withLifecycleEvents(events);
-    //             builder.withBootstrap(bootstrap);
-
-    //             options.connectTimeoutMs = 100;
-    //             builder.withSocketOptions(options);
-
-    //             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //                 client.start();
-
-    //                 try {
-    //                     events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //                 } catch (Exception ex) {
-    //                     exceptionOccurred = true;
-    //                     if (events.connectFailureCode == 1048) {
-    //                         foundExpectedError = true;
-    //                     }
-    //                 }
-    //                 if (foundExpectedError == false) {
-    //                     System.out.println("Error code was not AWS_IO_SOCKET_TIMEOUT like expected! There was an exception though");
-    //                 }
-    //                 if (exceptionOccurred == false) {
-    //                     fail("No exception occurred!");
-    //                 }
-    //             }
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Websocket handshake failure test */
-    // @Test
-    // public void ConnNegativeID_UC6() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(mqtt5WSMqttHost != null);
-    //     Assume.assumeTrue(mqtt5WSMqttPort != null);
-    //     boolean foundExpectedError = false;
-    //     boolean exceptionOccurred = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-    //         try (
-    //             EventLoopGroup elg = new EventLoopGroup(1);
-    //             HostResolver hr = new HostResolver(elg);
-    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-    //         ) {
-
-    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
-    //             builder.withLifecycleEvents(events);
-    //             builder.withBootstrap(bootstrap);
-
-    //             Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-    //                 @Override
-    //                 public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-    //                     t.completeExceptionally(new Throwable("Intentional failure!"));
-    //                 }
-    //             };
-    //             builder.withWebsocketHandshakeTransform(websocketTransform);
-    //             builder.withPort(mqtt5WSMqttPort);
-
-    //             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //                 client.start();
-
-    //                 try {
-    //                     events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //                 } catch (Exception ex) {
-    //                     exceptionOccurred = true;
-    //                     if (events.connectFailureCode == 3) {
-    //                         foundExpectedError = true;
-    //                     }
-    //                 }
-    //                 if (foundExpectedError == false) {
-    //                     System.out.println("Error code was not AWS_ERROR_UNKNOWN like expected! There was an exception though");
-    //                 }
-    //                 if (exceptionOccurred == false) {
-    //                     fail("No exception occurred!");
-    //                 }
-
-    //                 DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-    //                 client.stop(disconnect.build());
-    //             }
-    //         }
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* For the double client ID test */
-    // static final class LifecycleEvents_DoubleClientID implements Mqtt5ClientOptions.LifecycleEvents {
-    //     CompletableFuture<Void> connectedFuture = new CompletableFuture<>();
-    //     CompletableFuture<Void> disconnectedFuture = new CompletableFuture<>();
-    //     CompletableFuture<Void> stoppedFuture = new CompletableFuture<>();
-
-    //     @Override
-    //     public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
-
-    //     @Override
-    //     public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
-    //         connectedFuture.complete(null);
-    //     }
-
-    //     @Override
-    //     public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {
-    //         connectedFuture.completeExceptionally(new Exception("Could not connect!"));
-    //     }
-
-    //     @Override
-    //     public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {
-    //         disconnectedFuture.complete(null);
-    //     }
-
-    //     @Override
-    //     public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {
-    //         stoppedFuture.complete(null);
-    //     }
-    // }
-
-    // /* Double Client ID failure test */
-    // @Test
-    // public void ConnNegativeID_UC7() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-
-    //     try {
-    //         LifecycleEvents_DoubleClientID events = new LifecycleEvents_DoubleClientID();
-
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
-    //         builder.withConnectOptions(connectOptions.build());
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (
-    //             Mqtt5Client clientOne = new Mqtt5Client(builder.build());
-    //             Mqtt5Client clientTwo = new Mqtt5Client(builder.build());
-    //         ) {
-    //             clientOne.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             clientTwo.start();
-    //             events.connectedFuture = new CompletableFuture<>();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             // Make sure a disconnection happened
-    //             events.disconnectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             // Stop the clients from disconnecting each other. If we do not do this, then the clients will
-    //             // attempt to reconnect endlessly, making a never ending loop.
-    //             DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
-    //             clientOne.stop(disconnect);
-    //             clientTwo.stop(disconnect);
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Double Client ID disconnect and then reconnect test */
-    // @Test
-    // public void ConnNegativeID_UC7_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-    //     try {
-    //         LifecycleEvents_DoubleClientID events = new LifecycleEvents_DoubleClientID();
-    //         LifecycleEvents_DoubleClientID eventsTwo = new LifecycleEvents_DoubleClientID();
-
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
-    //         builder.withConnectOptions(connectOptions.build());
-
-    //         Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builderTwo.withLifecycleEvents(eventsTwo);
-    //         builderTwo.withConnectOptions(connectOptions.build());
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //             builderTwo.withTlsContext(tlsContext);
-    //         }
-
-    //         try (
-    //             Mqtt5Client clientOne = new Mqtt5Client(builder.build());
-    //             Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
-    //         ) {
-    //             clientOne.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             clientTwo.start();
-    //             eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             // Make sure the first client was disconnected
-    //             events.disconnectedFuture.get(180, TimeUnit.SECONDS);
-    //             // Disconnect the second client so the first can reconnect
-    //             clientTwo.stop(new DisconnectPacketBuilder().build());
-    //             // Confirm the second client has stopped
-    //             eventsTwo.stoppedFuture.get(180, TimeUnit.SECONDS);
-
-    //             // Wait until the first client has reconnected
-    //             events.connectedFuture = new CompletableFuture<>();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             assertTrue(clientOne.getIsConnected() == true);
-
-    //             // Stop the clients from disconnecting each other. If we do not do this, then the clients will
-    //             // attempt to reconnect endlessly, making a never ending loop.
-    //             DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
-    //             clientOne.stop(disconnect);
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /**
-    //  * ============================================================
-    //  * Negative Data Input Tests
-    //  * ============================================================
-    //  */
-
-    // /* Negative Connect Packet Properties */
-    // @Test
-    // public void NewNegative_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean clientCreationFailed = false;
-
-    //     try {
-    //         Mqtt5Client client = null;
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-
-    //         connectOptions.withKeepAliveIntervalSeconds(-100L);
-    //         builder.withConnectOptions(connectOptions.build());
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail with negative KeepAliveIntervalSeconds");
-    //         }
-    //         connectOptions.withKeepAliveIntervalSeconds(100L);
-
-    //         connectOptions.withSessionExpiryIntervalSeconds(-100L);
-    //         builder.withConnectOptions(connectOptions.build());
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail with negative SessionExpiryIntervalSeconds");
-    //         }
-    //         connectOptions.withSessionExpiryIntervalSeconds(100L);
-
-    //         connectOptions.withReceiveMaximum(-100L);
-    //         builder.withConnectOptions(connectOptions.build());
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail negative ReceiveMaximum");
-    //         }
-    //         connectOptions.withReceiveMaximum(100L);
-
-    //         connectOptions.withMaximumPacketSizeBytes(-100L);
-    //         builder.withConnectOptions(connectOptions.build());
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail with negative MaximumPacketSizeBytes");
-    //         }
-    //         connectOptions.withMaximumPacketSizeBytes(100L);
-
-    //         connectOptions.withWillDelayIntervalSeconds(-100L);
-    //         builder.withConnectOptions(connectOptions.build());
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail with negative willDelayIntervalSeconds");
-    //         }
-    //         connectOptions.withWillDelayIntervalSeconds(100L);
-
-    //         // Make sure everything is closed
-    //         if (client != null) {
-    //             client.close();
-    //         }
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Overflow Connect Packet Properties */
-    // @Test
-    // public void NewNegative_UC1_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean clientCreationFailed = false;
-
-    //     try {
-    //         Mqtt5Client client = null;
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-
-    //         connectOptions.withKeepAliveIntervalSeconds(2147483647L);
-    //         builder.withConnectOptions(connectOptions.build());
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail with overflow KeepAliveIntervalSeconds");
-    //         }
-    //         connectOptions.withKeepAliveIntervalSeconds(100L);
-
-    //         connectOptions.withSessionExpiryIntervalSeconds(9223372036854775807L);
-    //         builder.withConnectOptions(connectOptions.build());
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail with overflow SessionExpiryIntervalSeconds");
-    //         }
-    //         connectOptions.withSessionExpiryIntervalSeconds(100L);
-
-    //         connectOptions.withReceiveMaximum(2147483647L);
-    //         builder.withConnectOptions(connectOptions.build());
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail overflow ReceiveMaximum");
-    //         }
-    //         connectOptions.withReceiveMaximum(100L);
-
-    //         connectOptions.withMaximumPacketSizeBytes(9223372036854775807L);
-    //         builder.withConnectOptions(connectOptions.build());
-    //         clientCreationFailed = false;
-    //         try {
-    //             client = new Mqtt5Client(builder.build());
-    //         } catch (Exception ex) {
-    //             clientCreationFailed = true;
-    //         }
-    //         if (clientCreationFailed == false) {
-    //             fail("Client creation did not fail with overflow MaximumPacketSizeBytes");
-    //         }
-    //         connectOptions.withMaximumPacketSizeBytes(100L);
-
-    //         // WillDelayIntervalSeconds is an unsigned 64 bit Long, so it cannot overflow it from Java
-
-    //         // Make sure everything is closed
-    //         if (client != null) {
-    //             client.close();
-    //         }
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Negative Disconnect Packet Properties */
-    // @Test
-    // public void NewNegative_UC2() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean clientDisconnectFailed = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
-    //             disconnectBuilder.withSessionExpiryIntervalSeconds(-100L);
-    //             try {
-    //                 client.stop(disconnectBuilder.build());
-    //             } catch (Exception ex) {
-    //                 clientDisconnectFailed = true;
-    //             }
-
-    //             if (clientDisconnectFailed == false) {
-    //                 fail("Client disconnect packet creation did not fail!");
-    //             }
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Overflow Disconnect Packet Properties */
-    // @Test
-    // public void NewNegative_UC2_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean clientDisconnectFailed = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
-    //             disconnectBuilder.withSessionExpiryIntervalSeconds(9223372036854775807L);
-    //             try {
-    //                 client.stop(disconnectBuilder.build());
-    //             } catch (Exception ex) {
-    //                 clientDisconnectFailed = true;
-    //             }
-
-    //             if (clientDisconnectFailed == false) {
-    //                 fail("Client disconnect did not fail!");
-    //             }
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Negative Publish Packet Properties */
-    // @Test
-    // public void NewNegative_UC3() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean clientPublishFailed = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
-    //             publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
-    //             publishBuilder.withMessageExpiryIntervalSeconds(-100L);
-    //             try {
-    //                 CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
-    //                 future.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 clientPublishFailed = true;
-    //             }
-
-    //             if (clientPublishFailed == false) {
-    //                 fail("Client publish did not fail!");
-    //             }
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Overflow Publish Packet Properties */
-    // @Test
-    // public void NewNegative_UC3_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean clientPublishFailed = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
-    //             publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic").withQOS(QOS.AT_LEAST_ONCE);
-    //             publishBuilder.withMessageExpiryIntervalSeconds(9223372036854775807L);
-    //             try {
-    //                 CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
-    //                 future.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 clientPublishFailed = true;
-    //             }
-
-    //             if (clientPublishFailed == false) {
-    //                 fail("Client publish did not fail!");
-    //             }
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Negative Subscribe Packet Properties */
-    // @Test
-    // public void NewNegative_UC4() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean clientSubscribeFailed = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
-    //             subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
-    //             subscribeBuilder.withSubscriptionIdentifier(-100L);
-    //             try {
-    //                 CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
-    //                 future.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 clientSubscribeFailed = true;
-    //             }
-
-    //             if (clientSubscribeFailed == false) {
-    //                 fail("Client subscribe did not fail!");
-    //             }
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Overflow Subscribe Packet Properties */
-    // @Test
-    // public void NewNegative_UC4_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean clientSubscribeFailed = false;
-
-    //     try {
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
-    //             subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
-    //             subscribeBuilder.withSubscriptionIdentifier(9223372036854775807L);
-    //             try {
-    //                 CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
-    //                 future.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 clientSubscribeFailed = true;
-    //             }
-
-    //             if (clientSubscribeFailed == false) {
-    //                 fail("Client subscribe did not fail!");
-    //             }
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /**
-    //  * ============================================================
-    //  * Negotiated Settings Tests
-    //  * ============================================================
-    //  */
-
-    // /* Happy path, minimal success test */
-    // @Test
-    // public void Negotiated_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-    //         ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
-    //         optionsBuilder.withSessionExpiryIntervalSeconds(600000L);
-    //         builder.withConnectOptions(optionsBuilder.build());
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             // TODO - add support for this in the future!
-    //             // assertEquals(
-    //             //     "Negotiated Settings session expiry interval does not match sent session expiry interval",
-    //             //     events.connectSuccessSettings.getSessionExpiryInterval(),
-    //             //     600000L);
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Maximum success test */
-    // @Test
-    // public void Negotiated_UC2() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
-    //         optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
-    //         optionsBuilder.withSessionExpiryIntervalSeconds(0L);
-    //         optionsBuilder.withKeepAliveIntervalSeconds(360L);
-    //         builder.withConnectOptions(optionsBuilder.build());
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             assertEquals(
-    //                 "Negotiated Settings client ID does not match sent client ID",
-    //                 events.connectSuccessSettings.getAssignedClientID(),
-    //                 "test/MQTT5_Binding_Java_" + testUUID);
-    //             assertEquals(
-    //                 "Negotiated Settings session expiry interval does not match sent session expiry interval",
-    //                 events.connectSuccessSettings.getSessionExpiryInterval(),
-    //                 0L);
-    //             assertEquals(
-    //                 "Negotiated Settings keep alive result does not match sent keep alive",
-    //                 events.connectSuccessSettings.getServerKeepAlive(),
-    //                 360);
-    //             assertEquals(
-    //                     "Negotiated Settings rejoined session does not match expected value",
-    //                     false,
-    //                     events.connectSuccessSettings.getRejoinedSession());
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Rejoin always session resumption test */
-    // @Test
-    // public void Negotiated_Rejoin_Always() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
-    //         optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
-    //         optionsBuilder.withSessionExpiryIntervalSeconds(3600L);
-    //         optionsBuilder.withKeepAliveIntervalSeconds(360L);
-    //         builder.withConnectOptions(optionsBuilder.build());
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             assertEquals(
-    //                     "Negotiated Settings client ID does not match sent client ID",
-    //                     events.connectSuccessSettings.getAssignedClientID(),
-    //                     "test/MQTT5_Binding_Java_" + testUUID);
-    //             assertEquals(
-    //                     "Negotiated Settings session expiry interval does not match sent session expiry interval",
-    //                     events.connectSuccessSettings.getSessionExpiryInterval(),
-    //                     3600L);
-    //             assertEquals(
-    //                     "Negotiated Settings keep alive result does not match sent keep alive",
-    //                     events.connectSuccessSettings.getServerKeepAlive(),
-    //                     360);
-    //             assertEquals(
-    //                     "Negotiated Settings rejoined session does not match expected value",
-    //                     false,
-    //                     events.connectSuccessSettings.getRejoinedSession());
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         builder.withSessionBehavior(ClientSessionBehavior.REJOIN_ALWAYS);
-    //         LifecycleEvents_Futured rejoinEvents = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(rejoinEvents);
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             rejoinEvents.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             assertEquals(
-    //                     "Negotiated Settings rejoined session does not match expected value",
-    //                     true,
-    //                     rejoinEvents.connectSuccessSettings.getRejoinedSession());
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /**
-    //  * ============================================================
-    //  * Operation Tests
-    //  * ============================================================
-    //  */
-
-    // /* Sub-UnSub happy path */
-    // @Test
-    // public void Op_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         PublishEvents_Futured publishEvents = new PublishEvents_Futured();
-    //         builder.withPublishEvents(publishEvents);
-
-    //         PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-    //         publishPacketBuilder.withTopic(testTopic);
-    //         publishPacketBuilder.withPayload("Hello World".getBytes());
-    //         publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
-
-    //         SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-    //         subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-
-    //         UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
-    //         unsubscribePacketBuilder.withSubscription(testTopic);
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             client.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-    //             client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //             publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
-
-    //             publishEvents.publishReceivedFuture = new CompletableFuture<>();
-    //             publishEvents.publishPacket = null;
-    //             client.unsubscribe(unsubscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //             client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-    //             assertEquals(
-    //                 "Publish after unsubscribe still arrived!",
-    //                 publishEvents.publishPacket,
-    //                 null);
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Sub-UnSub happy path */
-    // @Test
-    // public void Op_UC2() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-    //         PublishPacketBuilder willPacket = new PublishPacketBuilder();
-    //         willPacket.withTopic(testTopic);
-    //         willPacket.withQOS(QOS.AT_LEAST_ONCE);
-    //         willPacket.withPayload("Hello World".getBytes());
-    //         connectOptions.withWill(willPacket.build());
-    //         connectOptions.withWillDelayIntervalSeconds(0L);
-    //         builder.withConnectOptions(connectOptions.build());
-
-    //         Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
-    //         builderTwo.withLifecycleEvents(eventsTwo);
-    //         PublishEvents_Futured publishEvents = new PublishEvents_Futured();
-    //         builderTwo.withPublishEvents(publishEvents);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContextTwo = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContextTwo = getIoTCoreTlsContext();
-    //             builderTwo.withTlsContext(tlsContextTwo);
-    //         }
-
-    //         SubscribePacketBuilder subscribeOptions = new SubscribePacketBuilder();
-    //         subscribeOptions.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-
-    //         try (
-    //             Mqtt5Client clientOne = new Mqtt5Client(builder.build());
-    //             Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
-    //         ) {
-    //             clientOne.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             clientTwo.start();
-    //             eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             clientTwo.subscribe(subscribeOptions.build()).get(180, TimeUnit.SECONDS);
-    //             clientOne.stop(null);
-
-    //             // Did we get a publish message?
-    //             publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
-    //             assertTrue(publishEvents.publishPacket != null);
-
-    //             clientTwo.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //             tlsContextTwo.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Binary Publish Test */
-    // @Test
-    // public void Op_UC3() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         PublishEvents_Futured publishEvents = new PublishEvents_Futured();
-    //         builder.withPublishEvents(publishEvents);
-
-    //         // Make random binary
-    //         byte[] randomBytes = new byte[256];
-    //         Random random = new Random();
-    //         random.nextBytes(randomBytes);
-
-    //         PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-    //         publishPacketBuilder.withTopic(testTopic).withPayload(randomBytes).withQOS(QOS.AT_LEAST_ONCE);
-
-    //         SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-    //         subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             client.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-    //             client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //             publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
-
-    //             assertTrue(java.util.Arrays.equals(publishEvents.publishPacket.getPayload(), randomBytes));
-
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //             events.stopFuture.get(180, TimeUnit.SECONDS);
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /**
-    //  * ============================================================
-    //  * Error Operation Tests
-    //  * ============================================================
-    //  */
-
-    // /* Null Publish Test */
-    // @Test
-    // public void ErrorOp_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean didExceptionOccur = false;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             try {
-    //                 client.publish(null).get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 didExceptionOccur = true;
-    //             }
-
-    //             if (didExceptionOccur == false) {
-    //                 fail("Null publish packet did not cause exception with error!");
-    //             }
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Publish with empty builder test */
-    // @Test
-    // public void ErrorOp_UC1_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean didExceptionOccur = false;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             try {
-    //                 client.publish(new PublishPacketBuilder().build()).get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 didExceptionOccur = true;
-    //             }
-
-    //             if (didExceptionOccur == false) {
-    //                 fail("Empty publish packet did not cause exception with error!");
-    //             }
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Null Subscribe Test */
-    // @Test
-    // public void ErrorOp_UC2() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean didExceptionOccur = false;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             try {
-    //                 client.subscribe(null).get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 didExceptionOccur = true;
-    //             }
-
-    //             if (didExceptionOccur == false) {
-    //                 fail("Null subscribe packet did not cause exception with error!");
-    //             }
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Empty Subscribe Test */
-    // @Test
-    // public void ErrorOp_UC2_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean didExceptionOccur = false;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             try {
-    //                 client.subscribe(new SubscribePacketBuilder().build()).get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 didExceptionOccur = true;
-    //             }
-
-    //             if (didExceptionOccur == false) {
-    //                 fail("Empty subscribe packet did not cause exception with error!");
-    //             }
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Null Unsubscribe Test */
-    // @Test
-    // public void ErrorOp_UC3() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean didExceptionOccur = false;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             try {
-    //                 client.unsubscribe(null).get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 didExceptionOccur = true;
-    //             }
-
-    //             if (didExceptionOccur == false) {
-    //                 fail("Null unsubscribe packet did not cause exception with error!");
-    //             }
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Empty Unsubscribe Test */
-    // @Test
-    // public void ErrorOp_UC3_ALT() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     boolean didExceptionOccur = false;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             try {
-    //                 client.unsubscribe(new UnsubscribePacketBuilder().build()).get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 didExceptionOccur = true;
-    //             }
-
-    //             if (didExceptionOccur == false) {
-    //                 fail("Empty unsubscribe packet did not cause exception with error!");
-    //             }
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /* Unsupported Connect packet data sent (IoT Core only) */
-    // @Test
-    // public void ErrorOp_UC4() {
-    //     skipIfNetworkUnavailable();
-    //     /* Only works on IoT Core */
-    //     Assume.assumeTrue(mqtt5IoTCoreMqttHost != null);
-    //     Assume.assumeTrue(mqtt5IoTCoreMqttPort != null);
-    //     Assume.assumeTrue(mqtt5IoTCoreMqttCertificateFile != null);
-    //     Assume.assumeTrue(mqtt5IoTCoreMqttKeyFile != null);
-    //     Assume.assumeTrue(mqtt5IoTCoreMqttCertificateBytes != null);
-    //     Assume.assumeTrue(mqtt5IoTCoreMqttKeyBytes != null);
-    //     boolean didExceptionOccur = false;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5IoTCoreMqttHost, mqtt5IoTCoreMqttPort);
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         TlsContext tlsContext = null;
-    //         tlsContext = getIoTCoreTlsContext();
-    //         builder.withTlsContext(tlsContext);
-
-    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-    //         String clientIDString = "";
-    //         for (int i = 0; i < 256; i++) {
-    //             clientIDString += "a";
-    //         }
-    //         connectOptions.withClientId(clientIDString);
-    //         builder.withConnectOptions(connectOptions.build());
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             try {
-    //                 client.start();
-    //                 events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 didExceptionOccur = true;
-    //             }
-
-    //             if (didExceptionOccur == false) {
-    //                 fail("Was able to connect with Client ID longer than 128 characters (AWS_IOT_CORE_MAXIMUM_CLIENT_ID_LENGTH)");
-    //             }
-    //             client.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /**
-    //  * ============================================================
-    //  * QoS1 Tests
-    //  * ============================================================
-    //  */
-
-    // /* Happy path. No drop in connection, no retry, no reconnect */
-    // @Test
-    // public void QoS1_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     int messageCount = 10;
-    //     String testUUID = UUID.randomUUID().toString();
-    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
-    //         builderTwo.withLifecycleEvents(eventsTwo);
-    //         PublishEvents_Futured_Counted publishEvents = new PublishEvents_Futured_Counted();
-    //         publishEvents.desiredPublishCount = messageCount;
-    //         builderTwo.withPublishEvents(publishEvents);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //             builderTwo.withTlsContext(tlsContext);
-    //         }
-
-    //         try (
-    //             Mqtt5Client publisher = new Mqtt5Client(builder.build());
-    //             Mqtt5Client subscriber = new Mqtt5Client(builderTwo.build());
-    //         ) {
-    //             publisher.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             subscriber.start();
-    //             eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-    //             subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-    //             subscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-    //             PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-    //             publishPacketBuilder.withTopic(testTopic);
-    //             publishPacketBuilder.withPayload("Hello World".getBytes());
-    //             publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
-
-    //             for (int i = 0; i < messageCount; i++) {
-    //                 publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //             }
-
-    //             // Did we get all the messages?
-    //             publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
-
-    //             subscriber.stop(new DisconnectPacketBuilder().build());
-    //             publisher.stop(new DisconnectPacketBuilder().build());
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /**
-    //  * ============================================================
-    //  * Retain Tests
-    //  * ============================================================
-    //  */
-
-    // /* Happy path. No drop in connection, no retry, no reconnect */
-    // @Test
-    // public void Retain_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-    //     String testTopic = "test/retained_topic/MQTT5_Binding_Java_" + testUUID;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder publisherEventsBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured publisherEvents = new LifecycleEvents_Futured();
-    //         publisherEventsBuilder.withLifecycleEvents(publisherEvents);
-
-    //         Mqtt5ClientOptionsBuilder successSubscriberBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured successSubscriberEvents = new LifecycleEvents_Futured();
-    //         PublishEvents_Futured successSubscriberPublishEvents = new PublishEvents_Futured();
-    //         successSubscriberBuilder.withLifecycleEvents(successSubscriberEvents);
-    //         successSubscriberBuilder.withPublishEvents(successSubscriberPublishEvents);
-
-    //         Mqtt5ClientOptionsBuilder unsuccessSubscriberBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured unsuccessfulSubscriberEvents = new LifecycleEvents_Futured();
-    //         PublishEvents_Futured unsuccessfulSubscriberPublishEvents = new PublishEvents_Futured();
-    //         unsuccessSubscriberBuilder.withLifecycleEvents(unsuccessfulSubscriberEvents);
-    //         unsuccessSubscriberBuilder.withPublishEvents(unsuccessfulSubscriberPublishEvents);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             publisherEventsBuilder.withTlsContext(tlsContext);
-    //             successSubscriberBuilder.withTlsContext(tlsContext);
-    //             unsuccessSubscriberBuilder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (
-    //             Mqtt5Client publisher = new Mqtt5Client(publisherEventsBuilder.build());
-    //             Mqtt5Client successSubscriber = new Mqtt5Client(successSubscriberBuilder.build());
-    //             Mqtt5Client unsuccessfulSubscriber = new Mqtt5Client(unsuccessSubscriberBuilder.build());
-    //         ) {
-    //             // Connect and publish a retained message
-    //             publisher.start();
-    //             publisherEvents.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-    //             publishPacketBuilder.withTopic(testTopic)
-    //                 .withPayload("Hello World".getBytes())
-    //                 .withQOS(QOS.AT_LEAST_ONCE)
-    //                 .withRetain(true);
-    //             publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-    //             // Setup for clearing the retained message
-    //             publishPacketBuilder.withPayload(null);
-
-    //             // Connect the successful subscriber
-    //             successSubscriber.start();
-    //             try {
-    //                 successSubscriberEvents.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 // Clear the retained message
-    //                 publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //                 fail("Success subscriber could not connect!");
-    //             }
-
-    //             // Subscribe and verify the retained message
-    //             SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-    //             subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE, false, true, RetainHandlingType.SEND_ON_SUBSCRIBE);
-    //             try {
-    //                 successSubscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 // Clear the retained message
-    //                 publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //                 fail("Success subscriber could not subscribe!");
-    //             }
-    //             try {
-    //                 successSubscriberPublishEvents.publishReceivedFuture.get(360, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 // Clear the retained message
-    //                 publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //                 fail("Success subscriber did not get retained message!");
-    //             }
-
-    //             // Clear the retained message
-    //             publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-    //             // Wait 15 seconds to give the server time to clear everything out
-    //             Thread.sleep(15000);
-
-    //             // Connect the unsuccessful subscriber
-    //             unsuccessfulSubscriber.start();
-    //             unsuccessfulSubscriberEvents.connectedFuture.get(180, TimeUnit.SECONDS);
-    //             unsuccessfulSubscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-    //             // Make sure we do NOT get a publish
-    //             boolean didExceptionOccur = false;
-    //             try {
-    //                 unsuccessfulSubscriberPublishEvents.publishReceivedFuture.get(30, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 didExceptionOccur = true;
-    //             }
-
-    //             if (didExceptionOccur == false) {
-    //                 fail("Unsuccessful subscriber got retained message even though it should be cleared!");
-    //             }
-
-    //             // Disconnect all clients
-    //             DisconnectPacketBuilder disconnectPacketBuilder = new DisconnectPacketBuilder();
-    //             publisher.stop(disconnectPacketBuilder.build());
-    //             publisherEvents.stopFuture.get(180, TimeUnit.SECONDS);
-    //             successSubscriber.stop(disconnectPacketBuilder.build());
-    //             successSubscriberEvents.stopFuture.get(180, TimeUnit.SECONDS);
-    //             unsuccessfulSubscriber.stop(disconnectPacketBuilder.build());
-    //             unsuccessfulSubscriberEvents.stopFuture.get(180, TimeUnit.SECONDS);
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // /**
-    //  * ============================================================
-    //  * Operation Interrupt Tests
-    //  * ============================================================
-    //  */
-
-    // // Subscribe interrupt test
-    // @Test
-    // public void Interrupt_Sub_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-    //             subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-
-    //             try {
-    //                 CompletableFuture<SubAckPacket> subscribeResult = client.subscribe(subscribePacketBuilder.build());
-    //                 client.stop(new DisconnectPacketBuilder().build());
-    //                 SubAckPacket packet = subscribeResult.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 if (ex.getCause().getClass() == CrtRuntimeException.class) {
-    //                     CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-    //                     if (exCrt.errorCode != 5153) {
-    //                         System.out.println("Exception ocurred when stopping subscribe" +
-    //                             "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
-    //                     }
-    //                 }
-    //             }
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // // Unsubscribe interrupt test
-    // @Test
-    // public void Interrupt_Unsub_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
-    //             unsubscribePacketBuilder.withSubscription(testTopic);
-
-    //             try {
-    //                 CompletableFuture<UnsubAckPacket> unsubscribeResult = client.unsubscribe(unsubscribePacketBuilder.build());
-    //                 client.stop(new DisconnectPacketBuilder().build());
-    //                 UnsubAckPacket packet = unsubscribeResult.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 if (ex.getCause().getClass() == CrtRuntimeException.class) {
-    //                     CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-    //                     if (exCrt.errorCode != 5153) {
-    //                         System.out.println("Exception ocurred when stopping unsubscribe" +
-    //                             "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
-    //                     }
-    //                 }
-    //             }
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
-
-    // // Publish interrupt test
-    // @Test
-    // public void Interrupt_Publish_UC1() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
-    //     String testUUID = UUID.randomUUID().toString();
-    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-    //     try {
-    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //         builder.withLifecycleEvents(events);
-
-    //         // Only needed for IoT Core
-    //         TlsContext tlsContext = null;
-    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-    //             Assume.assumeTrue(getMinimumDirectCert() != null);
-    //             Assume.assumeTrue(getMinimumDirectKey() != null);
-    //             tlsContext = getIoTCoreTlsContext();
-    //             builder.withTlsContext(tlsContext);
-    //         }
-
-    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //             client.start();
-    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-    //             PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-    //             publishPacketBuilder.withTopic(testTopic).withQOS(QOS.AT_LEAST_ONCE).withPayload("null".getBytes());
-
-    //             try {
-    //                 CompletableFuture<PublishResult> publishResult = client.publish(publishPacketBuilder.build());
-    //                 client.stop(new DisconnectPacketBuilder().build());
-    //                 PublishResult publishData = publishResult.get(180, TimeUnit.SECONDS);
-    //             } catch (Exception ex) {
-    //                 if (ex.getCause().getClass() == CrtRuntimeException.class) {
-    //                     CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-    //                     if (exCrt.errorCode != 5153) {
-    //                         System.out.println("Exception ocurred when stopping publish" +
-    //                             "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
-    //                     }
-    //                 }
-    //             }
-    //         }
-
-    //         if (tlsContext != null) {
-    //             tlsContext.close();
-    //         }
-
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
+    /* Client connect with invalid host name */
+    @Test
+    public void ConnNegativeID_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean foundExpectedError = false;
+        boolean exceptionOccurred = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("_test", getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+            builder.withMinReconnectDelayMs(1000L);
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+
+                try {
+                    events.connectedFuture.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    exceptionOccurred = true;
+                    if (events.connectFailureCode == 1059) {
+                        foundExpectedError = true;
+                    } else {
+                        System.out.println("EXCEPTION: " + ex);
+                        System.out.println(ex.getMessage() + " \n");
+                    }
+                }
+
+                if (foundExpectedError == false) {
+                    System.out.println("Error code was not AWS_IO_DNS_INVALID_NAME like expected! There was an exception though");
+                }
+                if (exceptionOccurred == false) {
+                    fail("No exception occurred!");
+                }
+            }
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Client connect with invalid, nonexistent port for direct connection */
+    @Test
+    public void ConnNegativeID_UC2() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean foundExpectedError = false;
+        boolean exceptionOccurred = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), 65535L);
+            builder.withLifecycleEvents(events);
+            builder.withMinReconnectDelayMs(1000L);
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+
+                try {
+                    events.connectedFuture.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    exceptionOccurred = true;
+                    if (events.connectFailureCode == 1047) {
+                        foundExpectedError = true;
+                    }
+                }
+
+                if (foundExpectedError == false) {
+                    System.out.println("Error code was not AWS_IO_SOCKET_CONNECTION_REFUSED like expected! There was an exception though");
+                }
+                if (exceptionOccurred == false) {
+                    fail("No exception occurred!");
+                }
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Client connect with invalid protocol port for direct connection */
+    @Test
+    public void ConnNegativeID_UC2_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5DirectMqttHost != null);
+        Assume.assumeTrue(mqtt5WSMqttPort != null);
+        boolean foundExpectedError = false;
+        boolean exceptionOccurred = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5WSMqttPort);
+            builder.withLifecycleEvents(events);
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+
+                try {
+                    events.connectedFuture.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    exceptionOccurred = true;
+                    if (events.connectFailureCode == 5149) {
+                        foundExpectedError = true;
+                    }
+                }
+
+                if (foundExpectedError == false) {
+                    System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
+                }
+                if (exceptionOccurred == false) {
+                    fail("No exception occurred!");
+                }
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Client connect with invalid, nonexistent port for websocket connection */
+    @Test
+    public void ConnNegativeID_UC3() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5WSMqttHost != null);
+        boolean foundExpectedError = false;
+        boolean exceptionOccurred = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, 444L);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
+
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.complete(t.getHttpRequest());
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
+
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+
+                    try {
+                        events.connectedFuture.get(180, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        exceptionOccurred = true;
+                        if (events.connectFailureCode == 1047) {
+                            foundExpectedError = true;
+                        }
+                    }
+
+                    if (foundExpectedError == false) {
+                        System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
+                    }
+                    if (exceptionOccurred == false) {
+                        fail("No exception occurred!");
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Client connect with invalid protocol port for websocket connection */
+    @Test
+    public void ConnNegativeID_UC3_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5WSMqttHost != null);
+        Assume.assumeTrue(mqtt5DirectMqttPort != null);
+        boolean foundExpectedError = false;
+        boolean exceptionOccurred = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
+
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5DirectMqttPort);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
+
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.complete(t.getHttpRequest());
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
+
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+                    try {
+                        events.connectedFuture.get(180, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        exceptionOccurred = true;
+                        if (events.connectFailureCode == 46) {
+                            foundExpectedError = true;
+                        }
+                    }
+
+                    if (foundExpectedError == false) {
+                        System.out.println("Error code was not AWS_ERROR_SYS_CALL_FAILURE (occurs right after AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR for Websockets) like expected! There was an exception though");
+                    }
+                    if (exceptionOccurred == false) {
+                        fail("No exception occurred!");
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Client connect with socket timeout */
+    @Test
+    public void ConnNegativeID_UC4() {
+        skipIfNetworkUnavailable();
+        boolean foundExpectedError = false;
+        boolean exceptionOccurred = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+                SocketOptions options = new SocketOptions();
+            ) {
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("www.example.com", 81L);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
+
+                options.connectTimeoutMs = 100;
+                builder.withSocketOptions(options);
+
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+
+                    try {
+                        events.connectedFuture.get(180, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        exceptionOccurred = true;
+                        if (events.connectFailureCode == 1048) {
+                            foundExpectedError = true;
+                        }
+                    }
+                    if (foundExpectedError == false) {
+                        System.out.println("Error code was not AWS_IO_SOCKET_TIMEOUT like expected! There was an exception though");
+                    }
+                    if (exceptionOccurred == false) {
+                        fail("No exception occurred!");
+                    }
+                }
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Websocket handshake failure test */
+    @Test
+    public void ConnNegativeID_UC6() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5WSMqttHost != null);
+        Assume.assumeTrue(mqtt5WSMqttPort != null);
+        boolean foundExpectedError = false;
+        boolean exceptionOccurred = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
+
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
+
+                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+                    @Override
+                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+                        t.completeExceptionally(new Throwable("Intentional failure!"));
+                    }
+                };
+                builder.withWebsocketHandshakeTransform(websocketTransform);
+                builder.withPort(mqtt5WSMqttPort);
+
+                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                    client.start();
+
+                    try {
+                        events.connectedFuture.get(180, TimeUnit.SECONDS);
+                    } catch (Exception ex) {
+                        exceptionOccurred = true;
+                        if (events.connectFailureCode == 3) {
+                            foundExpectedError = true;
+                        }
+                    }
+                    if (foundExpectedError == false) {
+                        System.out.println("Error code was not AWS_ERROR_UNKNOWN like expected! There was an exception though");
+                    }
+                    if (exceptionOccurred == false) {
+                        fail("No exception occurred!");
+                    }
+
+                    DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                    client.stop(disconnect.build());
+                }
+            }
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* For the double client ID test */
+    static final class LifecycleEvents_DoubleClientID implements Mqtt5ClientOptions.LifecycleEvents {
+        CompletableFuture<Void> connectedFuture = new CompletableFuture<>();
+        CompletableFuture<Void> disconnectedFuture = new CompletableFuture<>();
+        CompletableFuture<Void> stoppedFuture = new CompletableFuture<>();
+
+        @Override
+        public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
+
+        @Override
+        public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
+            connectedFuture.complete(null);
+        }
+
+        @Override
+        public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {
+            connectedFuture.completeExceptionally(new Exception("Could not connect!"));
+        }
+
+        @Override
+        public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {
+            disconnectedFuture.complete(null);
+        }
+
+        @Override
+        public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {
+            stoppedFuture.complete(null);
+        }
+    }
+
+    /* Double Client ID failure test */
+    @Test
+    public void ConnNegativeID_UC7() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+
+        try {
+            LifecycleEvents_DoubleClientID events = new LifecycleEvents_DoubleClientID();
+
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
+            builder.withConnectOptions(connectOptions.build());
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (
+                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+                Mqtt5Client clientTwo = new Mqtt5Client(builder.build());
+            ) {
+                clientOne.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                clientTwo.start();
+                events.connectedFuture = new CompletableFuture<>();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                // Make sure a disconnection happened
+                events.disconnectedFuture.get(180, TimeUnit.SECONDS);
+
+                // Stop the clients from disconnecting each other. If we do not do this, then the clients will
+                // attempt to reconnect endlessly, making a never ending loop.
+                DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
+                clientOne.stop(disconnect);
+                clientTwo.stop(disconnect);
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Double Client ID disconnect and then reconnect test */
+    @Test
+    public void ConnNegativeID_UC7_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+        try {
+            LifecycleEvents_DoubleClientID events = new LifecycleEvents_DoubleClientID();
+            LifecycleEvents_DoubleClientID eventsTwo = new LifecycleEvents_DoubleClientID();
+
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
+            builder.withConnectOptions(connectOptions.build());
+
+            Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builderTwo.withLifecycleEvents(eventsTwo);
+            builderTwo.withConnectOptions(connectOptions.build());
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+                builderTwo.withTlsContext(tlsContext);
+            }
+
+            try (
+                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+                Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
+            ) {
+                clientOne.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                clientTwo.start();
+                eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                // Make sure the first client was disconnected
+                events.disconnectedFuture.get(180, TimeUnit.SECONDS);
+                // Disconnect the second client so the first can reconnect
+                clientTwo.stop(new DisconnectPacketBuilder().build());
+                // Confirm the second client has stopped
+                eventsTwo.stoppedFuture.get(180, TimeUnit.SECONDS);
+
+                // Wait until the first client has reconnected
+                events.connectedFuture = new CompletableFuture<>();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                assertTrue(clientOne.getIsConnected() == true);
+
+                // Stop the clients from disconnecting each other. If we do not do this, then the clients will
+                // attempt to reconnect endlessly, making a never ending loop.
+                DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
+                clientOne.stop(disconnect);
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /**
+     * ============================================================
+     * Negative Data Input Tests
+     * ============================================================
+     */
+
+    /* Negative Connect Packet Properties */
+    @Test
+    public void NewNegative_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean clientCreationFailed = false;
+
+        try {
+            Mqtt5Client client = null;
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+
+            connectOptions.withKeepAliveIntervalSeconds(-100L);
+            builder.withConnectOptions(connectOptions.build());
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail with negative KeepAliveIntervalSeconds");
+            }
+            connectOptions.withKeepAliveIntervalSeconds(100L);
+
+            connectOptions.withSessionExpiryIntervalSeconds(-100L);
+            builder.withConnectOptions(connectOptions.build());
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail with negative SessionExpiryIntervalSeconds");
+            }
+            connectOptions.withSessionExpiryIntervalSeconds(100L);
+
+            connectOptions.withReceiveMaximum(-100L);
+            builder.withConnectOptions(connectOptions.build());
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail negative ReceiveMaximum");
+            }
+            connectOptions.withReceiveMaximum(100L);
+
+            connectOptions.withMaximumPacketSizeBytes(-100L);
+            builder.withConnectOptions(connectOptions.build());
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail with negative MaximumPacketSizeBytes");
+            }
+            connectOptions.withMaximumPacketSizeBytes(100L);
+
+            connectOptions.withWillDelayIntervalSeconds(-100L);
+            builder.withConnectOptions(connectOptions.build());
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail with negative willDelayIntervalSeconds");
+            }
+            connectOptions.withWillDelayIntervalSeconds(100L);
+
+            // Make sure everything is closed
+            if (client != null) {
+                client.close();
+            }
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Overflow Connect Packet Properties */
+    @Test
+    public void NewNegative_UC1_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean clientCreationFailed = false;
+
+        try {
+            Mqtt5Client client = null;
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+
+            connectOptions.withKeepAliveIntervalSeconds(2147483647L);
+            builder.withConnectOptions(connectOptions.build());
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail with overflow KeepAliveIntervalSeconds");
+            }
+            connectOptions.withKeepAliveIntervalSeconds(100L);
+
+            connectOptions.withSessionExpiryIntervalSeconds(9223372036854775807L);
+            builder.withConnectOptions(connectOptions.build());
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail with overflow SessionExpiryIntervalSeconds");
+            }
+            connectOptions.withSessionExpiryIntervalSeconds(100L);
+
+            connectOptions.withReceiveMaximum(2147483647L);
+            builder.withConnectOptions(connectOptions.build());
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail overflow ReceiveMaximum");
+            }
+            connectOptions.withReceiveMaximum(100L);
+
+            connectOptions.withMaximumPacketSizeBytes(9223372036854775807L);
+            builder.withConnectOptions(connectOptions.build());
+            clientCreationFailed = false;
+            try {
+                client = new Mqtt5Client(builder.build());
+            } catch (Exception ex) {
+                clientCreationFailed = true;
+            }
+            if (clientCreationFailed == false) {
+                fail("Client creation did not fail with overflow MaximumPacketSizeBytes");
+            }
+            connectOptions.withMaximumPacketSizeBytes(100L);
+
+            // WillDelayIntervalSeconds is an unsigned 64 bit Long, so it cannot overflow it from Java
+
+            // Make sure everything is closed
+            if (client != null) {
+                client.close();
+            }
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Negative Disconnect Packet Properties */
+    @Test
+    public void NewNegative_UC2() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean clientDisconnectFailed = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
+                disconnectBuilder.withSessionExpiryIntervalSeconds(-100L);
+                try {
+                    client.stop(disconnectBuilder.build());
+                } catch (Exception ex) {
+                    clientDisconnectFailed = true;
+                }
+
+                if (clientDisconnectFailed == false) {
+                    fail("Client disconnect packet creation did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Overflow Disconnect Packet Properties */
+    @Test
+    public void NewNegative_UC2_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean clientDisconnectFailed = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
+                disconnectBuilder.withSessionExpiryIntervalSeconds(9223372036854775807L);
+                try {
+                    client.stop(disconnectBuilder.build());
+                } catch (Exception ex) {
+                    clientDisconnectFailed = true;
+                }
+
+                if (clientDisconnectFailed == false) {
+                    fail("Client disconnect did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Negative Publish Packet Properties */
+    @Test
+    public void NewNegative_UC3() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean clientPublishFailed = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
+                publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
+                publishBuilder.withMessageExpiryIntervalSeconds(-100L);
+                try {
+                    CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
+                    future.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    clientPublishFailed = true;
+                }
+
+                if (clientPublishFailed == false) {
+                    fail("Client publish did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Overflow Publish Packet Properties */
+    @Test
+    public void NewNegative_UC3_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean clientPublishFailed = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
+                publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic").withQOS(QOS.AT_LEAST_ONCE);
+                publishBuilder.withMessageExpiryIntervalSeconds(9223372036854775807L);
+                try {
+                    CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
+                    future.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    clientPublishFailed = true;
+                }
+
+                if (clientPublishFailed == false) {
+                    fail("Client publish did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Negative Subscribe Packet Properties */
+    @Test
+    public void NewNegative_UC4() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean clientSubscribeFailed = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
+                subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
+                subscribeBuilder.withSubscriptionIdentifier(-100L);
+                try {
+                    CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
+                    future.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    clientSubscribeFailed = true;
+                }
+
+                if (clientSubscribeFailed == false) {
+                    fail("Client subscribe did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Overflow Subscribe Packet Properties */
+    @Test
+    public void NewNegative_UC4_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean clientSubscribeFailed = false;
+
+        try {
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
+                subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
+                subscribeBuilder.withSubscriptionIdentifier(9223372036854775807L);
+                try {
+                    CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
+                    future.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    clientSubscribeFailed = true;
+                }
+
+                if (clientSubscribeFailed == false) {
+                    fail("Client subscribe did not fail!");
+                }
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /**
+     * ============================================================
+     * Negotiated Settings Tests
+     * ============================================================
+     */
+
+    /* Happy path, minimal success test */
+    @Test
+    public void Negotiated_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+            ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
+            optionsBuilder.withSessionExpiryIntervalSeconds(600000L);
+            builder.withConnectOptions(optionsBuilder.build());
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                // TODO - add support for this in the future!
+                // assertEquals(
+                //     "Negotiated Settings session expiry interval does not match sent session expiry interval",
+                //     events.connectSuccessSettings.getSessionExpiryInterval(),
+                //     600000L);
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Maximum success test */
+    @Test
+    public void Negotiated_UC2() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
+            optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
+            optionsBuilder.withSessionExpiryIntervalSeconds(0L);
+            optionsBuilder.withKeepAliveIntervalSeconds(360L);
+            builder.withConnectOptions(optionsBuilder.build());
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                assertEquals(
+                    "Negotiated Settings client ID does not match sent client ID",
+                    events.connectSuccessSettings.getAssignedClientID(),
+                    "test/MQTT5_Binding_Java_" + testUUID);
+                assertEquals(
+                    "Negotiated Settings session expiry interval does not match sent session expiry interval",
+                    events.connectSuccessSettings.getSessionExpiryInterval(),
+                    0L);
+                assertEquals(
+                    "Negotiated Settings keep alive result does not match sent keep alive",
+                    events.connectSuccessSettings.getServerKeepAlive(),
+                    360);
+                assertEquals(
+                        "Negotiated Settings rejoined session does not match expected value",
+                        false,
+                        events.connectSuccessSettings.getRejoinedSession());
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Rejoin always session resumption test */
+    @Test
+    public void Negotiated_Rejoin_Always() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
+            optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
+            optionsBuilder.withSessionExpiryIntervalSeconds(3600L);
+            optionsBuilder.withKeepAliveIntervalSeconds(360L);
+            builder.withConnectOptions(optionsBuilder.build());
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                assertEquals(
+                        "Negotiated Settings client ID does not match sent client ID",
+                        events.connectSuccessSettings.getAssignedClientID(),
+                        "test/MQTT5_Binding_Java_" + testUUID);
+                assertEquals(
+                        "Negotiated Settings session expiry interval does not match sent session expiry interval",
+                        events.connectSuccessSettings.getSessionExpiryInterval(),
+                        3600L);
+                assertEquals(
+                        "Negotiated Settings keep alive result does not match sent keep alive",
+                        events.connectSuccessSettings.getServerKeepAlive(),
+                        360);
+                assertEquals(
+                        "Negotiated Settings rejoined session does not match expected value",
+                        false,
+                        events.connectSuccessSettings.getRejoinedSession());
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            builder.withSessionBehavior(ClientSessionBehavior.REJOIN_ALWAYS);
+            LifecycleEvents_Futured rejoinEvents = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(rejoinEvents);
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                rejoinEvents.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                assertEquals(
+                        "Negotiated Settings rejoined session does not match expected value",
+                        true,
+                        rejoinEvents.connectSuccessSettings.getRejoinedSession());
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /**
+     * ============================================================
+     * Operation Tests
+     * ============================================================
+     */
+
+    /* Sub-UnSub happy path */
+    @Test
+    public void Op_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+            builder.withPublishEvents(publishEvents);
+
+            PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+            publishPacketBuilder.withTopic(testTopic);
+            publishPacketBuilder.withPayload("Hello World".getBytes());
+            publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
+
+            SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+            subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+            UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
+            unsubscribePacketBuilder.withSubscription(testTopic);
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                client.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+                client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
+
+                publishEvents.publishReceivedFuture = new CompletableFuture<>();
+                publishEvents.publishPacket = null;
+                client.unsubscribe(unsubscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+                assertEquals(
+                    "Publish after unsubscribe still arrived!",
+                    publishEvents.publishPacket,
+                    null);
+
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Sub-UnSub happy path */
+    @Test
+    public void Op_UC2() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+            PublishPacketBuilder willPacket = new PublishPacketBuilder();
+            willPacket.withTopic(testTopic);
+            willPacket.withQOS(QOS.AT_LEAST_ONCE);
+            willPacket.withPayload("Hello World".getBytes());
+            connectOptions.withWill(willPacket.build());
+            connectOptions.withWillDelayIntervalSeconds(0L);
+            builder.withConnectOptions(connectOptions.build());
+
+            Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
+            builderTwo.withLifecycleEvents(eventsTwo);
+            PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+            builderTwo.withPublishEvents(publishEvents);
+
+            // Only needed for IoT Core
+            TlsContext tlsContextTwo = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContextTwo = getIoTCoreTlsContext();
+                builderTwo.withTlsContext(tlsContextTwo);
+            }
+
+            SubscribePacketBuilder subscribeOptions = new SubscribePacketBuilder();
+            subscribeOptions.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+            try (
+                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+                Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
+            ) {
+                clientOne.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+                clientTwo.start();
+                eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                clientTwo.subscribe(subscribeOptions.build()).get(180, TimeUnit.SECONDS);
+                clientOne.stop(null);
+
+                // Did we get a publish message?
+                publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
+                assertTrue(publishEvents.publishPacket != null);
+
+                clientTwo.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+                tlsContextTwo.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Binary Publish Test */
+    @Test
+    public void Op_UC3() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+            builder.withPublishEvents(publishEvents);
+
+            // Make random binary
+            byte[] randomBytes = new byte[256];
+            Random random = new Random();
+            random.nextBytes(randomBytes);
+
+            PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+            publishPacketBuilder.withTopic(testTopic).withPayload(randomBytes).withQOS(QOS.AT_LEAST_ONCE);
+
+            SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+            subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                client.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+                client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
+
+                assertTrue(java.util.Arrays.equals(publishEvents.publishPacket.getPayload(), randomBytes));
+
+                client.stop(new DisconnectPacketBuilder().build());
+                events.stopFuture.get(180, TimeUnit.SECONDS);
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /**
+     * ============================================================
+     * Error Operation Tests
+     * ============================================================
+     */
+
+    /* Null Publish Test */
+    @Test
+    public void ErrorOp_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean didExceptionOccur = false;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                try {
+                    client.publish(null).get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Null publish packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Publish with empty builder test */
+    @Test
+    public void ErrorOp_UC1_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean didExceptionOccur = false;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                try {
+                    client.publish(new PublishPacketBuilder().build()).get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Empty publish packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Null Subscribe Test */
+    @Test
+    public void ErrorOp_UC2() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean didExceptionOccur = false;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                try {
+                    client.subscribe(null).get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Null subscribe packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Empty Subscribe Test */
+    @Test
+    public void ErrorOp_UC2_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean didExceptionOccur = false;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                try {
+                    client.subscribe(new SubscribePacketBuilder().build()).get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Empty subscribe packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Null Unsubscribe Test */
+    @Test
+    public void ErrorOp_UC3() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean didExceptionOccur = false;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                try {
+                    client.unsubscribe(null).get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Null unsubscribe packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Empty Unsubscribe Test */
+    @Test
+    public void ErrorOp_UC3_ALT() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        boolean didExceptionOccur = false;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                try {
+                    client.unsubscribe(new UnsubscribePacketBuilder().build()).get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Empty unsubscribe packet did not cause exception with error!");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /* Unsupported Connect packet data sent (IoT Core only) */
+    @Test
+    public void ErrorOp_UC4() {
+        skipIfNetworkUnavailable();
+        /* Only works on IoT Core */
+        Assume.assumeTrue(mqtt5IoTCoreMqttHost != null);
+        Assume.assumeTrue(mqtt5IoTCoreMqttPort != null);
+        Assume.assumeTrue(mqtt5IoTCoreMqttCertificateFile != null);
+        Assume.assumeTrue(mqtt5IoTCoreMqttKeyFile != null);
+        Assume.assumeTrue(mqtt5IoTCoreMqttCertificateBytes != null);
+        Assume.assumeTrue(mqtt5IoTCoreMqttKeyBytes != null);
+        boolean didExceptionOccur = false;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5IoTCoreMqttHost, mqtt5IoTCoreMqttPort);
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            TlsContext tlsContext = null;
+            tlsContext = getIoTCoreTlsContext();
+            builder.withTlsContext(tlsContext);
+
+            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+            String clientIDString = "";
+            for (int i = 0; i < 256; i++) {
+                clientIDString += "a";
+            }
+            connectOptions.withClientId(clientIDString);
+            builder.withConnectOptions(connectOptions.build());
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                try {
+                    client.start();
+                    events.connectedFuture.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Was able to connect with Client ID longer than 128 characters (AWS_IOT_CORE_MAXIMUM_CLIENT_ID_LENGTH)");
+                }
+                client.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /**
+     * ============================================================
+     * QoS1 Tests
+     * ============================================================
+     */
+
+    /* Happy path. No drop in connection, no retry, no reconnect */
+    @Test
+    public void QoS1_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        int messageCount = 10;
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
+            builderTwo.withLifecycleEvents(eventsTwo);
+            PublishEvents_Futured_Counted publishEvents = new PublishEvents_Futured_Counted();
+            publishEvents.desiredPublishCount = messageCount;
+            builderTwo.withPublishEvents(publishEvents);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+                builderTwo.withTlsContext(tlsContext);
+            }
+
+            try (
+                Mqtt5Client publisher = new Mqtt5Client(builder.build());
+                Mqtt5Client subscriber = new Mqtt5Client(builderTwo.build());
+            ) {
+                publisher.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+                subscriber.start();
+                eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+                subscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+                publishPacketBuilder.withTopic(testTopic);
+                publishPacketBuilder.withPayload("Hello World".getBytes());
+                publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
+
+                for (int i = 0; i < messageCount; i++) {
+                    publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                }
+
+                // Did we get all the messages?
+                publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
+
+                subscriber.stop(new DisconnectPacketBuilder().build());
+                publisher.stop(new DisconnectPacketBuilder().build());
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /**
+     * ============================================================
+     * Retain Tests
+     * ============================================================
+     */
+
+    /* Happy path. No drop in connection, no retry, no reconnect */
+    @Test
+    public void Retain_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/retained_topic/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder publisherEventsBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured publisherEvents = new LifecycleEvents_Futured();
+            publisherEventsBuilder.withLifecycleEvents(publisherEvents);
+
+            Mqtt5ClientOptionsBuilder successSubscriberBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured successSubscriberEvents = new LifecycleEvents_Futured();
+            PublishEvents_Futured successSubscriberPublishEvents = new PublishEvents_Futured();
+            successSubscriberBuilder.withLifecycleEvents(successSubscriberEvents);
+            successSubscriberBuilder.withPublishEvents(successSubscriberPublishEvents);
+
+            Mqtt5ClientOptionsBuilder unsuccessSubscriberBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured unsuccessfulSubscriberEvents = new LifecycleEvents_Futured();
+            PublishEvents_Futured unsuccessfulSubscriberPublishEvents = new PublishEvents_Futured();
+            unsuccessSubscriberBuilder.withLifecycleEvents(unsuccessfulSubscriberEvents);
+            unsuccessSubscriberBuilder.withPublishEvents(unsuccessfulSubscriberPublishEvents);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                publisherEventsBuilder.withTlsContext(tlsContext);
+                successSubscriberBuilder.withTlsContext(tlsContext);
+                unsuccessSubscriberBuilder.withTlsContext(tlsContext);
+            }
+
+            try (
+                Mqtt5Client publisher = new Mqtt5Client(publisherEventsBuilder.build());
+                Mqtt5Client successSubscriber = new Mqtt5Client(successSubscriberBuilder.build());
+                Mqtt5Client unsuccessfulSubscriber = new Mqtt5Client(unsuccessSubscriberBuilder.build());
+            ) {
+                // Connect and publish a retained message
+                publisher.start();
+                publisherEvents.connectedFuture.get(180, TimeUnit.SECONDS);
+                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+                publishPacketBuilder.withTopic(testTopic)
+                    .withPayload("Hello World".getBytes())
+                    .withQOS(QOS.AT_LEAST_ONCE)
+                    .withRetain(true);
+                publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+                // Setup for clearing the retained message
+                publishPacketBuilder.withPayload(null);
+
+                // Connect the successful subscriber
+                successSubscriber.start();
+                try {
+                    successSubscriberEvents.connectedFuture.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    // Clear the retained message
+                    publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                    fail("Success subscriber could not connect!");
+                }
+
+                // Subscribe and verify the retained message
+                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE, false, true, RetainHandlingType.SEND_ON_SUBSCRIBE);
+                try {
+                    successSubscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    // Clear the retained message
+                    publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                    fail("Success subscriber could not subscribe!");
+                }
+                try {
+                    successSubscriberPublishEvents.publishReceivedFuture.get(360, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    // Clear the retained message
+                    publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                    fail("Success subscriber did not get retained message!");
+                }
+
+                // Clear the retained message
+                publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+                // Wait 15 seconds to give the server time to clear everything out
+                Thread.sleep(15000);
+
+                // Connect the unsuccessful subscriber
+                unsuccessfulSubscriber.start();
+                unsuccessfulSubscriberEvents.connectedFuture.get(180, TimeUnit.SECONDS);
+                unsuccessfulSubscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+                // Make sure we do NOT get a publish
+                boolean didExceptionOccur = false;
+                try {
+                    unsuccessfulSubscriberPublishEvents.publishReceivedFuture.get(30, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    didExceptionOccur = true;
+                }
+
+                if (didExceptionOccur == false) {
+                    fail("Unsuccessful subscriber got retained message even though it should be cleared!");
+                }
+
+                // Disconnect all clients
+                DisconnectPacketBuilder disconnectPacketBuilder = new DisconnectPacketBuilder();
+                publisher.stop(disconnectPacketBuilder.build());
+                publisherEvents.stopFuture.get(180, TimeUnit.SECONDS);
+                successSubscriber.stop(disconnectPacketBuilder.build());
+                successSubscriberEvents.stopFuture.get(180, TimeUnit.SECONDS);
+                unsuccessfulSubscriber.stop(disconnectPacketBuilder.build());
+                unsuccessfulSubscriberEvents.stopFuture.get(180, TimeUnit.SECONDS);
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    /**
+     * ============================================================
+     * Operation Interrupt Tests
+     * ============================================================
+     */
+
+    // Subscribe interrupt test
+    @Test
+    public void Interrupt_Sub_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+                try {
+                    CompletableFuture<SubAckPacket> subscribeResult = client.subscribe(subscribePacketBuilder.build());
+                    client.stop(new DisconnectPacketBuilder().build());
+                    SubAckPacket packet = subscribeResult.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                        if (exCrt.errorCode != 5153) {
+                            System.out.println("Exception ocurred when stopping subscribe" +
+                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                        }
+                    }
+                }
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    // Unsubscribe interrupt test
+    @Test
+    public void Interrupt_Unsub_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
+                unsubscribePacketBuilder.withSubscription(testTopic);
+
+                try {
+                    CompletableFuture<UnsubAckPacket> unsubscribeResult = client.unsubscribe(unsubscribePacketBuilder.build());
+                    client.stop(new DisconnectPacketBuilder().build());
+                    UnsubAckPacket packet = unsubscribeResult.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                        if (exCrt.errorCode != 5153) {
+                            System.out.println("Exception ocurred when stopping unsubscribe" +
+                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                        }
+                    }
+                }
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    // Publish interrupt test
+    @Test
+    public void Interrupt_Publish_UC1() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(checkMinimumDirectHostAndPort());
+        String testUUID = UUID.randomUUID().toString();
+        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+        try {
+            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+            builder.withLifecycleEvents(events);
+
+            // Only needed for IoT Core
+            TlsContext tlsContext = null;
+            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+                Assume.assumeTrue(getMinimumDirectCert() != null);
+                Assume.assumeTrue(getMinimumDirectKey() != null);
+                tlsContext = getIoTCoreTlsContext();
+                builder.withTlsContext(tlsContext);
+            }
+
+            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                client.start();
+                events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+                publishPacketBuilder.withTopic(testTopic).withQOS(QOS.AT_LEAST_ONCE).withPayload("null".getBytes());
+
+                try {
+                    CompletableFuture<PublishResult> publishResult = client.publish(publishPacketBuilder.build());
+                    client.stop(new DisconnectPacketBuilder().build());
+                    PublishResult publishData = publishResult.get(180, TimeUnit.SECONDS);
+                } catch (Exception ex) {
+                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
+                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+                        if (exCrt.errorCode != 5153) {
+                            System.out.println("Exception ocurred when stopping publish" +
+                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+                        }
+                    }
+                }
+            }
+
+            if (tlsContext != null) {
+                tlsContext.close();
+            }
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -621,52 +621,53 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     }
 
     /* Direct connection with HttpProxyOptions */
-    @Test
-    public void ConnDC_UC5() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(mqtt5DirectMqttTlsHost != null);
-        Assume.assumeTrue(mqtt5DirectMqttTlsPort != null);
-        Assume.assumeTrue(mqtt5ProxyHost != null);
-        Assume.assumeTrue(mqtt5ProxyPort != null);
+    // Disable for now! Is currently not working with Squid on Codebuild.
+    // @Test
+    // public void ConnDC_UC5() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(mqtt5DirectMqttTlsHost != null);
+    //     Assume.assumeTrue(mqtt5DirectMqttTlsPort != null);
+    //     Assume.assumeTrue(mqtt5ProxyHost != null);
+    //     Assume.assumeTrue(mqtt5ProxyPort != null);
 
-        try {
+    //     try {
 
-            try (
-                EventLoopGroup elg = new EventLoopGroup(1);
-                HostResolver hr = new HostResolver(elg);
-                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            ) {
-                LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
-                builder.withLifecycleEvents(events);
-                builder.withBootstrap(bootstrap);
+    //         try (
+    //             EventLoopGroup elg = new EventLoopGroup(1);
+    //             HostResolver hr = new HostResolver(elg);
+    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+    //         ) {
+    //             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
+    //             builder.withLifecycleEvents(events);
+    //             builder.withBootstrap(bootstrap);
 
-                HttpProxyOptions proxyOptions = new HttpProxyOptions();
-                proxyOptions.setHost(mqtt5ProxyHost);
-                proxyOptions.setPort((mqtt5ProxyPort.intValue()));
-                proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
+    //             HttpProxyOptions proxyOptions = new HttpProxyOptions();
+    //             proxyOptions.setHost(mqtt5ProxyHost);
+    //             proxyOptions.setPort((mqtt5ProxyPort.intValue()));
+    //             proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
 
-                try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
-                    tlsOptions.withVerifyPeer(false);
-                    try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
-                        builder.withTlsContext(tlsContext);
+    //             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
+    //                 tlsOptions.withVerifyPeer(false);
+    //                 try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
+    //                     builder.withTlsContext(tlsContext);
 
-                        builder.withHttpProxyOptions(proxyOptions);
+    //                     builder.withHttpProxyOptions(proxyOptions);
 
-                        try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                            client.start();
-                            events.connectedFuture.get(180, TimeUnit.SECONDS);
-                            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-                            client.stop(disconnect.build());
-                        }
-                    }
-                }
-            }
+    //                     try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //                         client.start();
+    //                         events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //                         DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+    //                         client.stop(disconnect.build());
+    //                     }
+    //                 }
+    //             }
+    //         }
 
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
 
     /* Maximum options set connection test */
     @Test

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import software.amazon.awssdk.crt.*;
+import software.amazon.awssdk.crt.Log.LogLevel;
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
 import software.amazon.awssdk.crt.http.HttpProxyOptions.HttpProxyConnectionType;
 import software.amazon.awssdk.crt.io.ClientBootstrap;
@@ -638,6 +639,9 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5ProxyPort != null);
         Assume.assumeTrue(mqtt5ProxyMqttHost != null);
         Assume.assumeTrue(mqtt5ProxyMqttPort != null);
+
+        // Enable logging (hopefully it will help show what is wrong)
+        Log.initLoggingToStdout(LogLevel.Trace);
 
         try {
             try (

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -638,6 +638,8 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5ProxyPort != null);
         Assume.assumeTrue(mqtt5ProxyPerformTest != null);
 
+        System.out.println("PROXY TEST IS GOING TO RUN!!!");
+
         try {
 
             try (

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -665,7 +665,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 builder.withTlsContext(tlsContext);
 
                 // Set the TLS in the proxy
-                proxyOptions.setTlsContext(getIoTCoreTlsContext());
+                // proxyOptions.setTlsContext(getIoTCoreTlsContext());
                 builder.withHttpProxyOptions(proxyOptions);
 
                 try (Mqtt5Client client = new Mqtt5Client(builder.build())) {

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -640,7 +640,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5ProxyMqttPort != null);
 
         try {
-
             try (
                 EventLoopGroup elg = new EventLoopGroup(1);
                 HostResolver hr = new HostResolver(elg);
@@ -675,7 +674,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                     tlsContext.close();
                 }
             }
-
         } catch (Exception ex) {
             fail(ex.getMessage());
         }

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -621,52 +621,52 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     }
 
     /* Direct connection with HttpProxyOptions */
-    @Test
-    public void ConnDC_UC5() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(mqtt5DirectMqttTlsHost != null);
-        Assume.assumeTrue(mqtt5DirectMqttTlsPort != null);
-        Assume.assumeTrue(mqtt5ProxyHost != null);
-        Assume.assumeTrue(mqtt5ProxyPort != null);
+    // @Test
+    // public void ConnDC_UC5() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(mqtt5DirectMqttTlsHost != null);
+    //     Assume.assumeTrue(mqtt5DirectMqttTlsPort != null);
+    //     Assume.assumeTrue(mqtt5ProxyHost != null);
+    //     Assume.assumeTrue(mqtt5ProxyPort != null);
 
-        try {
+    //     try {
 
-            try (
-                EventLoopGroup elg = new EventLoopGroup(1);
-                HostResolver hr = new HostResolver(elg);
-                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            ) {
-                LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
-                builder.withLifecycleEvents(events);
-                builder.withBootstrap(bootstrap);
+    //         try (
+    //             EventLoopGroup elg = new EventLoopGroup(1);
+    //             HostResolver hr = new HostResolver(elg);
+    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+    //         ) {
+    //             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
+    //             builder.withLifecycleEvents(events);
+    //             builder.withBootstrap(bootstrap);
 
-                HttpProxyOptions proxyOptions = new HttpProxyOptions();
-                proxyOptions.setHost(mqtt5ProxyHost);
-                proxyOptions.setPort((mqtt5ProxyPort.intValue()));
-                proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
+    //             HttpProxyOptions proxyOptions = new HttpProxyOptions();
+    //             proxyOptions.setHost(mqtt5ProxyHost);
+    //             proxyOptions.setPort((mqtt5ProxyPort.intValue()));
+    //             proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
 
-                try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
-                    tlsOptions.withVerifyPeer(false);
-                    try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
-                        builder.withTlsContext(tlsContext);
+    //             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
+    //                 tlsOptions.withVerifyPeer(false);
+    //                 try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
+    //                     builder.withTlsContext(tlsContext);
 
-                        builder.withHttpProxyOptions(proxyOptions);
+    //                     builder.withHttpProxyOptions(proxyOptions);
 
-                        try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                            client.start();
-                            events.connectedFuture.get(180, TimeUnit.SECONDS);
-                            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-                            client.stop(disconnect.build());
-                        }
-                    }
-                }
-            }
+    //                     try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //                         client.start();
+    //                         events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //                         DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+    //                         client.stop(disconnect.build());
+    //                     }
+    //                 }
+    //             }
+    //         }
 
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
 
     /* Maximum options set connection test */
     @Test
@@ -1035,2086 +1035,2086 @@ public class Mqtt5ClientTest extends CrtTestFixture {
      * ============================================================
      */
 
-    /* Client connect with invalid host name */
-    @Test
-    public void ConnNegativeID_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean foundExpectedError = false;
-        boolean exceptionOccurred = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("_test", getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-            builder.withMinReconnectDelayMs(1000L);
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-
-                try {
-                    events.connectedFuture.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    exceptionOccurred = true;
-                    if (events.connectFailureCode == 1059) {
-                        foundExpectedError = true;
-                    } else {
-                        System.out.println("EXCEPTION: " + ex);
-                        System.out.println(ex.getMessage() + " \n");
-                    }
-                }
-
-                if (foundExpectedError == false) {
-                    System.out.println("Error code was not AWS_IO_DNS_INVALID_NAME like expected! There was an exception though");
-                }
-                if (exceptionOccurred == false) {
-                    fail("No exception occurred!");
-                }
-            }
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Client connect with invalid, nonexistent port for direct connection */
-    @Test
-    public void ConnNegativeID_UC2() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean foundExpectedError = false;
-        boolean exceptionOccurred = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), 65535L);
-            builder.withLifecycleEvents(events);
-            builder.withMinReconnectDelayMs(1000L);
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-
-                try {
-                    events.connectedFuture.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    exceptionOccurred = true;
-                    if (events.connectFailureCode == 1047) {
-                        foundExpectedError = true;
-                    }
-                }
-
-                if (foundExpectedError == false) {
-                    System.out.println("Error code was not AWS_IO_SOCKET_CONNECTION_REFUSED like expected! There was an exception though");
-                }
-                if (exceptionOccurred == false) {
-                    fail("No exception occurred!");
-                }
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Client connect with invalid protocol port for direct connection */
-    @Test
-    public void ConnNegativeID_UC2_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(mqtt5DirectMqttHost != null);
-        Assume.assumeTrue(mqtt5WSMqttPort != null);
-        boolean foundExpectedError = false;
-        boolean exceptionOccurred = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5WSMqttPort);
-            builder.withLifecycleEvents(events);
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-
-                try {
-                    events.connectedFuture.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    exceptionOccurred = true;
-                    if (events.connectFailureCode == 5149) {
-                        foundExpectedError = true;
-                    }
-                }
-
-                if (foundExpectedError == false) {
-                    System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
-                }
-                if (exceptionOccurred == false) {
-                    fail("No exception occurred!");
-                }
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Client connect with invalid, nonexistent port for websocket connection */
-    @Test
-    public void ConnNegativeID_UC3() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(mqtt5WSMqttHost != null);
-        boolean foundExpectedError = false;
-        boolean exceptionOccurred = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-            try (
-                EventLoopGroup elg = new EventLoopGroup(1);
-                HostResolver hr = new HostResolver(elg);
-                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            ) {
-                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, 444L);
-                builder.withLifecycleEvents(events);
-                builder.withBootstrap(bootstrap);
-
-                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                    @Override
-                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                        t.complete(t.getHttpRequest());
-                    }
-                };
-                builder.withWebsocketHandshakeTransform(websocketTransform);
-
-                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                    client.start();
-
-                    try {
-                        events.connectedFuture.get(180, TimeUnit.SECONDS);
-                    } catch (Exception ex) {
-                        exceptionOccurred = true;
-                        if (events.connectFailureCode == 1047) {
-                            foundExpectedError = true;
-                        }
-                    }
-
-                    if (foundExpectedError == false) {
-                        System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
-                    }
-                    if (exceptionOccurred == false) {
-                        fail("No exception occurred!");
-                    }
-                }
-            }
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Client connect with invalid protocol port for websocket connection */
-    @Test
-    public void ConnNegativeID_UC3_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(mqtt5WSMqttHost != null);
-        Assume.assumeTrue(mqtt5DirectMqttPort != null);
-        boolean foundExpectedError = false;
-        boolean exceptionOccurred = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-            try (
-                EventLoopGroup elg = new EventLoopGroup(1);
-                HostResolver hr = new HostResolver(elg);
-                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            ) {
-
-                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5DirectMqttPort);
-                builder.withLifecycleEvents(events);
-                builder.withBootstrap(bootstrap);
-
-                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                    @Override
-                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                        t.complete(t.getHttpRequest());
-                    }
-                };
-                builder.withWebsocketHandshakeTransform(websocketTransform);
-
-                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                    client.start();
-                    try {
-                        events.connectedFuture.get(180, TimeUnit.SECONDS);
-                    } catch (Exception ex) {
-                        exceptionOccurred = true;
-                        if (events.connectFailureCode == 46) {
-                            foundExpectedError = true;
-                        }
-                    }
-
-                    if (foundExpectedError == false) {
-                        System.out.println("Error code was not AWS_ERROR_SYS_CALL_FAILURE (occurs right after AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR for Websockets) like expected! There was an exception though");
-                    }
-                    if (exceptionOccurred == false) {
-                        fail("No exception occurred!");
-                    }
-                }
-            }
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Client connect with socket timeout */
-    @Test
-    public void ConnNegativeID_UC4() {
-        skipIfNetworkUnavailable();
-        boolean foundExpectedError = false;
-        boolean exceptionOccurred = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-            try (
-                EventLoopGroup elg = new EventLoopGroup(1);
-                HostResolver hr = new HostResolver(elg);
-                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-                SocketOptions options = new SocketOptions();
-            ) {
-                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("www.example.com", 81L);
-                builder.withLifecycleEvents(events);
-                builder.withBootstrap(bootstrap);
-
-                options.connectTimeoutMs = 100;
-                builder.withSocketOptions(options);
-
-                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                    client.start();
-
-                    try {
-                        events.connectedFuture.get(180, TimeUnit.SECONDS);
-                    } catch (Exception ex) {
-                        exceptionOccurred = true;
-                        if (events.connectFailureCode == 1048) {
-                            foundExpectedError = true;
-                        }
-                    }
-                    if (foundExpectedError == false) {
-                        System.out.println("Error code was not AWS_IO_SOCKET_TIMEOUT like expected! There was an exception though");
-                    }
-                    if (exceptionOccurred == false) {
-                        fail("No exception occurred!");
-                    }
-                }
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Websocket handshake failure test */
-    @Test
-    public void ConnNegativeID_UC6() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(mqtt5WSMqttHost != null);
-        Assume.assumeTrue(mqtt5WSMqttPort != null);
-        boolean foundExpectedError = false;
-        boolean exceptionOccurred = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-
-            try (
-                EventLoopGroup elg = new EventLoopGroup(1);
-                HostResolver hr = new HostResolver(elg);
-                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            ) {
-
-                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
-                builder.withLifecycleEvents(events);
-                builder.withBootstrap(bootstrap);
-
-                Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
-                    @Override
-                    public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
-                        t.completeExceptionally(new Throwable("Intentional failure!"));
-                    }
-                };
-                builder.withWebsocketHandshakeTransform(websocketTransform);
-                builder.withPort(mqtt5WSMqttPort);
-
-                try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                    client.start();
-
-                    try {
-                        events.connectedFuture.get(180, TimeUnit.SECONDS);
-                    } catch (Exception ex) {
-                        exceptionOccurred = true;
-                        if (events.connectFailureCode == 3) {
-                            foundExpectedError = true;
-                        }
-                    }
-                    if (foundExpectedError == false) {
-                        System.out.println("Error code was not AWS_ERROR_UNKNOWN like expected! There was an exception though");
-                    }
-                    if (exceptionOccurred == false) {
-                        fail("No exception occurred!");
-                    }
-
-                    DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-                    client.stop(disconnect.build());
-                }
-            }
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* For the double client ID test */
-    static final class LifecycleEvents_DoubleClientID implements Mqtt5ClientOptions.LifecycleEvents {
-        CompletableFuture<Void> connectedFuture = new CompletableFuture<>();
-        CompletableFuture<Void> disconnectedFuture = new CompletableFuture<>();
-        CompletableFuture<Void> stoppedFuture = new CompletableFuture<>();
-
-        @Override
-        public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
-
-        @Override
-        public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
-            connectedFuture.complete(null);
-        }
-
-        @Override
-        public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {
-            connectedFuture.completeExceptionally(new Exception("Could not connect!"));
-        }
-
-        @Override
-        public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {
-            disconnectedFuture.complete(null);
-        }
-
-        @Override
-        public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {
-            stoppedFuture.complete(null);
-        }
-    }
-
-    /* Double Client ID failure test */
-    @Test
-    public void ConnNegativeID_UC7() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-
-        try {
-            LifecycleEvents_DoubleClientID events = new LifecycleEvents_DoubleClientID();
-
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
-            builder.withConnectOptions(connectOptions.build());
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (
-                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
-                Mqtt5Client clientTwo = new Mqtt5Client(builder.build());
-            ) {
-                clientOne.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                clientTwo.start();
-                events.connectedFuture = new CompletableFuture<>();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                // Make sure a disconnection happened
-                events.disconnectedFuture.get(180, TimeUnit.SECONDS);
-
-                // Stop the clients from disconnecting each other. If we do not do this, then the clients will
-                // attempt to reconnect endlessly, making a never ending loop.
-                DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
-                clientOne.stop(disconnect);
-                clientTwo.stop(disconnect);
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Double Client ID disconnect and then reconnect test */
-    @Test
-    public void ConnNegativeID_UC7_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-        try {
-            LifecycleEvents_DoubleClientID events = new LifecycleEvents_DoubleClientID();
-            LifecycleEvents_DoubleClientID eventsTwo = new LifecycleEvents_DoubleClientID();
-
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
-            builder.withConnectOptions(connectOptions.build());
-
-            Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builderTwo.withLifecycleEvents(eventsTwo);
-            builderTwo.withConnectOptions(connectOptions.build());
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-                builderTwo.withTlsContext(tlsContext);
-            }
-
-            try (
-                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
-                Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
-            ) {
-                clientOne.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                clientTwo.start();
-                eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                // Make sure the first client was disconnected
-                events.disconnectedFuture.get(180, TimeUnit.SECONDS);
-                // Disconnect the second client so the first can reconnect
-                clientTwo.stop(new DisconnectPacketBuilder().build());
-                // Confirm the second client has stopped
-                eventsTwo.stoppedFuture.get(180, TimeUnit.SECONDS);
-
-                // Wait until the first client has reconnected
-                events.connectedFuture = new CompletableFuture<>();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                assertTrue(clientOne.getIsConnected() == true);
-
-                // Stop the clients from disconnecting each other. If we do not do this, then the clients will
-                // attempt to reconnect endlessly, making a never ending loop.
-                DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
-                clientOne.stop(disconnect);
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /**
-     * ============================================================
-     * Negative Data Input Tests
-     * ============================================================
-     */
-
-    /* Negative Connect Packet Properties */
-    @Test
-    public void NewNegative_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean clientCreationFailed = false;
-
-        try {
-            Mqtt5Client client = null;
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-
-            connectOptions.withKeepAliveIntervalSeconds(-100L);
-            builder.withConnectOptions(connectOptions.build());
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail with negative KeepAliveIntervalSeconds");
-            }
-            connectOptions.withKeepAliveIntervalSeconds(100L);
-
-            connectOptions.withSessionExpiryIntervalSeconds(-100L);
-            builder.withConnectOptions(connectOptions.build());
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail with negative SessionExpiryIntervalSeconds");
-            }
-            connectOptions.withSessionExpiryIntervalSeconds(100L);
-
-            connectOptions.withReceiveMaximum(-100L);
-            builder.withConnectOptions(connectOptions.build());
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail negative ReceiveMaximum");
-            }
-            connectOptions.withReceiveMaximum(100L);
-
-            connectOptions.withMaximumPacketSizeBytes(-100L);
-            builder.withConnectOptions(connectOptions.build());
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail with negative MaximumPacketSizeBytes");
-            }
-            connectOptions.withMaximumPacketSizeBytes(100L);
-
-            connectOptions.withWillDelayIntervalSeconds(-100L);
-            builder.withConnectOptions(connectOptions.build());
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail with negative willDelayIntervalSeconds");
-            }
-            connectOptions.withWillDelayIntervalSeconds(100L);
-
-            // Make sure everything is closed
-            if (client != null) {
-                client.close();
-            }
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Overflow Connect Packet Properties */
-    @Test
-    public void NewNegative_UC1_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean clientCreationFailed = false;
-
-        try {
-            Mqtt5Client client = null;
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-
-            connectOptions.withKeepAliveIntervalSeconds(2147483647L);
-            builder.withConnectOptions(connectOptions.build());
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail with overflow KeepAliveIntervalSeconds");
-            }
-            connectOptions.withKeepAliveIntervalSeconds(100L);
-
-            connectOptions.withSessionExpiryIntervalSeconds(9223372036854775807L);
-            builder.withConnectOptions(connectOptions.build());
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail with overflow SessionExpiryIntervalSeconds");
-            }
-            connectOptions.withSessionExpiryIntervalSeconds(100L);
-
-            connectOptions.withReceiveMaximum(2147483647L);
-            builder.withConnectOptions(connectOptions.build());
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail overflow ReceiveMaximum");
-            }
-            connectOptions.withReceiveMaximum(100L);
-
-            connectOptions.withMaximumPacketSizeBytes(9223372036854775807L);
-            builder.withConnectOptions(connectOptions.build());
-            clientCreationFailed = false;
-            try {
-                client = new Mqtt5Client(builder.build());
-            } catch (Exception ex) {
-                clientCreationFailed = true;
-            }
-            if (clientCreationFailed == false) {
-                fail("Client creation did not fail with overflow MaximumPacketSizeBytes");
-            }
-            connectOptions.withMaximumPacketSizeBytes(100L);
-
-            // WillDelayIntervalSeconds is an unsigned 64 bit Long, so it cannot overflow it from Java
-
-            // Make sure everything is closed
-            if (client != null) {
-                client.close();
-            }
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Negative Disconnect Packet Properties */
-    @Test
-    public void NewNegative_UC2() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean clientDisconnectFailed = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
-                disconnectBuilder.withSessionExpiryIntervalSeconds(-100L);
-                try {
-                    client.stop(disconnectBuilder.build());
-                } catch (Exception ex) {
-                    clientDisconnectFailed = true;
-                }
-
-                if (clientDisconnectFailed == false) {
-                    fail("Client disconnect packet creation did not fail!");
-                }
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Overflow Disconnect Packet Properties */
-    @Test
-    public void NewNegative_UC2_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean clientDisconnectFailed = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
-                disconnectBuilder.withSessionExpiryIntervalSeconds(9223372036854775807L);
-                try {
-                    client.stop(disconnectBuilder.build());
-                } catch (Exception ex) {
-                    clientDisconnectFailed = true;
-                }
-
-                if (clientDisconnectFailed == false) {
-                    fail("Client disconnect did not fail!");
-                }
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Negative Publish Packet Properties */
-    @Test
-    public void NewNegative_UC3() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean clientPublishFailed = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
-                publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
-                publishBuilder.withMessageExpiryIntervalSeconds(-100L);
-                try {
-                    CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
-                    future.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    clientPublishFailed = true;
-                }
-
-                if (clientPublishFailed == false) {
-                    fail("Client publish did not fail!");
-                }
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Overflow Publish Packet Properties */
-    @Test
-    public void NewNegative_UC3_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean clientPublishFailed = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
-                publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic").withQOS(QOS.AT_LEAST_ONCE);
-                publishBuilder.withMessageExpiryIntervalSeconds(9223372036854775807L);
-                try {
-                    CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
-                    future.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    clientPublishFailed = true;
-                }
-
-                if (clientPublishFailed == false) {
-                    fail("Client publish did not fail!");
-                }
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Negative Subscribe Packet Properties */
-    @Test
-    public void NewNegative_UC4() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean clientSubscribeFailed = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
-                subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
-                subscribeBuilder.withSubscriptionIdentifier(-100L);
-                try {
-                    CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
-                    future.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    clientSubscribeFailed = true;
-                }
-
-                if (clientSubscribeFailed == false) {
-                    fail("Client subscribe did not fail!");
-                }
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Overflow Subscribe Packet Properties */
-    @Test
-    public void NewNegative_UC4_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean clientSubscribeFailed = false;
-
-        try {
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
-                subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
-                subscribeBuilder.withSubscriptionIdentifier(9223372036854775807L);
-                try {
-                    CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
-                    future.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    clientSubscribeFailed = true;
-                }
-
-                if (clientSubscribeFailed == false) {
-                    fail("Client subscribe did not fail!");
-                }
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /**
-     * ============================================================
-     * Negotiated Settings Tests
-     * ============================================================
-     */
-
-    /* Happy path, minimal success test */
-    @Test
-    public void Negotiated_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-            ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
-            optionsBuilder.withSessionExpiryIntervalSeconds(600000L);
-            builder.withConnectOptions(optionsBuilder.build());
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                // TODO - add support for this in the future!
-                // assertEquals(
-                //     "Negotiated Settings session expiry interval does not match sent session expiry interval",
-                //     events.connectSuccessSettings.getSessionExpiryInterval(),
-                //     600000L);
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Maximum success test */
-    @Test
-    public void Negotiated_UC2() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
-            optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
-            optionsBuilder.withSessionExpiryIntervalSeconds(0L);
-            optionsBuilder.withKeepAliveIntervalSeconds(360L);
-            builder.withConnectOptions(optionsBuilder.build());
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                assertEquals(
-                    "Negotiated Settings client ID does not match sent client ID",
-                    events.connectSuccessSettings.getAssignedClientID(),
-                    "test/MQTT5_Binding_Java_" + testUUID);
-                assertEquals(
-                    "Negotiated Settings session expiry interval does not match sent session expiry interval",
-                    events.connectSuccessSettings.getSessionExpiryInterval(),
-                    0L);
-                assertEquals(
-                    "Negotiated Settings keep alive result does not match sent keep alive",
-                    events.connectSuccessSettings.getServerKeepAlive(),
-                    360);
-                assertEquals(
-                        "Negotiated Settings rejoined session does not match expected value",
-                        false,
-                        events.connectSuccessSettings.getRejoinedSession());
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Rejoin always session resumption test */
-    @Test
-    public void Negotiated_Rejoin_Always() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
-            optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
-            optionsBuilder.withSessionExpiryIntervalSeconds(3600L);
-            optionsBuilder.withKeepAliveIntervalSeconds(360L);
-            builder.withConnectOptions(optionsBuilder.build());
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                assertEquals(
-                        "Negotiated Settings client ID does not match sent client ID",
-                        events.connectSuccessSettings.getAssignedClientID(),
-                        "test/MQTT5_Binding_Java_" + testUUID);
-                assertEquals(
-                        "Negotiated Settings session expiry interval does not match sent session expiry interval",
-                        events.connectSuccessSettings.getSessionExpiryInterval(),
-                        3600L);
-                assertEquals(
-                        "Negotiated Settings keep alive result does not match sent keep alive",
-                        events.connectSuccessSettings.getServerKeepAlive(),
-                        360);
-                assertEquals(
-                        "Negotiated Settings rejoined session does not match expected value",
-                        false,
-                        events.connectSuccessSettings.getRejoinedSession());
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            builder.withSessionBehavior(ClientSessionBehavior.REJOIN_ALWAYS);
-            LifecycleEvents_Futured rejoinEvents = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(rejoinEvents);
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                rejoinEvents.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                assertEquals(
-                        "Negotiated Settings rejoined session does not match expected value",
-                        true,
-                        rejoinEvents.connectSuccessSettings.getRejoinedSession());
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /**
-     * ============================================================
-     * Operation Tests
-     * ============================================================
-     */
-
-    /* Sub-UnSub happy path */
-    @Test
-    public void Op_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            PublishEvents_Futured publishEvents = new PublishEvents_Futured();
-            builder.withPublishEvents(publishEvents);
-
-            PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-            publishPacketBuilder.withTopic(testTopic);
-            publishPacketBuilder.withPayload("Hello World".getBytes());
-            publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
-
-            SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-            subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-
-            UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
-            unsubscribePacketBuilder.withSubscription(testTopic);
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                client.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-                client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
-
-                publishEvents.publishReceivedFuture = new CompletableFuture<>();
-                publishEvents.publishPacket = null;
-                client.unsubscribe(unsubscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-                assertEquals(
-                    "Publish after unsubscribe still arrived!",
-                    publishEvents.publishPacket,
-                    null);
-
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Sub-UnSub happy path */
-    @Test
-    public void Op_UC2() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-            PublishPacketBuilder willPacket = new PublishPacketBuilder();
-            willPacket.withTopic(testTopic);
-            willPacket.withQOS(QOS.AT_LEAST_ONCE);
-            willPacket.withPayload("Hello World".getBytes());
-            connectOptions.withWill(willPacket.build());
-            connectOptions.withWillDelayIntervalSeconds(0L);
-            builder.withConnectOptions(connectOptions.build());
-
-            Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
-            builderTwo.withLifecycleEvents(eventsTwo);
-            PublishEvents_Futured publishEvents = new PublishEvents_Futured();
-            builderTwo.withPublishEvents(publishEvents);
-
-            // Only needed for IoT Core
-            TlsContext tlsContextTwo = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContextTwo = getIoTCoreTlsContext();
-                builderTwo.withTlsContext(tlsContextTwo);
-            }
-
-            SubscribePacketBuilder subscribeOptions = new SubscribePacketBuilder();
-            subscribeOptions.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-
-            try (
-                Mqtt5Client clientOne = new Mqtt5Client(builder.build());
-                Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
-            ) {
-                clientOne.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-                clientTwo.start();
-                eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                clientTwo.subscribe(subscribeOptions.build()).get(180, TimeUnit.SECONDS);
-                clientOne.stop(null);
-
-                // Did we get a publish message?
-                publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
-                assertTrue(publishEvents.publishPacket != null);
-
-                clientTwo.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-                tlsContextTwo.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Binary Publish Test */
-    @Test
-    public void Op_UC3() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            PublishEvents_Futured publishEvents = new PublishEvents_Futured();
-            builder.withPublishEvents(publishEvents);
-
-            // Make random binary
-            byte[] randomBytes = new byte[256];
-            Random random = new Random();
-            random.nextBytes(randomBytes);
-
-            PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-            publishPacketBuilder.withTopic(testTopic).withPayload(randomBytes).withQOS(QOS.AT_LEAST_ONCE);
-
-            SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-            subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                client.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-                client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
-
-                assertTrue(java.util.Arrays.equals(publishEvents.publishPacket.getPayload(), randomBytes));
-
-                client.stop(new DisconnectPacketBuilder().build());
-                events.stopFuture.get(180, TimeUnit.SECONDS);
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /**
-     * ============================================================
-     * Error Operation Tests
-     * ============================================================
-     */
-
-    /* Null Publish Test */
-    @Test
-    public void ErrorOp_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean didExceptionOccur = false;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                try {
-                    client.publish(null).get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    didExceptionOccur = true;
-                }
-
-                if (didExceptionOccur == false) {
-                    fail("Null publish packet did not cause exception with error!");
-                }
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Publish with empty builder test */
-    @Test
-    public void ErrorOp_UC1_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean didExceptionOccur = false;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                try {
-                    client.publish(new PublishPacketBuilder().build()).get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    didExceptionOccur = true;
-                }
-
-                if (didExceptionOccur == false) {
-                    fail("Empty publish packet did not cause exception with error!");
-                }
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Null Subscribe Test */
-    @Test
-    public void ErrorOp_UC2() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean didExceptionOccur = false;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                try {
-                    client.subscribe(null).get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    didExceptionOccur = true;
-                }
-
-                if (didExceptionOccur == false) {
-                    fail("Null subscribe packet did not cause exception with error!");
-                }
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Empty Subscribe Test */
-    @Test
-    public void ErrorOp_UC2_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean didExceptionOccur = false;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                try {
-                    client.subscribe(new SubscribePacketBuilder().build()).get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    didExceptionOccur = true;
-                }
-
-                if (didExceptionOccur == false) {
-                    fail("Empty subscribe packet did not cause exception with error!");
-                }
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Null Unsubscribe Test */
-    @Test
-    public void ErrorOp_UC3() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean didExceptionOccur = false;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                try {
-                    client.unsubscribe(null).get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    didExceptionOccur = true;
-                }
-
-                if (didExceptionOccur == false) {
-                    fail("Null unsubscribe packet did not cause exception with error!");
-                }
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Empty Unsubscribe Test */
-    @Test
-    public void ErrorOp_UC3_ALT() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        boolean didExceptionOccur = false;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                try {
-                    client.unsubscribe(new UnsubscribePacketBuilder().build()).get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    didExceptionOccur = true;
-                }
-
-                if (didExceptionOccur == false) {
-                    fail("Empty unsubscribe packet did not cause exception with error!");
-                }
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /* Unsupported Connect packet data sent (IoT Core only) */
-    @Test
-    public void ErrorOp_UC4() {
-        skipIfNetworkUnavailable();
-        /* Only works on IoT Core */
-        Assume.assumeTrue(mqtt5IoTCoreMqttHost != null);
-        Assume.assumeTrue(mqtt5IoTCoreMqttPort != null);
-        Assume.assumeTrue(mqtt5IoTCoreMqttCertificateFile != null);
-        Assume.assumeTrue(mqtt5IoTCoreMqttKeyFile != null);
-        Assume.assumeTrue(mqtt5IoTCoreMqttCertificateBytes != null);
-        Assume.assumeTrue(mqtt5IoTCoreMqttKeyBytes != null);
-        boolean didExceptionOccur = false;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5IoTCoreMqttHost, mqtt5IoTCoreMqttPort);
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            TlsContext tlsContext = null;
-            tlsContext = getIoTCoreTlsContext();
-            builder.withTlsContext(tlsContext);
-
-            ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
-            String clientIDString = "";
-            for (int i = 0; i < 256; i++) {
-                clientIDString += "a";
-            }
-            connectOptions.withClientId(clientIDString);
-            builder.withConnectOptions(connectOptions.build());
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                try {
-                    client.start();
-                    events.connectedFuture.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    didExceptionOccur = true;
-                }
-
-                if (didExceptionOccur == false) {
-                    fail("Was able to connect with Client ID longer than 128 characters (AWS_IOT_CORE_MAXIMUM_CLIENT_ID_LENGTH)");
-                }
-                client.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /**
-     * ============================================================
-     * QoS1 Tests
-     * ============================================================
-     */
-
-    /* Happy path. No drop in connection, no retry, no reconnect */
-    @Test
-    public void QoS1_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        int messageCount = 10;
-        String testUUID = UUID.randomUUID().toString();
-        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
-            builderTwo.withLifecycleEvents(eventsTwo);
-            PublishEvents_Futured_Counted publishEvents = new PublishEvents_Futured_Counted();
-            publishEvents.desiredPublishCount = messageCount;
-            builderTwo.withPublishEvents(publishEvents);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-                builderTwo.withTlsContext(tlsContext);
-            }
-
-            try (
-                Mqtt5Client publisher = new Mqtt5Client(builder.build());
-                Mqtt5Client subscriber = new Mqtt5Client(builderTwo.build());
-            ) {
-                publisher.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-                subscriber.start();
-                eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-                subscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-                publishPacketBuilder.withTopic(testTopic);
-                publishPacketBuilder.withPayload("Hello World".getBytes());
-                publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
-
-                for (int i = 0; i < messageCount; i++) {
-                    publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                }
-
-                // Did we get all the messages?
-                publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
-
-                subscriber.stop(new DisconnectPacketBuilder().build());
-                publisher.stop(new DisconnectPacketBuilder().build());
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /**
-     * ============================================================
-     * Retain Tests
-     * ============================================================
-     */
-
-    /* Happy path. No drop in connection, no retry, no reconnect */
-    @Test
-    public void Retain_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-        String testTopic = "test/retained_topic/MQTT5_Binding_Java_" + testUUID;
-
-        try {
-            Mqtt5ClientOptionsBuilder publisherEventsBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured publisherEvents = new LifecycleEvents_Futured();
-            publisherEventsBuilder.withLifecycleEvents(publisherEvents);
-
-            Mqtt5ClientOptionsBuilder successSubscriberBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured successSubscriberEvents = new LifecycleEvents_Futured();
-            PublishEvents_Futured successSubscriberPublishEvents = new PublishEvents_Futured();
-            successSubscriberBuilder.withLifecycleEvents(successSubscriberEvents);
-            successSubscriberBuilder.withPublishEvents(successSubscriberPublishEvents);
-
-            Mqtt5ClientOptionsBuilder unsuccessSubscriberBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured unsuccessfulSubscriberEvents = new LifecycleEvents_Futured();
-            PublishEvents_Futured unsuccessfulSubscriberPublishEvents = new PublishEvents_Futured();
-            unsuccessSubscriberBuilder.withLifecycleEvents(unsuccessfulSubscriberEvents);
-            unsuccessSubscriberBuilder.withPublishEvents(unsuccessfulSubscriberPublishEvents);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                publisherEventsBuilder.withTlsContext(tlsContext);
-                successSubscriberBuilder.withTlsContext(tlsContext);
-                unsuccessSubscriberBuilder.withTlsContext(tlsContext);
-            }
-
-            try (
-                Mqtt5Client publisher = new Mqtt5Client(publisherEventsBuilder.build());
-                Mqtt5Client successSubscriber = new Mqtt5Client(successSubscriberBuilder.build());
-                Mqtt5Client unsuccessfulSubscriber = new Mqtt5Client(unsuccessSubscriberBuilder.build());
-            ) {
-                // Connect and publish a retained message
-                publisher.start();
-                publisherEvents.connectedFuture.get(180, TimeUnit.SECONDS);
-                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-                publishPacketBuilder.withTopic(testTopic)
-                    .withPayload("Hello World".getBytes())
-                    .withQOS(QOS.AT_LEAST_ONCE)
-                    .withRetain(true);
-                publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-                // Setup for clearing the retained message
-                publishPacketBuilder.withPayload(null);
-
-                // Connect the successful subscriber
-                successSubscriber.start();
-                try {
-                    successSubscriberEvents.connectedFuture.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    // Clear the retained message
-                    publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                    fail("Success subscriber could not connect!");
-                }
-
-                // Subscribe and verify the retained message
-                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE, false, true, RetainHandlingType.SEND_ON_SUBSCRIBE);
-                try {
-                    successSubscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    // Clear the retained message
-                    publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                    fail("Success subscriber could not subscribe!");
-                }
-                try {
-                    successSubscriberPublishEvents.publishReceivedFuture.get(360, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    // Clear the retained message
-                    publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                    fail("Success subscriber did not get retained message!");
-                }
-
-                // Clear the retained message
-                publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
-
-                // Wait 15 seconds to give the server time to clear everything out
-                Thread.sleep(15000);
-
-                // Connect the unsuccessful subscriber
-                unsuccessfulSubscriber.start();
-                unsuccessfulSubscriberEvents.connectedFuture.get(180, TimeUnit.SECONDS);
-                unsuccessfulSubscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
-                // Make sure we do NOT get a publish
-                boolean didExceptionOccur = false;
-                try {
-                    unsuccessfulSubscriberPublishEvents.publishReceivedFuture.get(30, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    didExceptionOccur = true;
-                }
-
-                if (didExceptionOccur == false) {
-                    fail("Unsuccessful subscriber got retained message even though it should be cleared!");
-                }
-
-                // Disconnect all clients
-                DisconnectPacketBuilder disconnectPacketBuilder = new DisconnectPacketBuilder();
-                publisher.stop(disconnectPacketBuilder.build());
-                publisherEvents.stopFuture.get(180, TimeUnit.SECONDS);
-                successSubscriber.stop(disconnectPacketBuilder.build());
-                successSubscriberEvents.stopFuture.get(180, TimeUnit.SECONDS);
-                unsuccessfulSubscriber.stop(disconnectPacketBuilder.build());
-                unsuccessfulSubscriberEvents.stopFuture.get(180, TimeUnit.SECONDS);
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    /**
-     * ============================================================
-     * Operation Interrupt Tests
-     * ============================================================
-     */
-
-    // Subscribe interrupt test
-    @Test
-    public void Interrupt_Sub_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
-                subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
-
-                try {
-                    CompletableFuture<SubAckPacket> subscribeResult = client.subscribe(subscribePacketBuilder.build());
-                    client.stop(new DisconnectPacketBuilder().build());
-                    SubAckPacket packet = subscribeResult.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
-                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-                        if (exCrt.errorCode != 5153) {
-                            System.out.println("Exception ocurred when stopping subscribe" +
-                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
-                        }
-                    }
-                }
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    // Unsubscribe interrupt test
-    @Test
-    public void Interrupt_Unsub_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
-                unsubscribePacketBuilder.withSubscription(testTopic);
-
-                try {
-                    CompletableFuture<UnsubAckPacket> unsubscribeResult = client.unsubscribe(unsubscribePacketBuilder.build());
-                    client.stop(new DisconnectPacketBuilder().build());
-                    UnsubAckPacket packet = unsubscribeResult.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
-                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-                        if (exCrt.errorCode != 5153) {
-                            System.out.println("Exception ocurred when stopping unsubscribe" +
-                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
-                        }
-                    }
-                }
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
-
-    // Publish interrupt test
-    @Test
-    public void Interrupt_Publish_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(checkMinimumDirectHostAndPort());
-        String testUUID = UUID.randomUUID().toString();
-        String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
-
-        try {
-            Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
-            LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-            builder.withLifecycleEvents(events);
-
-            // Only needed for IoT Core
-            TlsContext tlsContext = null;
-            if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
-                Assume.assumeTrue(getMinimumDirectCert() != null);
-                Assume.assumeTrue(getMinimumDirectKey() != null);
-                tlsContext = getIoTCoreTlsContext();
-                builder.withTlsContext(tlsContext);
-            }
-
-            try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-                client.start();
-                events.connectedFuture.get(180, TimeUnit.SECONDS);
-
-                PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
-                publishPacketBuilder.withTopic(testTopic).withQOS(QOS.AT_LEAST_ONCE).withPayload("null".getBytes());
-
-                try {
-                    CompletableFuture<PublishResult> publishResult = client.publish(publishPacketBuilder.build());
-                    client.stop(new DisconnectPacketBuilder().build());
-                    PublishResult publishData = publishResult.get(180, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    if (ex.getCause().getClass() == CrtRuntimeException.class) {
-                        CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
-                        if (exCrt.errorCode != 5153) {
-                            System.out.println("Exception ocurred when stopping publish" +
-                                "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
-                        }
-                    }
-                }
-            }
-
-            if (tlsContext != null) {
-                tlsContext.close();
-            }
-
-        } catch (Exception ex) {
-            fail(ex.getMessage());
-        }
-    }
+    // /* Client connect with invalid host name */
+    // @Test
+    // public void ConnNegativeID_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean foundExpectedError = false;
+    //     boolean exceptionOccurred = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("_test", getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+    //         builder.withMinReconnectDelayMs(1000L);
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+
+    //             try {
+    //                 events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 exceptionOccurred = true;
+    //                 if (events.connectFailureCode == 1059) {
+    //                     foundExpectedError = true;
+    //                 } else {
+    //                     System.out.println("EXCEPTION: " + ex);
+    //                     System.out.println(ex.getMessage() + " \n");
+    //                 }
+    //             }
+
+    //             if (foundExpectedError == false) {
+    //                 System.out.println("Error code was not AWS_IO_DNS_INVALID_NAME like expected! There was an exception though");
+    //             }
+    //             if (exceptionOccurred == false) {
+    //                 fail("No exception occurred!");
+    //             }
+    //         }
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Client connect with invalid, nonexistent port for direct connection */
+    // @Test
+    // public void ConnNegativeID_UC2() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean foundExpectedError = false;
+    //     boolean exceptionOccurred = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), 65535L);
+    //         builder.withLifecycleEvents(events);
+    //         builder.withMinReconnectDelayMs(1000L);
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+
+    //             try {
+    //                 events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 exceptionOccurred = true;
+    //                 if (events.connectFailureCode == 1047) {
+    //                     foundExpectedError = true;
+    //                 }
+    //             }
+
+    //             if (foundExpectedError == false) {
+    //                 System.out.println("Error code was not AWS_IO_SOCKET_CONNECTION_REFUSED like expected! There was an exception though");
+    //             }
+    //             if (exceptionOccurred == false) {
+    //                 fail("No exception occurred!");
+    //             }
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Client connect with invalid protocol port for direct connection */
+    // @Test
+    // public void ConnNegativeID_UC2_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(mqtt5DirectMqttHost != null);
+    //     Assume.assumeTrue(mqtt5WSMqttPort != null);
+    //     boolean foundExpectedError = false;
+    //     boolean exceptionOccurred = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttHost, mqtt5WSMqttPort);
+    //         builder.withLifecycleEvents(events);
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+
+    //             try {
+    //                 events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 exceptionOccurred = true;
+    //                 if (events.connectFailureCode == 5149) {
+    //                     foundExpectedError = true;
+    //                 }
+    //             }
+
+    //             if (foundExpectedError == false) {
+    //                 System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
+    //             }
+    //             if (exceptionOccurred == false) {
+    //                 fail("No exception occurred!");
+    //             }
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Client connect with invalid, nonexistent port for websocket connection */
+    // @Test
+    // public void ConnNegativeID_UC3() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(mqtt5WSMqttHost != null);
+    //     boolean foundExpectedError = false;
+    //     boolean exceptionOccurred = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+    //         try (
+    //             EventLoopGroup elg = new EventLoopGroup(1);
+    //             HostResolver hr = new HostResolver(elg);
+    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+    //         ) {
+    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, 444L);
+    //             builder.withLifecycleEvents(events);
+    //             builder.withBootstrap(bootstrap);
+
+    //             Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+    //                 @Override
+    //                 public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+    //                     t.complete(t.getHttpRequest());
+    //                 }
+    //             };
+    //             builder.withWebsocketHandshakeTransform(websocketTransform);
+
+    //             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //                 client.start();
+
+    //                 try {
+    //                     events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //                 } catch (Exception ex) {
+    //                     exceptionOccurred = true;
+    //                     if (events.connectFailureCode == 1047) {
+    //                         foundExpectedError = true;
+    //                     }
+    //                 }
+
+    //                 if (foundExpectedError == false) {
+    //                     System.out.println("Error code was not AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR like expected! There was an exception though");
+    //                 }
+    //                 if (exceptionOccurred == false) {
+    //                     fail("No exception occurred!");
+    //                 }
+    //             }
+    //         }
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Client connect with invalid protocol port for websocket connection */
+    // @Test
+    // public void ConnNegativeID_UC3_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(mqtt5WSMqttHost != null);
+    //     Assume.assumeTrue(mqtt5DirectMqttPort != null);
+    //     boolean foundExpectedError = false;
+    //     boolean exceptionOccurred = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+    //         try (
+    //             EventLoopGroup elg = new EventLoopGroup(1);
+    //             HostResolver hr = new HostResolver(elg);
+    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+    //         ) {
+
+    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5DirectMqttPort);
+    //             builder.withLifecycleEvents(events);
+    //             builder.withBootstrap(bootstrap);
+
+    //             Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+    //                 @Override
+    //                 public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+    //                     t.complete(t.getHttpRequest());
+    //                 }
+    //             };
+    //             builder.withWebsocketHandshakeTransform(websocketTransform);
+
+    //             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //                 client.start();
+    //                 try {
+    //                     events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //                 } catch (Exception ex) {
+    //                     exceptionOccurred = true;
+    //                     if (events.connectFailureCode == 46) {
+    //                         foundExpectedError = true;
+    //                     }
+    //                 }
+
+    //                 if (foundExpectedError == false) {
+    //                     System.out.println("Error code was not AWS_ERROR_SYS_CALL_FAILURE (occurs right after AWS_ERROR_MQTT5_DECODE_PROTOCOL_ERROR for Websockets) like expected! There was an exception though");
+    //                 }
+    //                 if (exceptionOccurred == false) {
+    //                     fail("No exception occurred!");
+    //                 }
+    //             }
+    //         }
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Client connect with socket timeout */
+    // @Test
+    // public void ConnNegativeID_UC4() {
+    //     skipIfNetworkUnavailable();
+    //     boolean foundExpectedError = false;
+    //     boolean exceptionOccurred = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+    //         try (
+    //             EventLoopGroup elg = new EventLoopGroup(1);
+    //             HostResolver hr = new HostResolver(elg);
+    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+    //             SocketOptions options = new SocketOptions();
+    //         ) {
+    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder("www.example.com", 81L);
+    //             builder.withLifecycleEvents(events);
+    //             builder.withBootstrap(bootstrap);
+
+    //             options.connectTimeoutMs = 100;
+    //             builder.withSocketOptions(options);
+
+    //             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //                 client.start();
+
+    //                 try {
+    //                     events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //                 } catch (Exception ex) {
+    //                     exceptionOccurred = true;
+    //                     if (events.connectFailureCode == 1048) {
+    //                         foundExpectedError = true;
+    //                     }
+    //                 }
+    //                 if (foundExpectedError == false) {
+    //                     System.out.println("Error code was not AWS_IO_SOCKET_TIMEOUT like expected! There was an exception though");
+    //                 }
+    //                 if (exceptionOccurred == false) {
+    //                     fail("No exception occurred!");
+    //                 }
+    //             }
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Websocket handshake failure test */
+    // @Test
+    // public void ConnNegativeID_UC6() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(mqtt5WSMqttHost != null);
+    //     Assume.assumeTrue(mqtt5WSMqttPort != null);
+    //     boolean foundExpectedError = false;
+    //     boolean exceptionOccurred = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+
+    //         try (
+    //             EventLoopGroup elg = new EventLoopGroup(1);
+    //             HostResolver hr = new HostResolver(elg);
+    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+    //         ) {
+
+    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5WSMqttHost, mqtt5WSMqttPort);
+    //             builder.withLifecycleEvents(events);
+    //             builder.withBootstrap(bootstrap);
+
+    //             Consumer<Mqtt5WebsocketHandshakeTransformArgs> websocketTransform = new Consumer<Mqtt5WebsocketHandshakeTransformArgs>() {
+    //                 @Override
+    //                 public void accept(Mqtt5WebsocketHandshakeTransformArgs t) {
+    //                     t.completeExceptionally(new Throwable("Intentional failure!"));
+    //                 }
+    //             };
+    //             builder.withWebsocketHandshakeTransform(websocketTransform);
+    //             builder.withPort(mqtt5WSMqttPort);
+
+    //             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //                 client.start();
+
+    //                 try {
+    //                     events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //                 } catch (Exception ex) {
+    //                     exceptionOccurred = true;
+    //                     if (events.connectFailureCode == 3) {
+    //                         foundExpectedError = true;
+    //                     }
+    //                 }
+    //                 if (foundExpectedError == false) {
+    //                     System.out.println("Error code was not AWS_ERROR_UNKNOWN like expected! There was an exception though");
+    //                 }
+    //                 if (exceptionOccurred == false) {
+    //                     fail("No exception occurred!");
+    //                 }
+
+    //                 DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+    //                 client.stop(disconnect.build());
+    //             }
+    //         }
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* For the double client ID test */
+    // static final class LifecycleEvents_DoubleClientID implements Mqtt5ClientOptions.LifecycleEvents {
+    //     CompletableFuture<Void> connectedFuture = new CompletableFuture<>();
+    //     CompletableFuture<Void> disconnectedFuture = new CompletableFuture<>();
+    //     CompletableFuture<Void> stoppedFuture = new CompletableFuture<>();
+
+    //     @Override
+    //     public void onAttemptingConnect(Mqtt5Client client, OnAttemptingConnectReturn onAttemptingConnectReturn) {}
+
+    //     @Override
+    //     public void onConnectionSuccess(Mqtt5Client client, OnConnectionSuccessReturn onConnectionSuccessReturn) {
+    //         connectedFuture.complete(null);
+    //     }
+
+    //     @Override
+    //     public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {
+    //         connectedFuture.completeExceptionally(new Exception("Could not connect!"));
+    //     }
+
+    //     @Override
+    //     public void onDisconnection(Mqtt5Client client, OnDisconnectionReturn onDisconnectionReturn) {
+    //         disconnectedFuture.complete(null);
+    //     }
+
+    //     @Override
+    //     public void onStopped(Mqtt5Client client, OnStoppedReturn onStoppedReturn) {
+    //         stoppedFuture.complete(null);
+    //     }
+    // }
+
+    // /* Double Client ID failure test */
+    // @Test
+    // public void ConnNegativeID_UC7() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+
+    //     try {
+    //         LifecycleEvents_DoubleClientID events = new LifecycleEvents_DoubleClientID();
+
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
+    //         builder.withConnectOptions(connectOptions.build());
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (
+    //             Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+    //             Mqtt5Client clientTwo = new Mqtt5Client(builder.build());
+    //         ) {
+    //             clientOne.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             clientTwo.start();
+    //             events.connectedFuture = new CompletableFuture<>();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             // Make sure a disconnection happened
+    //             events.disconnectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             // Stop the clients from disconnecting each other. If we do not do this, then the clients will
+    //             // attempt to reconnect endlessly, making a never ending loop.
+    //             DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
+    //             clientOne.stop(disconnect);
+    //             clientTwo.stop(disconnect);
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Double Client ID disconnect and then reconnect test */
+    // @Test
+    // public void ConnNegativeID_UC7_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+    //     try {
+    //         LifecycleEvents_DoubleClientID events = new LifecycleEvents_DoubleClientID();
+    //         LifecycleEvents_DoubleClientID eventsTwo = new LifecycleEvents_DoubleClientID();
+
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder().withClientId("test/MQTT5_Binding_Java_" + testUUID);
+    //         builder.withConnectOptions(connectOptions.build());
+
+    //         Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builderTwo.withLifecycleEvents(eventsTwo);
+    //         builderTwo.withConnectOptions(connectOptions.build());
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //             builderTwo.withTlsContext(tlsContext);
+    //         }
+
+    //         try (
+    //             Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+    //             Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
+    //         ) {
+    //             clientOne.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             clientTwo.start();
+    //             eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             // Make sure the first client was disconnected
+    //             events.disconnectedFuture.get(180, TimeUnit.SECONDS);
+    //             // Disconnect the second client so the first can reconnect
+    //             clientTwo.stop(new DisconnectPacketBuilder().build());
+    //             // Confirm the second client has stopped
+    //             eventsTwo.stoppedFuture.get(180, TimeUnit.SECONDS);
+
+    //             // Wait until the first client has reconnected
+    //             events.connectedFuture = new CompletableFuture<>();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             assertTrue(clientOne.getIsConnected() == true);
+
+    //             // Stop the clients from disconnecting each other. If we do not do this, then the clients will
+    //             // attempt to reconnect endlessly, making a never ending loop.
+    //             DisconnectPacket disconnect = new DisconnectPacketBuilder().build();
+    //             clientOne.stop(disconnect);
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /**
+    //  * ============================================================
+    //  * Negative Data Input Tests
+    //  * ============================================================
+    //  */
+
+    // /* Negative Connect Packet Properties */
+    // @Test
+    // public void NewNegative_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean clientCreationFailed = false;
+
+    //     try {
+    //         Mqtt5Client client = null;
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+
+    //         connectOptions.withKeepAliveIntervalSeconds(-100L);
+    //         builder.withConnectOptions(connectOptions.build());
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail with negative KeepAliveIntervalSeconds");
+    //         }
+    //         connectOptions.withKeepAliveIntervalSeconds(100L);
+
+    //         connectOptions.withSessionExpiryIntervalSeconds(-100L);
+    //         builder.withConnectOptions(connectOptions.build());
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail with negative SessionExpiryIntervalSeconds");
+    //         }
+    //         connectOptions.withSessionExpiryIntervalSeconds(100L);
+
+    //         connectOptions.withReceiveMaximum(-100L);
+    //         builder.withConnectOptions(connectOptions.build());
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail negative ReceiveMaximum");
+    //         }
+    //         connectOptions.withReceiveMaximum(100L);
+
+    //         connectOptions.withMaximumPacketSizeBytes(-100L);
+    //         builder.withConnectOptions(connectOptions.build());
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail with negative MaximumPacketSizeBytes");
+    //         }
+    //         connectOptions.withMaximumPacketSizeBytes(100L);
+
+    //         connectOptions.withWillDelayIntervalSeconds(-100L);
+    //         builder.withConnectOptions(connectOptions.build());
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail with negative willDelayIntervalSeconds");
+    //         }
+    //         connectOptions.withWillDelayIntervalSeconds(100L);
+
+    //         // Make sure everything is closed
+    //         if (client != null) {
+    //             client.close();
+    //         }
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Overflow Connect Packet Properties */
+    // @Test
+    // public void NewNegative_UC1_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean clientCreationFailed = false;
+
+    //     try {
+    //         Mqtt5Client client = null;
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+
+    //         connectOptions.withKeepAliveIntervalSeconds(2147483647L);
+    //         builder.withConnectOptions(connectOptions.build());
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail with overflow KeepAliveIntervalSeconds");
+    //         }
+    //         connectOptions.withKeepAliveIntervalSeconds(100L);
+
+    //         connectOptions.withSessionExpiryIntervalSeconds(9223372036854775807L);
+    //         builder.withConnectOptions(connectOptions.build());
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail with overflow SessionExpiryIntervalSeconds");
+    //         }
+    //         connectOptions.withSessionExpiryIntervalSeconds(100L);
+
+    //         connectOptions.withReceiveMaximum(2147483647L);
+    //         builder.withConnectOptions(connectOptions.build());
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail overflow ReceiveMaximum");
+    //         }
+    //         connectOptions.withReceiveMaximum(100L);
+
+    //         connectOptions.withMaximumPacketSizeBytes(9223372036854775807L);
+    //         builder.withConnectOptions(connectOptions.build());
+    //         clientCreationFailed = false;
+    //         try {
+    //             client = new Mqtt5Client(builder.build());
+    //         } catch (Exception ex) {
+    //             clientCreationFailed = true;
+    //         }
+    //         if (clientCreationFailed == false) {
+    //             fail("Client creation did not fail with overflow MaximumPacketSizeBytes");
+    //         }
+    //         connectOptions.withMaximumPacketSizeBytes(100L);
+
+    //         // WillDelayIntervalSeconds is an unsigned 64 bit Long, so it cannot overflow it from Java
+
+    //         // Make sure everything is closed
+    //         if (client != null) {
+    //             client.close();
+    //         }
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Negative Disconnect Packet Properties */
+    // @Test
+    // public void NewNegative_UC2() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean clientDisconnectFailed = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
+    //             disconnectBuilder.withSessionExpiryIntervalSeconds(-100L);
+    //             try {
+    //                 client.stop(disconnectBuilder.build());
+    //             } catch (Exception ex) {
+    //                 clientDisconnectFailed = true;
+    //             }
+
+    //             if (clientDisconnectFailed == false) {
+    //                 fail("Client disconnect packet creation did not fail!");
+    //             }
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Overflow Disconnect Packet Properties */
+    // @Test
+    // public void NewNegative_UC2_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean clientDisconnectFailed = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
+    //             disconnectBuilder.withSessionExpiryIntervalSeconds(9223372036854775807L);
+    //             try {
+    //                 client.stop(disconnectBuilder.build());
+    //             } catch (Exception ex) {
+    //                 clientDisconnectFailed = true;
+    //             }
+
+    //             if (clientDisconnectFailed == false) {
+    //                 fail("Client disconnect did not fail!");
+    //             }
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Negative Publish Packet Properties */
+    // @Test
+    // public void NewNegative_UC3() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean clientPublishFailed = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
+    //             publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
+    //             publishBuilder.withMessageExpiryIntervalSeconds(-100L);
+    //             try {
+    //                 CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
+    //                 future.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 clientPublishFailed = true;
+    //             }
+
+    //             if (clientPublishFailed == false) {
+    //                 fail("Client publish did not fail!");
+    //             }
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Overflow Publish Packet Properties */
+    // @Test
+    // public void NewNegative_UC3_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean clientPublishFailed = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             PublishPacketBuilder publishBuilder = new PublishPacketBuilder();
+    //             publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic").withQOS(QOS.AT_LEAST_ONCE);
+    //             publishBuilder.withMessageExpiryIntervalSeconds(9223372036854775807L);
+    //             try {
+    //                 CompletableFuture<PublishResult> future = client.publish(publishBuilder.build());
+    //                 future.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 clientPublishFailed = true;
+    //             }
+
+    //             if (clientPublishFailed == false) {
+    //                 fail("Client publish did not fail!");
+    //             }
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Negative Subscribe Packet Properties */
+    // @Test
+    // public void NewNegative_UC4() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean clientSubscribeFailed = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
+    //             subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
+    //             subscribeBuilder.withSubscriptionIdentifier(-100L);
+    //             try {
+    //                 CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
+    //                 future.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 clientSubscribeFailed = true;
+    //             }
+
+    //             if (clientSubscribeFailed == false) {
+    //                 fail("Client subscribe did not fail!");
+    //             }
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Overflow Subscribe Packet Properties */
+    // @Test
+    // public void NewNegative_UC4_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean clientSubscribeFailed = false;
+
+    //     try {
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder();
+    //             subscribeBuilder.withSubscription("test/topic", QOS.AT_LEAST_ONCE);
+    //             subscribeBuilder.withSubscriptionIdentifier(9223372036854775807L);
+    //             try {
+    //                 CompletableFuture<SubAckPacket> future = client.subscribe(subscribeBuilder.build());
+    //                 future.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 clientSubscribeFailed = true;
+    //             }
+
+    //             if (clientSubscribeFailed == false) {
+    //                 fail("Client subscribe did not fail!");
+    //             }
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /**
+    //  * ============================================================
+    //  * Negotiated Settings Tests
+    //  * ============================================================
+    //  */
+
+    // /* Happy path, minimal success test */
+    // @Test
+    // public void Negotiated_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+    //         ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
+    //         optionsBuilder.withSessionExpiryIntervalSeconds(600000L);
+    //         builder.withConnectOptions(optionsBuilder.build());
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             // TODO - add support for this in the future!
+    //             // assertEquals(
+    //             //     "Negotiated Settings session expiry interval does not match sent session expiry interval",
+    //             //     events.connectSuccessSettings.getSessionExpiryInterval(),
+    //             //     600000L);
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Maximum success test */
+    // @Test
+    // public void Negotiated_UC2() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
+    //         optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
+    //         optionsBuilder.withSessionExpiryIntervalSeconds(0L);
+    //         optionsBuilder.withKeepAliveIntervalSeconds(360L);
+    //         builder.withConnectOptions(optionsBuilder.build());
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             assertEquals(
+    //                 "Negotiated Settings client ID does not match sent client ID",
+    //                 events.connectSuccessSettings.getAssignedClientID(),
+    //                 "test/MQTT5_Binding_Java_" + testUUID);
+    //             assertEquals(
+    //                 "Negotiated Settings session expiry interval does not match sent session expiry interval",
+    //                 events.connectSuccessSettings.getSessionExpiryInterval(),
+    //                 0L);
+    //             assertEquals(
+    //                 "Negotiated Settings keep alive result does not match sent keep alive",
+    //                 events.connectSuccessSettings.getServerKeepAlive(),
+    //                 360);
+    //             assertEquals(
+    //                     "Negotiated Settings rejoined session does not match expected value",
+    //                     false,
+    //                     events.connectSuccessSettings.getRejoinedSession());
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Rejoin always session resumption test */
+    // @Test
+    // public void Negotiated_Rejoin_Always() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         ConnectPacketBuilder optionsBuilder = new ConnectPacketBuilder();
+    //         optionsBuilder.withClientId("test/MQTT5_Binding_Java_" + testUUID);
+    //         optionsBuilder.withSessionExpiryIntervalSeconds(3600L);
+    //         optionsBuilder.withKeepAliveIntervalSeconds(360L);
+    //         builder.withConnectOptions(optionsBuilder.build());
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             assertEquals(
+    //                     "Negotiated Settings client ID does not match sent client ID",
+    //                     events.connectSuccessSettings.getAssignedClientID(),
+    //                     "test/MQTT5_Binding_Java_" + testUUID);
+    //             assertEquals(
+    //                     "Negotiated Settings session expiry interval does not match sent session expiry interval",
+    //                     events.connectSuccessSettings.getSessionExpiryInterval(),
+    //                     3600L);
+    //             assertEquals(
+    //                     "Negotiated Settings keep alive result does not match sent keep alive",
+    //                     events.connectSuccessSettings.getServerKeepAlive(),
+    //                     360);
+    //             assertEquals(
+    //                     "Negotiated Settings rejoined session does not match expected value",
+    //                     false,
+    //                     events.connectSuccessSettings.getRejoinedSession());
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         builder.withSessionBehavior(ClientSessionBehavior.REJOIN_ALWAYS);
+    //         LifecycleEvents_Futured rejoinEvents = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(rejoinEvents);
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             rejoinEvents.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             assertEquals(
+    //                     "Negotiated Settings rejoined session does not match expected value",
+    //                     true,
+    //                     rejoinEvents.connectSuccessSettings.getRejoinedSession());
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /**
+    //  * ============================================================
+    //  * Operation Tests
+    //  * ============================================================
+    //  */
+
+    // /* Sub-UnSub happy path */
+    // @Test
+    // public void Op_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+    //         builder.withPublishEvents(publishEvents);
+
+    //         PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+    //         publishPacketBuilder.withTopic(testTopic);
+    //         publishPacketBuilder.withPayload("Hello World".getBytes());
+    //         publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
+
+    //         SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+    //         subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+    //         UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
+    //         unsubscribePacketBuilder.withSubscription(testTopic);
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             client.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+    //             client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //             publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
+
+    //             publishEvents.publishReceivedFuture = new CompletableFuture<>();
+    //             publishEvents.publishPacket = null;
+    //             client.unsubscribe(unsubscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //             client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+    //             assertEquals(
+    //                 "Publish after unsubscribe still arrived!",
+    //                 publishEvents.publishPacket,
+    //                 null);
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Sub-UnSub happy path */
+    // @Test
+    // public void Op_UC2() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+    //         PublishPacketBuilder willPacket = new PublishPacketBuilder();
+    //         willPacket.withTopic(testTopic);
+    //         willPacket.withQOS(QOS.AT_LEAST_ONCE);
+    //         willPacket.withPayload("Hello World".getBytes());
+    //         connectOptions.withWill(willPacket.build());
+    //         connectOptions.withWillDelayIntervalSeconds(0L);
+    //         builder.withConnectOptions(connectOptions.build());
+
+    //         Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
+    //         builderTwo.withLifecycleEvents(eventsTwo);
+    //         PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+    //         builderTwo.withPublishEvents(publishEvents);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContextTwo = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContextTwo = getIoTCoreTlsContext();
+    //             builderTwo.withTlsContext(tlsContextTwo);
+    //         }
+
+    //         SubscribePacketBuilder subscribeOptions = new SubscribePacketBuilder();
+    //         subscribeOptions.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+    //         try (
+    //             Mqtt5Client clientOne = new Mqtt5Client(builder.build());
+    //             Mqtt5Client clientTwo = new Mqtt5Client(builderTwo.build());
+    //         ) {
+    //             clientOne.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             clientTwo.start();
+    //             eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             clientTwo.subscribe(subscribeOptions.build()).get(180, TimeUnit.SECONDS);
+    //             clientOne.stop(null);
+
+    //             // Did we get a publish message?
+    //             publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
+    //             assertTrue(publishEvents.publishPacket != null);
+
+    //             clientTwo.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //             tlsContextTwo.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Binary Publish Test */
+    // @Test
+    // public void Op_UC3() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         PublishEvents_Futured publishEvents = new PublishEvents_Futured();
+    //         builder.withPublishEvents(publishEvents);
+
+    //         // Make random binary
+    //         byte[] randomBytes = new byte[256];
+    //         Random random = new Random();
+    //         random.nextBytes(randomBytes);
+
+    //         PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+    //         publishPacketBuilder.withTopic(testTopic).withPayload(randomBytes).withQOS(QOS.AT_LEAST_ONCE);
+
+    //         SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+    //         subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             client.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+    //             client.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //             publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
+
+    //             assertTrue(java.util.Arrays.equals(publishEvents.publishPacket.getPayload(), randomBytes));
+
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //             events.stopFuture.get(180, TimeUnit.SECONDS);
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /**
+    //  * ============================================================
+    //  * Error Operation Tests
+    //  * ============================================================
+    //  */
+
+    // /* Null Publish Test */
+    // @Test
+    // public void ErrorOp_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean didExceptionOccur = false;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             try {
+    //                 client.publish(null).get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 didExceptionOccur = true;
+    //             }
+
+    //             if (didExceptionOccur == false) {
+    //                 fail("Null publish packet did not cause exception with error!");
+    //             }
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Publish with empty builder test */
+    // @Test
+    // public void ErrorOp_UC1_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean didExceptionOccur = false;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             try {
+    //                 client.publish(new PublishPacketBuilder().build()).get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 didExceptionOccur = true;
+    //             }
+
+    //             if (didExceptionOccur == false) {
+    //                 fail("Empty publish packet did not cause exception with error!");
+    //             }
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Null Subscribe Test */
+    // @Test
+    // public void ErrorOp_UC2() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean didExceptionOccur = false;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             try {
+    //                 client.subscribe(null).get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 didExceptionOccur = true;
+    //             }
+
+    //             if (didExceptionOccur == false) {
+    //                 fail("Null subscribe packet did not cause exception with error!");
+    //             }
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Empty Subscribe Test */
+    // @Test
+    // public void ErrorOp_UC2_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean didExceptionOccur = false;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             try {
+    //                 client.subscribe(new SubscribePacketBuilder().build()).get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 didExceptionOccur = true;
+    //             }
+
+    //             if (didExceptionOccur == false) {
+    //                 fail("Empty subscribe packet did not cause exception with error!");
+    //             }
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Null Unsubscribe Test */
+    // @Test
+    // public void ErrorOp_UC3() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean didExceptionOccur = false;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             try {
+    //                 client.unsubscribe(null).get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 didExceptionOccur = true;
+    //             }
+
+    //             if (didExceptionOccur == false) {
+    //                 fail("Null unsubscribe packet did not cause exception with error!");
+    //             }
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Empty Unsubscribe Test */
+    // @Test
+    // public void ErrorOp_UC3_ALT() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     boolean didExceptionOccur = false;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             try {
+    //                 client.unsubscribe(new UnsubscribePacketBuilder().build()).get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 didExceptionOccur = true;
+    //             }
+
+    //             if (didExceptionOccur == false) {
+    //                 fail("Empty unsubscribe packet did not cause exception with error!");
+    //             }
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /* Unsupported Connect packet data sent (IoT Core only) */
+    // @Test
+    // public void ErrorOp_UC4() {
+    //     skipIfNetworkUnavailable();
+    //     /* Only works on IoT Core */
+    //     Assume.assumeTrue(mqtt5IoTCoreMqttHost != null);
+    //     Assume.assumeTrue(mqtt5IoTCoreMqttPort != null);
+    //     Assume.assumeTrue(mqtt5IoTCoreMqttCertificateFile != null);
+    //     Assume.assumeTrue(mqtt5IoTCoreMqttKeyFile != null);
+    //     Assume.assumeTrue(mqtt5IoTCoreMqttCertificateBytes != null);
+    //     Assume.assumeTrue(mqtt5IoTCoreMqttKeyBytes != null);
+    //     boolean didExceptionOccur = false;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5IoTCoreMqttHost, mqtt5IoTCoreMqttPort);
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         TlsContext tlsContext = null;
+    //         tlsContext = getIoTCoreTlsContext();
+    //         builder.withTlsContext(tlsContext);
+
+    //         ConnectPacketBuilder connectOptions = new ConnectPacketBuilder();
+    //         String clientIDString = "";
+    //         for (int i = 0; i < 256; i++) {
+    //             clientIDString += "a";
+    //         }
+    //         connectOptions.withClientId(clientIDString);
+    //         builder.withConnectOptions(connectOptions.build());
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             try {
+    //                 client.start();
+    //                 events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 didExceptionOccur = true;
+    //             }
+
+    //             if (didExceptionOccur == false) {
+    //                 fail("Was able to connect with Client ID longer than 128 characters (AWS_IOT_CORE_MAXIMUM_CLIENT_ID_LENGTH)");
+    //             }
+    //             client.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /**
+    //  * ============================================================
+    //  * QoS1 Tests
+    //  * ============================================================
+    //  */
+
+    // /* Happy path. No drop in connection, no retry, no reconnect */
+    // @Test
+    // public void QoS1_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     int messageCount = 10;
+    //     String testUUID = UUID.randomUUID().toString();
+    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         Mqtt5ClientOptionsBuilder builderTwo = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured eventsTwo = new LifecycleEvents_Futured();
+    //         builderTwo.withLifecycleEvents(eventsTwo);
+    //         PublishEvents_Futured_Counted publishEvents = new PublishEvents_Futured_Counted();
+    //         publishEvents.desiredPublishCount = messageCount;
+    //         builderTwo.withPublishEvents(publishEvents);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //             builderTwo.withTlsContext(tlsContext);
+    //         }
+
+    //         try (
+    //             Mqtt5Client publisher = new Mqtt5Client(builder.build());
+    //             Mqtt5Client subscriber = new Mqtt5Client(builderTwo.build());
+    //         ) {
+    //             publisher.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             subscriber.start();
+    //             eventsTwo.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+    //             subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+    //             subscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+    //             PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+    //             publishPacketBuilder.withTopic(testTopic);
+    //             publishPacketBuilder.withPayload("Hello World".getBytes());
+    //             publishPacketBuilder.withQOS(QOS.AT_LEAST_ONCE);
+
+    //             for (int i = 0; i < messageCount; i++) {
+    //                 publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //             }
+
+    //             // Did we get all the messages?
+    //             publishEvents.publishReceivedFuture.get(180, TimeUnit.SECONDS);
+
+    //             subscriber.stop(new DisconnectPacketBuilder().build());
+    //             publisher.stop(new DisconnectPacketBuilder().build());
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /**
+    //  * ============================================================
+    //  * Retain Tests
+    //  * ============================================================
+    //  */
+
+    // /* Happy path. No drop in connection, no retry, no reconnect */
+    // @Test
+    // public void Retain_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+    //     String testTopic = "test/retained_topic/MQTT5_Binding_Java_" + testUUID;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder publisherEventsBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured publisherEvents = new LifecycleEvents_Futured();
+    //         publisherEventsBuilder.withLifecycleEvents(publisherEvents);
+
+    //         Mqtt5ClientOptionsBuilder successSubscriberBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured successSubscriberEvents = new LifecycleEvents_Futured();
+    //         PublishEvents_Futured successSubscriberPublishEvents = new PublishEvents_Futured();
+    //         successSubscriberBuilder.withLifecycleEvents(successSubscriberEvents);
+    //         successSubscriberBuilder.withPublishEvents(successSubscriberPublishEvents);
+
+    //         Mqtt5ClientOptionsBuilder unsuccessSubscriberBuilder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured unsuccessfulSubscriberEvents = new LifecycleEvents_Futured();
+    //         PublishEvents_Futured unsuccessfulSubscriberPublishEvents = new PublishEvents_Futured();
+    //         unsuccessSubscriberBuilder.withLifecycleEvents(unsuccessfulSubscriberEvents);
+    //         unsuccessSubscriberBuilder.withPublishEvents(unsuccessfulSubscriberPublishEvents);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             publisherEventsBuilder.withTlsContext(tlsContext);
+    //             successSubscriberBuilder.withTlsContext(tlsContext);
+    //             unsuccessSubscriberBuilder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (
+    //             Mqtt5Client publisher = new Mqtt5Client(publisherEventsBuilder.build());
+    //             Mqtt5Client successSubscriber = new Mqtt5Client(successSubscriberBuilder.build());
+    //             Mqtt5Client unsuccessfulSubscriber = new Mqtt5Client(unsuccessSubscriberBuilder.build());
+    //         ) {
+    //             // Connect and publish a retained message
+    //             publisher.start();
+    //             publisherEvents.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+    //             publishPacketBuilder.withTopic(testTopic)
+    //                 .withPayload("Hello World".getBytes())
+    //                 .withQOS(QOS.AT_LEAST_ONCE)
+    //                 .withRetain(true);
+    //             publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+    //             // Setup for clearing the retained message
+    //             publishPacketBuilder.withPayload(null);
+
+    //             // Connect the successful subscriber
+    //             successSubscriber.start();
+    //             try {
+    //                 successSubscriberEvents.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 // Clear the retained message
+    //                 publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //                 fail("Success subscriber could not connect!");
+    //             }
+
+    //             // Subscribe and verify the retained message
+    //             SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+    //             subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE, false, true, RetainHandlingType.SEND_ON_SUBSCRIBE);
+    //             try {
+    //                 successSubscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 // Clear the retained message
+    //                 publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //                 fail("Success subscriber could not subscribe!");
+    //             }
+    //             try {
+    //                 successSubscriberPublishEvents.publishReceivedFuture.get(360, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 // Clear the retained message
+    //                 publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //                 fail("Success subscriber did not get retained message!");
+    //             }
+
+    //             // Clear the retained message
+    //             publisher.publish(publishPacketBuilder.build()).get(180, TimeUnit.SECONDS);
+
+    //             // Wait 15 seconds to give the server time to clear everything out
+    //             Thread.sleep(15000);
+
+    //             // Connect the unsuccessful subscriber
+    //             unsuccessfulSubscriber.start();
+    //             unsuccessfulSubscriberEvents.connectedFuture.get(180, TimeUnit.SECONDS);
+    //             unsuccessfulSubscriber.subscribe(subscribePacketBuilder.build()).get(180, TimeUnit.SECONDS);
+    //             // Make sure we do NOT get a publish
+    //             boolean didExceptionOccur = false;
+    //             try {
+    //                 unsuccessfulSubscriberPublishEvents.publishReceivedFuture.get(30, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 didExceptionOccur = true;
+    //             }
+
+    //             if (didExceptionOccur == false) {
+    //                 fail("Unsuccessful subscriber got retained message even though it should be cleared!");
+    //             }
+
+    //             // Disconnect all clients
+    //             DisconnectPacketBuilder disconnectPacketBuilder = new DisconnectPacketBuilder();
+    //             publisher.stop(disconnectPacketBuilder.build());
+    //             publisherEvents.stopFuture.get(180, TimeUnit.SECONDS);
+    //             successSubscriber.stop(disconnectPacketBuilder.build());
+    //             successSubscriberEvents.stopFuture.get(180, TimeUnit.SECONDS);
+    //             unsuccessfulSubscriber.stop(disconnectPacketBuilder.build());
+    //             unsuccessfulSubscriberEvents.stopFuture.get(180, TimeUnit.SECONDS);
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // /**
+    //  * ============================================================
+    //  * Operation Interrupt Tests
+    //  * ============================================================
+    //  */
+
+    // // Subscribe interrupt test
+    // @Test
+    // public void Interrupt_Sub_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             SubscribePacketBuilder subscribePacketBuilder = new SubscribePacketBuilder();
+    //             subscribePacketBuilder.withSubscription(testTopic, QOS.AT_LEAST_ONCE);
+
+    //             try {
+    //                 CompletableFuture<SubAckPacket> subscribeResult = client.subscribe(subscribePacketBuilder.build());
+    //                 client.stop(new DisconnectPacketBuilder().build());
+    //                 SubAckPacket packet = subscribeResult.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 if (ex.getCause().getClass() == CrtRuntimeException.class) {
+    //                     CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+    //                     if (exCrt.errorCode != 5153) {
+    //                         System.out.println("Exception ocurred when stopping subscribe" +
+    //                             "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+    //                     }
+    //                 }
+    //             }
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // // Unsubscribe interrupt test
+    // @Test
+    // public void Interrupt_Unsub_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             UnsubscribePacketBuilder unsubscribePacketBuilder = new UnsubscribePacketBuilder();
+    //             unsubscribePacketBuilder.withSubscription(testTopic);
+
+    //             try {
+    //                 CompletableFuture<UnsubAckPacket> unsubscribeResult = client.unsubscribe(unsubscribePacketBuilder.build());
+    //                 client.stop(new DisconnectPacketBuilder().build());
+    //                 UnsubAckPacket packet = unsubscribeResult.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 if (ex.getCause().getClass() == CrtRuntimeException.class) {
+    //                     CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+    //                     if (exCrt.errorCode != 5153) {
+    //                         System.out.println("Exception ocurred when stopping unsubscribe" +
+    //                             "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+    //                     }
+    //                 }
+    //             }
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
+
+    // // Publish interrupt test
+    // @Test
+    // public void Interrupt_Publish_UC1() {
+    //     skipIfNetworkUnavailable();
+    //     Assume.assumeTrue(checkMinimumDirectHostAndPort());
+    //     String testUUID = UUID.randomUUID().toString();
+    //     String testTopic = "test/MQTT5_Binding_Java_" + testUUID;
+
+    //     try {
+    //         Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(getMinimumDirectHost(), getMinimumDirectPort());
+    //         LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+    //         builder.withLifecycleEvents(events);
+
+    //         // Only needed for IoT Core
+    //         TlsContext tlsContext = null;
+    //         if (getMinimumDirectHost() == mqtt5IoTCoreMqttHost && mqtt5IoTCoreMqttCertificateBytes != null) {
+    //             Assume.assumeTrue(getMinimumDirectCert() != null);
+    //             Assume.assumeTrue(getMinimumDirectKey() != null);
+    //             tlsContext = getIoTCoreTlsContext();
+    //             builder.withTlsContext(tlsContext);
+    //         }
+
+    //         try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+    //             client.start();
+    //             events.connectedFuture.get(180, TimeUnit.SECONDS);
+
+    //             PublishPacketBuilder publishPacketBuilder = new PublishPacketBuilder();
+    //             publishPacketBuilder.withTopic(testTopic).withQOS(QOS.AT_LEAST_ONCE).withPayload("null".getBytes());
+
+    //             try {
+    //                 CompletableFuture<PublishResult> publishResult = client.publish(publishPacketBuilder.build());
+    //                 client.stop(new DisconnectPacketBuilder().build());
+    //                 PublishResult publishData = publishResult.get(180, TimeUnit.SECONDS);
+    //             } catch (Exception ex) {
+    //                 if (ex.getCause().getClass() == CrtRuntimeException.class) {
+    //                     CrtRuntimeException exCrt = (CrtRuntimeException)ex.getCause();
+    //                     if (exCrt.errorCode != 5153) {
+    //                         System.out.println("Exception ocurred when stopping publish" +
+    //                             "but it was not AWS_ERROR_MQTT5_USER_REQUESTED_STOP like expected");
+    //                     }
+    //                 }
+    //             }
+    //         }
+
+    //         if (tlsContext != null) {
+    //             tlsContext.close();
+    //         }
+
+    //     } catch (Exception ex) {
+    //         fail(ex.getMessage());
+    //     }
+    // }
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -121,7 +121,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         if (System.getenv("AWS_TEST_MQTT5_PROXY_PORT") != null) {
             mqtt5ProxyPort = Long.parseLong(System.getenv("AWS_TEST_MQTT5_PROXY_PORT"));
         }
-        mqtt5ProxyHost = System.getenv("AWS_TEST_MQTT5_PROXY_PERFORM_TEST");
+        mqtt5ProxyPerformTest = System.getenv("AWS_TEST_MQTT5_PROXY_PERFORM_TEST");
         mqtt5CertificateFile = System.getenv("AWS_TEST_MQTT5_CERTIFICATE_FILE");
         mqtt5KeyFile = System.getenv("AWS_TEST_MQTT5_KEY_FILE");
 
@@ -637,8 +637,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5ProxyHost != null);
         Assume.assumeTrue(mqtt5ProxyPort != null);
         Assume.assumeTrue(mqtt5ProxyPerformTest != null);
-
-        System.out.println("PROXY TEST IS GOING TO RUN!!!");
 
         try {
 

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -640,9 +640,6 @@ public class Mqtt5ClientTest extends CrtTestFixture {
         Assume.assumeTrue(mqtt5ProxyMqttHost != null);
         Assume.assumeTrue(mqtt5ProxyMqttPort != null);
 
-        // Enable logging (hopefully it will help show what is wrong)
-        Log.initLoggingToStdout(LogLevel.Trace);
-
         try {
             try (
                 EventLoopGroup elg = new EventLoopGroup(1);
@@ -664,8 +661,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 tlsContext = getIoTCoreTlsContext();
                 builder.withTlsContext(tlsContext);
 
-                // Set the TLS in the proxy
-                // proxyOptions.setTlsContext(getIoTCoreTlsContext());
+                // Set the HTTP proxy
                 builder.withHttpProxyOptions(proxyOptions);
 
                 try (Mqtt5Client client = new Mqtt5Client(builder.build())) {

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -630,7 +630,7 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     @Test
     public void ConnDC_UC5() {
         skipIfNetworkUnavailable();
-        // Only perform against IoT Core on Codebuild
+        // We need a cert/key for TLS (IoT Core)
         Assume.assumeTrue(getMinimumDirectCert() != null);
         Assume.assumeTrue(getMinimumDirectKey() != null);
         // Proxy stuff
@@ -655,12 +655,15 @@ public class Mqtt5ClientTest extends CrtTestFixture {
                 proxyOptions.setHost(mqtt5ProxyHost);
                 proxyOptions.setPort((mqtt5ProxyPort.intValue()));
                 proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
-                builder.withHttpProxyOptions(proxyOptions);
 
-                // Needed for IoT Core
+                // Needed for TLS (IoT Core)
                 TlsContext tlsContext = null;
                 tlsContext = getIoTCoreTlsContext();
                 builder.withTlsContext(tlsContext);
+
+                // Set the TLS in the proxy
+                proxyOptions.setTlsContext(getIoTCoreTlsContext());
+                builder.withHttpProxyOptions(proxyOptions);
 
                 try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
                     client.start();

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -621,53 +621,52 @@ public class Mqtt5ClientTest extends CrtTestFixture {
     }
 
     /* Direct connection with HttpProxyOptions */
-    /* NOTE: Might not work initially on Codebuild Mosquitto - will need to test on its own */
-    // @Test
-    // public void ConnDC_UC5() {
-    //     skipIfNetworkUnavailable();
-    //     Assume.assumeTrue(mqtt5DirectMqttTlsHost != null);
-    //     Assume.assumeTrue(mqtt5DirectMqttTlsPort != null);
-    //     Assume.assumeTrue(mqtt5ProxyHost != null);
-    //     Assume.assumeTrue(mqtt5ProxyPort != null);
+    @Test
+    public void ConnDC_UC5() {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(mqtt5DirectMqttTlsHost != null);
+        Assume.assumeTrue(mqtt5DirectMqttTlsPort != null);
+        Assume.assumeTrue(mqtt5ProxyHost != null);
+        Assume.assumeTrue(mqtt5ProxyPort != null);
 
-    //     try {
+        try {
 
-    //         try (
-    //             EventLoopGroup elg = new EventLoopGroup(1);
-    //             HostResolver hr = new HostResolver(elg);
-    //             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-    //         ) {
-    //             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
-    //             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
-    //             builder.withLifecycleEvents(events);
-    //             builder.withBootstrap(bootstrap);
+            try (
+                EventLoopGroup elg = new EventLoopGroup(1);
+                HostResolver hr = new HostResolver(elg);
+                ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+            ) {
+                LifecycleEvents_Futured events = new LifecycleEvents_Futured();
+                Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(mqtt5DirectMqttTlsHost, mqtt5DirectMqttTlsPort);
+                builder.withLifecycleEvents(events);
+                builder.withBootstrap(bootstrap);
 
-    //             HttpProxyOptions proxyOptions = new HttpProxyOptions();
-    //             proxyOptions.setHost(mqtt5ProxyHost);
-    //             proxyOptions.setPort((mqtt5ProxyPort.intValue()));
-    //             proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
+                HttpProxyOptions proxyOptions = new HttpProxyOptions();
+                proxyOptions.setHost(mqtt5ProxyHost);
+                proxyOptions.setPort((mqtt5ProxyPort.intValue()));
+                proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
 
-    //             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
-    //                 tlsOptions.withVerifyPeer(false);
-    //                 try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
-    //                     builder.withTlsContext(tlsContext);
+                try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
+                    tlsOptions.withVerifyPeer(false);
+                    try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
+                        builder.withTlsContext(tlsContext);
 
-    //                     builder.withHttpProxyOptions(proxyOptions);
+                        builder.withHttpProxyOptions(proxyOptions);
 
-    //                     try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
-    //                         client.start();
-    //                         events.connectedFuture.get(180, TimeUnit.SECONDS);
-    //                         DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
-    //                         client.stop(disconnect.build());
-    //                     }
-    //                 }
-    //             }
-    //         }
+                        try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
+                            client.start();
+                            events.connectedFuture.get(180, TimeUnit.SECONDS);
+                            DisconnectPacketBuilder disconnect = new DisconnectPacketBuilder();
+                            client.stop(disconnect.build());
+                        }
+                    }
+                }
+            }
 
-    //     } catch (Exception ex) {
-    //         fail(ex.getMessage());
-    //     }
-    // }
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
 
     /* Maximum options set connection test */
     @Test


### PR DESCRIPTION
*Description of changes:*

Adds installing and running Mosquitto in Codebuild CI. This makes our Codebuild CI more standalone and ensures we can always run the basic MQTT5 tests.
- Doing this required modifying the HTTP proxy tests to run against IoT Core.
- Adds a shell script to install Mosquttio (and dependencies) in Codebuild. Building from source to use version new enough to work for our purposes (`apt-get` uses too old of a version for what we need).
  - Unfortunately this adds about 6-10 minutes of extra time to the Codebuild Job.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
