### PR TITLE
Add serializable to clients

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/mqtt/MqttClient.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt/MqttClient.java
@@ -10,6 +10,8 @@ import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.ClientBootstrap;
 import software.amazon.awssdk.crt.io.TlsContext;
 
+import java.io.Serializable;
+
 /**
  * This class wraps aws-c-mqtt to provide the basic MQTT pub/sub functionalities
  * via the AWS Common Runtime
@@ -17,7 +19,7 @@ import software.amazon.awssdk.crt.io.TlsContext;
  * One MqttClient class is needed per application. It can create any number of connections to
  * any number of MQTT endpoints
  */
-public class MqttClient extends CrtResource {
+public class MqttClient extends CrtResource implements Serializable {
 
     private TlsContext tlsContext;
 

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5Client.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/Mqtt5Client.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.awssdk.crt.mqtt5;
 
+import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -34,7 +35,7 @@ import software.amazon.awssdk.crt.mqtt5.packets.ConnectPacket.ConnectPacketBuild
  * preview window is especially valuable in shaping the final product.  During the preview period we may make
  * backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
  */
-public class Mqtt5Client extends CrtResource {
+public class Mqtt5Client extends CrtResource implements Serializable {
 
     /**
      * A private reference to the websocket handshake from the MQTT5 client options


### PR DESCRIPTION
Description of changes:

Add serializable to the clients, this would help to work in Spark for example, since it needs the objects to be serializable


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
