### PR TITLE
remove experimental for `Platform-Specific JARs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ From the aws-crt-java directory:
 ```mvn install```
 From maven: (https://search.maven.org/artifact/software.amazon.awssdk.crt/aws-crt/)
 
-## Platform-Specific JARs [experimental]
+## Platform-Specific JARs
 
 The `aws-crt` JAR in Maven Central is a large "uber" jar that contains compiled C libraries for many different platforms (Windows, Linux, etc). If size is an issue, you can pick a smaller platform-specific JAR by setting the `<classifier>`.
 


### PR DESCRIPTION
- Remove experimental flag from `Platform-Specific JARs` from readme.
  - As we have released the feature for months and nothing breaks, it's probably good
  - And people are not willing to take that with experimental flag


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
