### PR TITLE
forgot to release the jni lock before return

### DIFF
--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -328,6 +328,8 @@ static int s_on_s3_meta_request_body_callback(
     if (jni_payload == NULL) {
         /* JVM is out of memory, but native code can still have memory available, handle it and don't crash. */
         aws_jni_check_and_clear_exception(env);
+        aws_jni_release_thread_env(callback_data->jvm, env);
+        /********** JNI ENV RELEASE **********/
         return aws_raise_error(AWS_ERROR_JAVA_CRT_JVM_OUT_OF_MEMORY);
     }
 


### PR DESCRIPTION
*Issue #, if available:*

- follow up fix for https://github.com/awslabs/aws-crt-java/pull/602

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
