### PR TITLE
Add void to aws_jni_get_allocator()

### DIFF
--- a/src/native/crt.c
+++ b/src/native/crt.c
@@ -42,7 +42,7 @@ static struct aws_allocator *s_init_allocator(void) {
 }
 
 static struct aws_allocator *s_allocator = NULL;
-struct aws_allocator *aws_jni_get_allocator() {
+struct aws_allocator *aws_jni_get_allocator(void) {
     if (AWS_UNLIKELY(s_allocator == NULL)) {
         s_allocator = s_init_allocator();
     }


### PR DESCRIPTION
* aws_jni_get_allocator(void) to fix strict prototypes error


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
