### PR TITLE
Update integration test Codebuild spec

### DIFF
--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -1,18 +1,11 @@
 version: 0.2
-#this build spec assumes the ubuntu aws/codebuild/java:openjdk-8 image
 phases:
   install:
     commands:
       - sudo add-apt-repository ppa:openjdk-r/ppa
       - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       - sudo apt-get update -y
-      - sudo apt-get install gcc-7 cmake3 ninja-build -y
-      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
-      - unzip -q -d /tmp /tmp/awscliv2.zip
-      - sudo /tmp/aws/install
-  pre_build:
-    commands:
-      - export CC=gcc-7
+      - sudo apt-get install cmake -y
   build:
     commands:
       - echo Build started on `date`


### PR DESCRIPTION
*Description of changes:*

To get the aws-crt-builder running in CI I needed to change the Codebuild image, but this broke the existing CI because the Codebuild spec references stuff that is really old. This fixes the Codebuild CI.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
