### PR TITLE
Skip test if httpbin.org responds with with server error

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -8,6 +8,7 @@ package software.amazon.awssdk.crt.test;
 import static software.amazon.awssdk.crt.utils.ByteBufferUtils.transferData;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
@@ -98,9 +99,10 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
         }
 
         Assert.assertTrue(hasContentLengthHeader);
-        if (response.statusCode < 500) { // if the server errored, not our fault
-            Assert.assertEquals("Expected and Actual Status Codes don't match", expectedStatus, response.statusCode);
-        }
+
+        Assume.assumeTrue("The server errored, not our fault, skip test", response.statusCode < 500);
+
+        Assert.assertEquals("Expected and Actual Status Codes don't match", expectedStatus, response.statusCode);
 
         return response;
     }


### PR DESCRIPTION
**Issue:**
The `testHttpUpload` tests have been increasingly flaky lately, due to httpbin.org returning 504 Gateway Time-out.

**Description of changes:**
Skip test if httpbin.org returns a 5xx. There was already code to ignore 5xx status codes, but now we officially skip the whole test.

This unblocks us, but it's not a long term fix. Long term we should stop hitting httpbin.org. The httpbin project seems to be [abandonded](https://github.com/postmanlabs/httpbin/issues/673#issuecomment-1247410146). I can't even get the latest version running locally, due to its dependencies changing out from under it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
