### PR TITLE
Move to postman-echo.com from httpbin.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           mvn -B compile -P mac-arm64
-          mvn test
       - name: verify backward compatibility
         run: |
           python3 codebuild/macos_compatibility_check.py armv8
@@ -164,7 +163,6 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           mvn -B compile -P mac-x64
-          mvn test
       - name: verify backward compatibility
         run: |
           python3 codebuild/macos_compatibility_check.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.40
+  BUILDER_VERSION: v0.9.43
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-java
@@ -20,7 +20,7 @@ env:
 
 jobs:
   linux-compat:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     strategy:
       matrix:
         image:
@@ -42,7 +42,7 @@ jobs:
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
 
   linux-compiler-compat:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     strategy:
       matrix:
         compiler:
@@ -69,7 +69,7 @@ jobs:
 
   linux-arm:
     name: ARM (${{ matrix.arch }})
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     strategy:
       matrix:
         arch: [armv6, armv7, arm64]
@@ -81,7 +81,7 @@ jobs:
           ./builder build -p ${{ env.PACKAGE_NAME }} --target=linux-${{ matrix.arch }} --spec=downstream
 
   raspberry:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +127,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }} downstream
 
   osx:  # With integration tests
-    runs-on: macos-11 # latest
+    runs-on: macos-13 # latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
@@ -140,7 +140,7 @@ jobs:
           ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   osx-arm64:
-    runs-on: macos-11 # latest
+    runs-on: macos-13 # latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3
@@ -149,12 +149,13 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           mvn -B compile -P mac-arm64
+          mvn test
       - name: verify backward compatibility
         run: |
           python3 codebuild/macos_compatibility_check.py armv8
 
   osx-x64:
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
@@ -163,6 +164,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           mvn -B compile -P mac-x64
+          mvn test
       - name: verify backward compatibility
         run: |
           python3 codebuild/macos_compatibility_check.py
@@ -182,7 +184,7 @@ jobs:
 
   # check that docs can still build
   check-docs:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -192,7 +194,7 @@ jobs:
           ./make-docs.sh
 
   check-submodules:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
@@ -206,7 +208,7 @@ jobs:
 
 
   localhost-test-linux:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -224,7 +226,7 @@ jobs:
         python builder.pyz localhost-test -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   localhost-test-mac:
-    runs-on: macos-11 # latest
+    runs-on: macos-13 # latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
@@ -26,7 +26,7 @@ import software.amazon.awssdk.crt.CrtResource;
 
 public class Http2ClientConnectionTest extends HttpClientTestFixture {
 
-    private final static String HOST = "https://httpbin.org";
+    private final static String HOST = "https://postman-echo.com";
     private final static HttpVersion EXPECTED_VERSION = HttpVersion.HTTP_2;
 
     @Test

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -201,6 +201,8 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
                 try (Http2Stream h2Stream = conn.makeRequest(request, streamHandler)) {
                     h2Stream.activate();
                     streamComplete.get();
+                } catch(Exception e) {
+                    // ignoring the exception as it might fail that RST_STREAM has been sent.
                 }
             }
         } catch (Exception e) {

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 public class Http2RequestResponseTest extends HttpRequestResponseFixture {
-    private final static String HOST = "https://httpbin.org";
+    private final static String HOST = "https://postman-echo.com";
     private final static HttpVersion EXPECTED_VERSION = HttpVersion.HTTP_2;
 
     private Http2Request getHttp2Request(String method, String endpoint, String path, String requestBody)
@@ -114,27 +114,27 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
     @Test
     public void testHttp2Get() throws Exception {
         Assume.assumeTrue(System.getProperty("NETWORK_TESTS_DISABLED") == null);
-        testHttp2Request("GET", HOST, "/delete", EMPTY_BODY, 405);
+        testHttp2Request("GET", HOST, "/delete", EMPTY_BODY, 404);
         testHttp2Request("GET", HOST, "/get", EMPTY_BODY, 200);
-        testHttp2Request("GET", HOST, "/post", EMPTY_BODY, 405);
-        testHttp2Request("GET", HOST, "/put", EMPTY_BODY, 405);
+        testHttp2Request("GET", HOST, "/post", EMPTY_BODY, 404);
+        testHttp2Request("GET", HOST, "/put", EMPTY_BODY, 404);
     }
 
     @Test
     public void testHttp2Post() throws Exception {
         skipIfNetworkUnavailable();
-        testHttp2Request("POST", HOST, "/delete", EMPTY_BODY, 405);
-        testHttp2Request("POST", HOST, "/get", EMPTY_BODY, 405);
+        testHttp2Request("POST", HOST, "/delete", EMPTY_BODY, 404);
+        testHttp2Request("POST", HOST, "/get", EMPTY_BODY, 404);
         testHttp2Request("POST", HOST, "/post", EMPTY_BODY, 200);
-        testHttp2Request("POST", HOST, "/put", EMPTY_BODY, 405);
+        testHttp2Request("POST", HOST, "/put", EMPTY_BODY, 404);
     }
 
     @Test
     public void testHttp2Put() throws Exception {
         skipIfNetworkUnavailable();
-        testHttp2Request("PUT", HOST, "/delete", EMPTY_BODY, 405);
-        testHttp2Request("PUT", HOST, "/get", EMPTY_BODY, 405);
-        testHttp2Request("PUT", HOST, "/post", EMPTY_BODY, 405);
+        testHttp2Request("PUT", HOST, "/delete", EMPTY_BODY, 404);
+        testHttp2Request("PUT", HOST, "/get", EMPTY_BODY, 404);
+        testHttp2Request("PUT", HOST, "/post", EMPTY_BODY, 404);
         testHttp2Request("PUT", HOST, "/put", EMPTY_BODY, 200);
     }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -200,6 +200,8 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
                 Http2Request request = getHttp2Request("GET", HOST, "/get", EMPTY_BODY);
                 try (Http2Stream h2Stream = conn.makeRequest(request, streamHandler)) {
                     h2Stream.activate();
+                }
+                try {
                     streamComplete.get();
                 } catch(Exception e) {
                     // ignoring the exception as it might fail that RST_STREAM has been sent.

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -200,10 +200,9 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
                 Http2Request request = getHttp2Request("GET", HOST, "/get", EMPTY_BODY);
                 try (Http2Stream h2Stream = conn.makeRequest(request, streamHandler)) {
                     h2Stream.activate();
-                }
-                try {
                     streamComplete.get();
-                } catch(Exception e) {
+                }
+                catch(Exception e) {
                     // ignoring the exception as it might fail that RST_STREAM has been sent.
                 }
             }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 public class HttpRequestResponseTest extends HttpRequestResponseFixture {
+    private final static String HOST = "https://postman-echo.com";
 
     public TestHttpResponse testRequest(String method, String endpoint, String path, String requestBody,
             boolean useChunkedEncoding, int expectedStatus) throws Exception {
@@ -108,46 +109,46 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
     @Test
     public void testHttpDelete() throws Exception {
         skipIfNetworkUnavailable();
-        testRequest("DELETE", "https://httpbin.org", "/delete", EMPTY_BODY, false, 200);
-        testRequest("DELETE", "https://httpbin.org", "/get", EMPTY_BODY, false, 405);
-        testRequest("DELETE", "https://httpbin.org", "/post", EMPTY_BODY, false, 405);
-        testRequest("DELETE", "https://httpbin.org", "/put", EMPTY_BODY, false, 405);
+        testRequest("DELETE", HOST, "/delete", EMPTY_BODY, false, 200);
+        testRequest("DELETE", HOST, "/get", EMPTY_BODY, false, 404);
+        testRequest("DELETE", HOST, "/post", EMPTY_BODY, false, 404);
+        testRequest("DELETE", HOST, "/put", EMPTY_BODY, false, 404);
     }
 
     @Test
     public void testHttpGet() throws Exception {
         skipIfNetworkUnavailable();
-        testRequest("GET", "https://httpbin.org", "/delete", EMPTY_BODY, false, 405);
-        testRequest("GET", "https://httpbin.org", "/get", EMPTY_BODY, false, 200);
-        testRequest("GET", "https://httpbin.org", "/post", EMPTY_BODY, false, 405);
-        testRequest("GET", "https://httpbin.org", "/put", EMPTY_BODY, false, 405);
+        testRequest("GET", HOST, "/delete", EMPTY_BODY, false, 404);
+        testRequest("GET", HOST, "/get", EMPTY_BODY, false, 200);
+        testRequest("GET", HOST, "/post", EMPTY_BODY, false, 404);
+        testRequest("GET", HOST, "/put", EMPTY_BODY, false, 404);
     }
 
     @Test
     public void testHttpPost() throws Exception {
         skipIfNetworkUnavailable();
-        testRequest("POST", "https://httpbin.org", "/delete", EMPTY_BODY, false, 405);
-        testRequest("POST", "https://httpbin.org", "/get", EMPTY_BODY, false, 405);
-        testRequest("POST", "https://httpbin.org", "/post", EMPTY_BODY, false, 200);
-        testRequest("POST", "https://httpbin.org", "/put", EMPTY_BODY, false, 405);
+        testRequest("POST", HOST, "/delete", EMPTY_BODY, false, 404);
+        testRequest("POST", HOST, "/get", EMPTY_BODY, false, 404);
+        testRequest("POST", HOST, "/post", EMPTY_BODY, false, 200);
+        testRequest("POST", HOST, "/put", EMPTY_BODY, false, 404);
     }
 
     @Test
     public void testHttpPut() throws Exception {
         skipIfNetworkUnavailable();
-        testRequest("PUT", "https://httpbin.org", "/delete", EMPTY_BODY, false, 405);
-        testRequest("PUT", "https://httpbin.org", "/get", EMPTY_BODY, false, 405);
-        testRequest("PUT", "https://httpbin.org", "/post", EMPTY_BODY, false, 405);
-        testRequest("PUT", "https://httpbin.org", "/put", EMPTY_BODY, false, 200);
+        testRequest("PUT", HOST, "/delete", EMPTY_BODY, false, 404);
+        testRequest("PUT", HOST, "/get", EMPTY_BODY, false, 404);
+        testRequest("PUT", HOST, "/post", EMPTY_BODY, false, 404);
+        testRequest("PUT", HOST, "/put", EMPTY_BODY, false, 200);
     }
 
     @Test
     public void testHttpResponseStatusCodes() throws Exception {
         skipIfNetworkUnavailable();
-        testRequest("GET", "https://httpbin.org", "/status/200", EMPTY_BODY, false, 200);
-        testRequest("GET", "https://httpbin.org", "/status/300", EMPTY_BODY, false, 300);
-        testRequest("GET", "https://httpbin.org", "/status/400", EMPTY_BODY, false, 400);
-        testRequest("GET", "https://httpbin.org", "/status/500", EMPTY_BODY, false, 500);
+        testRequest("GET", HOST, "/status/200", EMPTY_BODY, false, 200);
+        testRequest("GET", HOST, "/status/300", EMPTY_BODY, false, 300);
+        testRequest("GET", HOST, "/status/400", EMPTY_BODY, false, 400);
+        testRequest("GET", HOST, "/status/500", EMPTY_BODY, false, 500);
     }
 
     @Test
@@ -177,13 +178,13 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
     private void testHttpUpload(boolean chunked) throws Exception {
         skipIfNetworkUnavailable();
         String bodyToSend = TEST_DOC_LINE;
-        TestHttpResponse response = testRequest("PUT", "https://httpbin.org", "/anything", bodyToSend, chunked, 200);
+        TestHttpResponse response = testRequest("PUT", HOST, "/put", bodyToSend, chunked, 200);
 
         // Get the Body bytes that were echoed back to us
         String body = response.getBody();
 
         /**
-         * Example Json Response Body from httpbin.org:
+         * Example Json Response Body from postman-echo.com:
          *
          * {
          * "args": {},
@@ -194,12 +195,11 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
          * "form": {},
          * "headers": {
          * "Content-Length": "166",
-         * "Host": "httpbin.org"
+         * "Host": "postman-echo.com"
          * },
          * "json": null,
          * "method": "PUT",
          * "origin": "1.2.3.4, 5.6.7.8",
-         * "url": "https://httpbin.org/anything"
          * }
          *
          */
@@ -240,7 +240,7 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
     public void testHttpRequestUnActivated() throws Exception {
         skipIfNetworkUnavailable();
 
-        URI uri = new URI("https://httpbin.org");
+        URI uri = new URI(HOST);
 
         HttpHeader[] requestHeaders = new HttpHeader[] { new HttpHeader("Host", uri.getHost()) };
 


### PR DESCRIPTION
*Description of changes:*
- Replace httpbin.org with postman-echo.com as httpbin.org is abandoned and flaky.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
