### PR TITLE
Fix Codebuild YAML to point to the correct builder source

### DIFF
--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -3,8 +3,8 @@ version: 0.2
 env:
   shell: bash
   variables:
-    BUILDER_VERSION: setup_crt_ci_from_action
-    BUILDER_SOURCE: channels
+    BUILDER_VERSION: v0.9.45
+    BUILDER_SOURCE: releases
     BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
     PACKAGE_NAME: aws-crt-java
 


### PR DESCRIPTION
*Description of changes:*

I also missed the Codebuild YAML pointing to the wrong builder version... This PR fixes it.

____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
