### PR TITLE
use gradlew in root folder instead of /android

### DIFF
--- a/codebuild/cd/deploy-snapshot-android.sh
+++ b/codebuild/cd/deploy-snapshot-android.sh
@@ -3,6 +3,6 @@ cd ./android
 
 GPG_KEY=$(cat /tmp/aws-sdk-common-runtime.key.asc)
 # Publish to nexus
-./gradlew -PsigningKey=$"$GPG_KEY" -PsigningPassword=$GPG_PASSPHRASE -PsonatypeUsername='aws-sdk-common-runtime' -PsonatypePassword=$ST_PASSWORD publishToAwsNexus closeAwsNexusStagingRepository | tee /tmp/android_deploy.log
+../gradlew -PsigningKey=$"$GPG_KEY" -PsigningPassword=$GPG_PASSPHRASE -PsonatypeUsername='aws-sdk-common-runtime' -PsonatypePassword=$ST_PASSWORD publishToAwsNexus closeAwsNexusStagingRepository | tee /tmp/android_deploy.log
 # Get the staging repository id and save it
 cat /tmp/android_deploy.log | grep "Created staging repository" | cut -d\' -f2 | tee /tmp/android_repositoryId.txt


### PR DESCRIPTION
* use gradlew in root folder instead of removed duplicate copy


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
