### PR TITLE
Change jstring to deep copies to prevent garbage collection in android

### DIFF
--- a/src/native/aws_signing.c
+++ b/src/native/aws_signing.c
@@ -343,7 +343,7 @@ int aws_build_signing_config(
 
     jstring signed_body_value =
         (jstring)(*env)->GetObjectField(env, java_config, aws_signing_config_properties.signed_body_value_field_id);
-    if(signed_body_value == NULL){
+    if (signed_body_value == NULL){
         AWS_ZERO_STRUCT(config->signed_body_value);
     } else {
         config_data->signed_body_value = aws_jni_new_string_from_jstring(env, signed_body_value);

--- a/src/native/aws_signing.c
+++ b/src/native/aws_signing.c
@@ -343,7 +343,7 @@ int aws_build_signing_config(
 
     jstring signed_body_value =
         (jstring)(*env)->GetObjectField(env, java_config, aws_signing_config_properties.signed_body_value_field_id);
-    if (signed_body_value == NULL){
+    if (signed_body_value == NULL) {
         AWS_ZERO_STRUCT(config->signed_body_value);
     } else {
         config_data->signed_body_value = aws_jni_new_string_from_jstring(env, signed_body_value);

--- a/src/native/aws_signing.c
+++ b/src/native/aws_signing.c
@@ -341,7 +341,8 @@ int aws_build_signing_config(
     config->flags.omit_session_token =
         (*env)->GetBooleanField(env, java_config, aws_signing_config_properties.omit_session_token_field_id);
 
-    jstring signed_body_value = (jstring)(*env)->GetObjectField(env, java_config, aws_signing_config_properties.signed_body_value_field_id);
+    jstring signed_body_value =
+        (jstring)(*env)->GetObjectField(env, java_config, aws_signing_config_properties.signed_body_value_field_id);
     if(signed_body_value == NULL){
         AWS_ZERO_STRUCT(config->signed_body_value);
     } else {

--- a/src/native/aws_signing.h
+++ b/src/native/aws_signing.h
@@ -13,12 +13,9 @@ struct aws_signing_config_aws;
 
 struct aws_signing_config_data {
     JavaVM *jvm;
-    jstring region;
-    struct aws_byte_cursor region_cursor;
-    jstring service;
-    struct aws_byte_cursor service_cursor;
-    jstring signed_body_value;
-    struct aws_byte_cursor signed_body_value_cursor;
+    struct aws_string *region;
+    struct aws_string *service;
+    struct aws_string *signed_body_value;
 
     jobject java_sign_header_predicate;
     struct aws_credentials *credentials;


### PR DESCRIPTION
Android specific fix to prevent crashes resulting from garbage collection of jstrings


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
