### PR TITLE
Support systems with both glibc and Musl

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ a classifier-based jar, you must specify the classifier name yourself.
   <dependencies>
 ```
 
+## System Properties
+
+-  To enable logging, set `aws.crt.log.destination` or `aws.crt.log.level`:
+    - `aws.crt.log.level` - Log level. May be: "None", "Fatal", "Error", "Warn" (default), "Info", "Debug", "Trace". 
+    - `aws.crt.log.destination` - Log destination. May be: "Stderr" (default), "Stdout", "File", "None".
+    - `aws.crt.log.filename` - File to use when `-Daws.crt.log.destination=File`.
+- `aws.crt.libc` - (Linux only) Set to "musl" or "glibc" if CRT is cannot properly detect which to use.
+- `aws.crt.lib.dir` - Set directory where CRT may extract its native library (by default, "java.io.tmpdir" is used)
+- `aws.crt.memory.tracing` - Enable tracking native memory usage. May be: "0" (default), "1" (track bytes), "2" (more detail). Enables the CRT.nativeMemory() and CRT.dumpNativeMemory() functions.
+
 ## Mac-Only TLS Behavior
 
 Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain. All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v0.6.6, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ a classifier-based jar, you must specify the classifier name yourself.
     - `aws.crt.log.level` - Log level. May be: "None", "Fatal", "Error", "Warn" (default), "Info", "Debug", "Trace".
     - `aws.crt.log.destination` - Log destination. May be: "Stderr" (default), "Stdout", "File", "None".
     - `aws.crt.log.filename` - File to use when `aws.crt.log.destination` is "File".
-- `aws.crt.libc` - (Linux only) Set to "musl" or "glibc" if CRT is cannot properly detect which to use.
+- `aws.crt.libc` - (Linux only) Set to "musl" or "glibc" if CRT cannot properly detect which to use.
 - `aws.crt.lib.dir` - Set directory where CRT may extract its native library (by default, `java.io.tmpdir` is used)
 - `aws.crt.memory.tracing` - May be: "0" (default, no tracing), "1" (track bytes), "2" (more detail).
     Allows the CRT.nativeMemory() and CRT.dumpNativeMemory() functions to report native memory usage.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The `aws-crt` JAR in Maven Central is a large "uber" jar that contains compiled 
 The [os-maven-plugin](https://github.com/trustin/os-maven-plugin) can automatically detect your platform's classifier at build time.
 
 **NOTES**: The auto-detected `linux-arm_32` platform classifier is not supported, you must specify `linux-armv6` or `linux-armv7`.
-Additionally, musl vs glibc detection is not supported either.  If you are deploying to a musl-based system and wish to use 
+Additionally, musl vs glibc detection is not supported either.  If you are deploying to a musl-based system and wish to use
 a classifier-based jar, you must specify the classifier name yourself.
 
 ``` xml
@@ -127,13 +127,14 @@ a classifier-based jar, you must specify the classifier name yourself.
 
 ## System Properties
 
--  To enable logging, set `aws.crt.log.destination` or `aws.crt.log.level`:
-    - `aws.crt.log.level` - Log level. May be: "None", "Fatal", "Error", "Warn" (default), "Info", "Debug", "Trace". 
+- To enable logging, set `aws.crt.log.destination` or `aws.crt.log.level`:
+    - `aws.crt.log.level` - Log level. May be: "None", "Fatal", "Error", "Warn" (default), "Info", "Debug", "Trace".
     - `aws.crt.log.destination` - Log destination. May be: "Stderr" (default), "Stdout", "File", "None".
-    - `aws.crt.log.filename` - File to use when `-Daws.crt.log.destination=File`.
+    - `aws.crt.log.filename` - File to use when `aws.crt.log.destination` is "File".
 - `aws.crt.libc` - (Linux only) Set to "musl" or "glibc" if CRT is cannot properly detect which to use.
-- `aws.crt.lib.dir` - Set directory where CRT may extract its native library (by default, "java.io.tmpdir" is used)
-- `aws.crt.memory.tracing` - Enable tracking native memory usage. May be: "0" (default), "1" (track bytes), "2" (more detail). Enables the CRT.nativeMemory() and CRT.dumpNativeMemory() functions.
+- `aws.crt.lib.dir` - Set directory where CRT may extract its native library (by default, `java.io.tmpdir` is used)
+- `aws.crt.memory.tracing` - May be: "0" (default, no tracing), "1" (track bytes), "2" (more detail).
+    Allows the CRT.nativeMemory() and CRT.dumpNativeMemory() functions to report native memory usage.
 
 ## Mac-Only TLS Behavior
 

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -152,40 +152,78 @@ public final class CRT {
             return NON_LINUX_RUNTIME_TAG;
         }
 
-        Runtime rt = Runtime.getRuntime();
-        String[] commands = {"ldd", "--version"};
-        try {
-            java.lang.Process proc = rt.exec(commands);
+        // The system might have both musl and glibc on it:
+        // https://github.com/awslabs/aws-crt-java/issues/659
 
-            // the "normal" input stream of the proc is the stdout of the invoked command
-            BufferedReader stdOutput = new BufferedReader(new
-                    InputStreamReader(proc.getInputStream()));
-
-            // sometimes, ldd's output goes to stderr, so capture that too
-            BufferedReader stdError = new BufferedReader(new
-                    InputStreamReader(proc.getErrorStream()));
-
-            String line;
-            StringBuilder outputBuilder = new StringBuilder();
-            while ((line = stdOutput.readLine()) != null) {
-                outputBuilder.append(line);
+        // First, check which one java is using.
+        // Run: ldd $JAVA_HOME/bin/java
+        // If musl, has a line like: libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f7732ae4000)
+        // If glibc, has a line like: libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f112c894000)
+        String javaHome = System.getProperty("java.home");
+        if (javaHome != null) {
+            File javaExecutable = new File(new File(javaHome, "bin"), "java");
+            if (javaExecutable.exists()) {
+                try {
+                    String[] lddJavaCmd = {"ldd", javaExecutable.toString()};
+                    List<String> lddJavaOutput = runProcess(lddJavaCmd);
+                    for (String line : lddJavaOutput) {
+                        String lower = line.toLowerCase();
+                        if (lower.contains("libc")) {
+                            if (lower.contains("musl")) {
+                                return MUSL_RUNTIME_TAG;
+                            } else {
+                                return GLIBC_RUNTIME_TAG;
+                            }
+                        }
+                    }
+                    // uncertain, continue to next check
+                } catch (IOException ex) {
+                    // uncertain, continue to next check
+                }
             }
-
-            StringBuilder errorBuilder = new StringBuilder();
-            while ((line = stdError.readLine()) != null) {
-                errorBuilder.append(line);
-            }
-
-            String lddOutput = outputBuilder.toString();
-            String lddError = errorBuilder.toString();
-            if (lddOutput.contains("musl") || lddError.contains("musl")) {
-                return MUSL_RUNTIME_TAG;
-            } else {
-                return GLIBC_RUNTIME_TAG;
-            }
-        } catch (IOException io) {
-            return GLIBC_RUNTIME_TAG;
         }
+
+        // Next, check whether ldd says it's using musl
+        // Run: ldd --version
+        // If musl, has a line like: musl libc (x86_64)
+        try {
+            String[] lddVersionCmd = {"ldd", "--version"};
+            List<String> lddVersionOutput = runProcess(lddVersionCmd);
+            for (String line : lddVersionOutput) {
+                if (line.toLowerCase().contains("musl")) {
+                    return MUSL_RUNTIME_TAG;
+                }
+            }
+            // uncertain, continue to next check
+
+        } catch (IOException io) {
+            // uncertain, continue to next check
+        }
+
+        // Assume it's glibc
+        return GLIBC_RUNTIME_TAG;
+    }
+
+    // Run process and return lines of output.
+    // (ouput is stdout and stderr merged together)
+    // (exit code is ignored)
+    private static List<String> runProcess(String[] cmdArray) throws IOException {
+        java.lang.Process proc = new ProcessBuilder(cmdArray)
+                .redirectErrorStream(true)
+                .start();
+
+        BufferedReader outputReader = new BufferedReader(new
+                InputStreamReader(proc.getInputStream()));
+
+        String line;
+        List<String> output = new ArrayList<String>();
+        while ((line = outputReader.readLine()) != null) {
+            output.add(line);
+        }
+
+        proc.destroy();
+
+        return output;
     }
 
     private static void extractAndLoadLibrary(String path) {
@@ -432,4 +470,5 @@ public final class CRT {
     private static native void nativeCheckJniExceptionContract(boolean clearException);
 
     private static native void onJvmShutdown();
+
 };

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -153,11 +153,20 @@ public final class CRT {
             return NON_LINUX_RUNTIME_TAG;
         }
 
-        // The system might have both musl and glibc on it:
+        // If system property is set, use that.
+        String systemPropertyOverride = System.getProperty("aws.crt.libc");
+        if (systemPropertyOverride != null) {
+            systemPropertyOverride = systemPropertyOverride.toLowerCase().trim();
+            if (!systemPropertyOverride.isEmpty()) {
+                return systemPropertyOverride;
+            }
+        }
+
+        // Be warned, the system might have both musl and glibc on it:
         // https://github.com/awslabs/aws-crt-java/issues/659
 
-        // First, check which one java is using.
-        // Run: ldd $JAVA_HOME/bin/java
+        // Next, check which one java is using.
+        // Run: ldd /path/to/java
         // If musl, has a line like: libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f7732ae4000)
         // If glibc, has a line like: libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f112c894000)
         Pattern muslWord = Pattern.compile("\\bmusl\\b", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -209,13 +209,17 @@ public final class CRT {
     }
 
     // Run process and return lines of output.
-    // (ouput is stdout and stderr merged together)
-    // (exit code is ignored)
+    // Output is stdout and stderr merged together.
+    // The exit code is ignored.
+    // We do it this way because, on some Linux distros (Alpine),
+    // "ldd --version" reports exit code 1 and prints to stderr.
+    // But on most Linux distros it reports exit code 0 and prints to stdout.
     private static List<String> runProcess(String[] cmdArray) throws IOException {
         java.lang.Process proc = new ProcessBuilder(cmdArray)
-                .redirectErrorStream(true)
+                .redirectErrorStream(true) // merge stderr into stdout
                 .start();
 
+        // confusingly, getInputStream() gets you stdout
         BufferedReader outputReader = new BufferedReader(new
                 InputStreamReader(proc.getInputStream()));
 
@@ -224,8 +228,6 @@ public final class CRT {
         while ((line = outputReader.readLine()) != null) {
             output.add(line);
         }
-
-        proc.destroy();
 
         return output;
     }


### PR DESCRIPTION
**Issue #:** https://github.com/awslabs/aws-crt-java/issues/659

Customer has a system with both glibc and Musl on it. The system is Alpine-based, and uses Musl for most things. But the installed Java is using glibc.

aws-crt-java used to work on this system, back when the shared lib only worked with glibc. But as of [v0.23.0](https://github.com/awslabs/aws-crt-java/releases/tag/v0.23.0) we have different shared libs for glibc and Musl, and need to detect at runtime which to use.

Our current method checks only checks whether the system's built-in libraries use Musl.

**Description of changes:**

NEW: Let users specify "musl" or "glibc" via system property "aws.crt.libc".

NEW: Otherwise, check whether the current Java executable is using glibc or Musl.

And if those fail, fall back to the previous method of calling `ldd --version` to see if it mentions "musl".

**Testing:**

I tested this by hand. It would be a ton of effort to hook up regular CI for this. Seeing as this is such an edge-case, that feels sufficient.

I didn't touch the compile-time CMake logic, only the runtime logic. So you can't test this without using our released JARs (which have shared libs for every platform), or by preparing a JAR by hand with shared libs for both Musl and glibc. Again, since this is such an edge case, this level of effort seems sufficient.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
