### PR TITLE
Use properties for Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ static: certificate has an existing certificate-key pair that was previously imp
 ```
 
 ## Testing
-Many tests require environment variables to be set. These tests will be quietly skipped if their environment variables are not set.
+Many tests require environment variables to be set. These environment variables are translated at runtime to system properties for use by the tests. These tests will be quietly skipped if the properties they require are not set.
+
 Environment variables can be set like so:
 ```
 export ENV_VARIABLE_NAME="<variable value>"

--- a/README.md
+++ b/README.md
@@ -159,24 +159,25 @@ static: certificate has an existing certificate-key pair that was previously imp
 ```
 
 ## Testing
-Many tests require custom arguments. These tests will be quietly skipped if their arguments are not set.
-Arguments can be passed like so:
+Many tests require environment variables to be set. These tests will be quietly skipped if their environment variables are not set.
+Environment variables can be set like so:
 ```
-mvn test -Dcertificate=path/to/cert -Dprivatekey=path/to/key ...
+export ENV_VARIABLE_NAME="<variable value>"
 ```
 Many tests require that you have [set up](https://console.aws.amazon.com/iot) an AWS IoT Thing.
 
-Full list of test arguments:
-- `endpoint`: AWS IoT service endpoint hostname
-- `certificate`: Path to the IoT thing certificate
-- `privatekey`: Path to the IoT thing private key
-- `privatekey_p8`: Path to the IoT thing private key in PKCS#8 format
-- `ecc_certificate`: Path to the IoT thing with EC-based certificate
-- `ecc_privatekey`: Path to the IoT thing with ECC private key (The ECC key file should only contains the ECC Private Key section to working on MacOS.)
-- `rootca`: Path to the root certificate
-- `proxyhost`: Hostname of proxy
-- `proxyport`: Port of proxy
+Partial list of environment variables:
+- `AWS_TEST_MQTT311_IOT_CORE_HOST`: AWS IoT service endpoint hostname for MQTT3
+- `AWS_TEST_MQTT311_IOT_CORE_RSA_CERT`: Path to the IoT thing certificate for MQTT3
+- `AWS_TEST_MQTT311_IOT_CORE_RSA_KEY`: Path to the IoT thing private key for MQTT3
+- `AWS_TEST_MQTT311_IOT_CORE_ECC_CERT`: Path to the IoT thing with EC-based certificate for MQTT3
+- `AWS_TEST_MQTT311_IOT_CORE_ECC_KEY`: Path to the IoT thing with ECC private key for MQTT3 (The ECC key file should only contains the ECC Private Key section to working on MacOS.)
+- `AWS_TEST_MQTT311_ROOT_CA`: Path to the root certificate
+- `AWS_TEST_HTTP_PROXY_HOST`: Hostname of proxy
+- `AWS_TEST_HTTP_PROXY_PORT`: Port of proxy
 - `NETWORK_TESTS_DISABLED`: Set this if tests are running in a constrained environment where network access is not guaranteed/allowed.
+
+Other Environment Variables that can be set can be found in the `SetupTestProperties()` function in [CrtTestFixture.java](https://github.com/awslabs/aws-crt-java/blob/main/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java)
 
 These can be set persistently via Maven settings (usually in `~/.m2/settings.xml`):
 ```xml

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -115,7 +115,7 @@ public final class CRT {
             return systemPropertyOverride;
         }
 
-        String environmentOverride = System.getenv(CRT_ARCH_OVERRIDE_ENVIRONMENT_VARIABLE);
+        String environmentOverride = System.getProperty(CRT_ARCH_OVERRIDE_ENVIRONMENT_VARIABLE);
         if (environmentOverride != null && environmentOverride.length() > 0) {
             return environmentOverride;
         }

--- a/src/test/java/software/amazon/awssdk/crt/test/CredentialsProviderTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CredentialsProviderTest.java
@@ -32,10 +32,10 @@ public class CredentialsProviderTest extends CrtTestFixture {
     static private String SECRET_ACCESS_KEY = "secret_access_key";
     static private String SESSION_TOKEN = "session_token";
 
-    private static String COGNITO_ENDPOINT = System.getenv("AWS_TEST_MQTT311_COGNITO_ENDPOINT");
-    private static String COGNITO_IDENTITY = System.getenv("AWS_TEST_MQTT311_COGNITO_IDENTITY");
-    private static String TEST_HTTP_PROXY_HOST = System.getenv("AWS_TEST_HTTP_PROXY_HOST");
-    private static String TEST_HTTP_PROXY_PORT = System.getenv("AWS_TEST_HTTP_PROXY_PORT");
+    private static String COGNITO_ENDPOINT = System.getProperty("AWS_TEST_MQTT311_COGNITO_ENDPOINT");
+    private static String COGNITO_IDENTITY = System.getProperty("AWS_TEST_MQTT311_COGNITO_IDENTITY");
+    private static String TEST_HTTP_PROXY_HOST = System.getProperty("AWS_TEST_HTTP_PROXY_HOST");
+    private static String TEST_HTTP_PROXY_PORT = System.getProperty("AWS_TEST_HTTP_PROXY_PORT");
 
     private boolean isCIEnvironmentSetUp() {
         if (COGNITO_IDENTITY == null ) {

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -42,6 +42,7 @@ public class CrtTestFixture {
 
     private void SetupTestProperties(){
         SetPropertyFromEnv("AWS_TEST_IS_CI");
+        SetPropertyFromEnv("NETWORK_TESTS_DISABLED");
         SetPropertyFromEnv("AWS_TEST_MQTT311_ROOT_CA");
         SetPropertyFromEnv("ENDPOINT");
         SetPropertyFromEnv("REGION");
@@ -62,9 +63,11 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN");
+
         // Custom Key Ops
         SetPropertyFromEnv("AWS_TEST_MQTT311_CUSTOM_KEY_OPS_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT311_CUSTOM_KEY_OPS_CERT");
+
         // MQTT311 Codebuild/Direct connections data
         SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_PORT");
@@ -72,6 +75,7 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT");
         SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT");
+
         // MQTT311 Codebuild/Websocket connections data
         SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_PORT");
@@ -79,29 +83,35 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT");
         SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_TLS_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_TLS_PORT");
+
         // MQTT311 Codebuild misc connections data
         SetPropertyFromEnv("AWS_TEST_MQTT311_BASIC_AUTH_USERNAME");
         SetPropertyFromEnv("AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD");
         SetPropertyFromEnv("AWS_TEST_MQTT311_CERTIFICATE_FILE");
         SetPropertyFromEnv("AWS_TEST_MQTT311_KEY_FILE");
+
         // MQTT311 IoT Endpoint, Key, Cert
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_ECC_CERT");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_ECC_KEY");
+
         // MQTT311 Proxy
         SetPropertyFromEnv("AWS_TEST_MQTT311_PROXY_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT311_PROXY_PORT");
+
         // MQTT311 Keystore
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FILE");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_PASSWORD");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD");
+
         // MQTT311 PKCS12
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD");
+
         // PKCS11
         SetPropertyFromEnv("AWS_TEST_PKCS11_LIB");
         SetPropertyFromEnv("AWS_TEST_PKCS11_TOKEN_LABEL");
@@ -109,12 +119,14 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_PKCS11_PKEY_LABEL");
         SetPropertyFromEnv("AWS_TEST_PKCS11_CERT_FILE");
         SetPropertyFromEnv("AWS_TEST_PKCS11_CA_FILE");
+
         // MQTT311 X509
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_CERT");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME");
+
         // MQTT311 Windows Cert Store
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
         SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE");
@@ -126,6 +138,7 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT");
+
         // MQTT5 Codebuild/Websocket connections data
         SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_PORT");
@@ -133,41 +146,50 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_TLS_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_TLS_PORT");
+
         // MQTT5 Codebuild misc connections data
         SetPropertyFromEnv("AWS_TEST_MQTT5_BASIC_AUTH_USERNAME");
         SetPropertyFromEnv("AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD");
         SetPropertyFromEnv("AWS_TEST_MQTT5_CERTIFICATE_FILE");
         SetPropertyFromEnv("AWS_TEST_MQTT5_KEY_FILE");
+
         // MQTT5 Proxy
         SetPropertyFromEnv("AWS_TEST_MQTT5_PROXY_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT5_PROXY_PORT");
+
         // MQTT5 Endpoint/Host credential
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_HOST");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_REGION");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY");
+
         // MQTT5 Static credential related
         SetPropertyFromEnv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_ACCESS_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SECRET_ACCESS_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SESSION_TOKEN");
+
         // MQTT5 Cognito
         SetPropertyFromEnv("AWS_TEST_MQTT5_COGNITO_ENDPOINT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_COGNITO_IDENTITY");
+
         // MQTT5 Keystore
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FORMAT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FILE");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_PASSWORD");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_ALIAS");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_PASSWORD");
+
         // MQTT5 PKCS12
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD");
+
         // MQTT5 X509
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_CERT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_KEY");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_ENDPOINT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_ROLE_ALIAS");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_THING_NAME");
+
         // MQTT5 Windows Cert Store
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE");
@@ -175,7 +197,6 @@ public class CrtTestFixture {
         // MQTT5 Custom Key Ops (so we don't have to make a new file just for a single test)
         SetPropertyFromEnv("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_CERT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_KEY");
-
 
         SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_USERNAME");
         SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_PASSWORD");

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -43,7 +43,6 @@ public class CrtTestFixture {
     // Setup System properties from environment variables set by builder for use by unit tests.
     private void SetupTestProperties(){
         SetPropertyFromEnv("AWS_TEST_IS_CI");
-        SetPropertyFromEnv("NETWORK_TESTS_DISABLED");
         SetPropertyFromEnv("AWS_TEST_MQTT311_ROOT_CA");
         SetPropertyFromEnv("ENDPOINT");
         SetPropertyFromEnv("REGION");

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -40,6 +40,7 @@ public class CrtTestFixture {
         }
     }
 
+    // Setup System properties from environment variables set by builder for use by unit tests.
     private void SetupTestProperties(){
         SetPropertyFromEnv("AWS_TEST_IS_CI");
         SetPropertyFromEnv("NETWORK_TESTS_DISABLED");
@@ -215,6 +216,7 @@ public class CrtTestFixture {
             Log.initLoggingToFile(Log.LogLevel.Trace, "log.txt");
         }
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup begin");
+
         context = new CrtTestContext();
         CrtPlatform platform = CRT.getPlatformImpl();
         if (platform != null) {

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -33,6 +33,154 @@ public class CrtTestFixture {
         return context;
     }
 
+    private void SetPropertyFromEnv(String name){
+        String propertyValue = System.getenv(name);
+        if (propertyValue != null){
+            System.setProperty(name, propertyValue);
+        }
+    }
+
+    private void SetupTestProperties(){
+        SetPropertyFromEnv("AWS_TEST_IS_CI");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_ROOT_CA");
+        SetPropertyFromEnv("ENDPOINT");
+        SetPropertyFromEnv("REGION");
+
+        // Cognito
+        SetPropertyFromEnv("AWS_TEST_MQTT311_COGNITO_ENDPOINT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_COGNITO_IDENTITY");
+
+        //Proxy
+        SetPropertyFromEnv("AWS_TEST_HTTP_PROXY_HOST");
+        SetPropertyFromEnv("AWS_TEST_HTTP_PROXY_PORT");
+        SetPropertyFromEnv("AWS_TEST_HTTPS_PROXY_HOST");
+        SetPropertyFromEnv("AWS_TEST_HTTPS_PROXY_PORT");
+        SetPropertyFromEnv("AWS_TEST_HTTP_PROXY_BASIC_HOST");
+        SetPropertyFromEnv("AWS_TEST_HTTP_PROXY_BASIC_PORT");
+
+        // Static credential related
+        SetPropertyFromEnv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN");
+        // Custom Key Ops
+        SetPropertyFromEnv("AWS_TEST_MQTT311_CUSTOM_KEY_OPS_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_CUSTOM_KEY_OPS_CERT");
+        // MQTT311 Codebuild/Direct connections data
+        SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_PORT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT");
+        // MQTT311 Codebuild/Websocket connections data
+        SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_PORT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_TLS_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_WS_MQTT_TLS_PORT");
+        // MQTT311 Codebuild misc connections data
+        SetPropertyFromEnv("AWS_TEST_MQTT311_BASIC_AUTH_USERNAME");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_CERTIFICATE_FILE");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_KEY_FILE");
+        // MQTT311 IoT Endpoint, Key, Cert
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_ECC_CERT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_ECC_KEY");
+        // MQTT311 Proxy
+        SetPropertyFromEnv("AWS_TEST_MQTT311_PROXY_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_PROXY_PORT");
+        // MQTT311 Keystore
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FILE");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_PASSWORD");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD");
+        // MQTT311 PKCS12
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD");
+        // PKCS11
+        SetPropertyFromEnv("AWS_TEST_PKCS11_LIB");
+        SetPropertyFromEnv("AWS_TEST_PKCS11_TOKEN_LABEL");
+        SetPropertyFromEnv("AWS_TEST_PKCS11_PIN");
+        SetPropertyFromEnv("AWS_TEST_PKCS11_PKEY_LABEL");
+        SetPropertyFromEnv("AWS_TEST_PKCS11_CERT_FILE");
+        SetPropertyFromEnv("AWS_TEST_PKCS11_CA_FILE");
+        // MQTT311 X509
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_CERT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME");
+        // MQTT311 Windows Cert Store
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
+        SetPropertyFromEnv("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE");
+
+        // MQTT5 Codebuild/Direct connections data
+        SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_PORT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT");
+        // MQTT5 Codebuild/Websocket connections data
+        SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_PORT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_TLS_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_WS_MQTT_TLS_PORT");
+        // MQTT5 Codebuild misc connections data
+        SetPropertyFromEnv("AWS_TEST_MQTT5_BASIC_AUTH_USERNAME");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_CERTIFICATE_FILE");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_KEY_FILE");
+        // MQTT5 Proxy
+        SetPropertyFromEnv("AWS_TEST_MQTT5_PROXY_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_PROXY_PORT");
+        // MQTT5 Endpoint/Host credential
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_HOST");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_REGION");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY");
+        // MQTT5 Static credential related
+        SetPropertyFromEnv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_ACCESS_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SECRET_ACCESS_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SESSION_TOKEN");
+        // MQTT5 Cognito
+        SetPropertyFromEnv("AWS_TEST_MQTT5_COGNITO_ENDPOINT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_COGNITO_IDENTITY");
+        // MQTT5 Keystore
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FORMAT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FILE");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_PASSWORD");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_ALIAS");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_PASSWORD");
+        // MQTT5 PKCS12
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD");
+        // MQTT5 X509
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_CERT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_KEY");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_ENDPOINT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_ROLE_ALIAS");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_X509_THING_NAME");
+        // MQTT5 Windows Cert Store
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE");
+
+        // MQTT5 Custom Key Ops (so we don't have to make a new file just for a single test)
+        SetPropertyFromEnv("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_CERT");
+        SetPropertyFromEnv("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_KEY");
+
+
+        SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_USERNAME");
+        SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_PASSWORD");
+    }
+
     @Before
     public void setup() {
         // We only want to see the CRT logs if the test fails.
@@ -50,7 +198,10 @@ public class CrtTestFixture {
         CrtPlatform platform = CRT.getPlatformImpl();
         if (platform != null) {
             platform.testSetup(context);
+        } else {
+            SetupTestProperties();
         }
+
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup end");
     }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -10,7 +10,6 @@ import org.junit.Assume;
 import org.junit.Test;
 
 import software.amazon.awssdk.crt.CrtRuntimeException;
-import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.HttpVersion;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.http.Http2Request;

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -54,63 +54,63 @@ import java.util.function.Consumer;
 public class Mqtt5ClientTest extends CrtTestFixture {
 
     // MQTT5 Codebuild/Direct connections data
-    static final String AWS_TEST_MQTT5_DIRECT_MQTT_HOST = System.getenv("AWS_TEST_MQTT5_DIRECT_MQTT_HOST");
-    static final String AWS_TEST_MQTT5_DIRECT_MQTT_PORT = System.getenv("AWS_TEST_MQTT5_DIRECT_MQTT_PORT");
-    static final String AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST = System.getenv("AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST");
-    static final String AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT = System.getenv("AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT");
-    static final String AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST = System.getenv("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST");
-    static final String AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT = System.getenv("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT");
+    static final String AWS_TEST_MQTT5_DIRECT_MQTT_HOST = System.getProperty("AWS_TEST_MQTT5_DIRECT_MQTT_HOST");
+    static final String AWS_TEST_MQTT5_DIRECT_MQTT_PORT = System.getProperty("AWS_TEST_MQTT5_DIRECT_MQTT_PORT");
+    static final String AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST = System.getProperty("AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST");
+    static final String AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT = System.getProperty("AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT");
+    static final String AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST = System.getProperty("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST");
+    static final String AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT = System.getProperty("AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT");
     // MQTT5 Codebuild/Websocket connections data
-    static final String AWS_TEST_MQTT5_WS_MQTT_HOST = System.getenv("AWS_TEST_MQTT5_WS_MQTT_HOST");
-    static final String AWS_TEST_MQTT5_WS_MQTT_PORT = System.getenv("AWS_TEST_MQTT5_WS_MQTT_PORT");
-    static final String AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST = System.getenv("AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST");
-    static final String AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT = System.getenv("AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT");
-    static final String AWS_TEST_MQTT5_WS_MQTT_TLS_HOST = System.getenv("AWS_TEST_MQTT5_WS_MQTT_TLS_HOST");
-    static final String AWS_TEST_MQTT5_WS_MQTT_TLS_PORT = System.getenv("AWS_TEST_MQTT5_WS_MQTT_TLS_PORT");
+    static final String AWS_TEST_MQTT5_WS_MQTT_HOST = System.getProperty("AWS_TEST_MQTT5_WS_MQTT_HOST");
+    static final String AWS_TEST_MQTT5_WS_MQTT_PORT = System.getProperty("AWS_TEST_MQTT5_WS_MQTT_PORT");
+    static final String AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST = System.getProperty("AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST");
+    static final String AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT = System.getProperty("AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT");
+    static final String AWS_TEST_MQTT5_WS_MQTT_TLS_HOST = System.getProperty("AWS_TEST_MQTT5_WS_MQTT_TLS_HOST");
+    static final String AWS_TEST_MQTT5_WS_MQTT_TLS_PORT = System.getProperty("AWS_TEST_MQTT5_WS_MQTT_TLS_PORT");
     // MQTT5 Codebuild misc connections data
-    static final String AWS_TEST_MQTT5_BASIC_AUTH_USERNAME = System.getenv("AWS_TEST_MQTT5_BASIC_AUTH_USERNAME");
-    static final String AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD = System.getenv("AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD");
-    static final String AWS_TEST_MQTT5_CERTIFICATE_FILE = System.getenv("AWS_TEST_MQTT5_CERTIFICATE_FILE");
-    static final String AWS_TEST_MQTT5_KEY_FILE = System.getenv("AWS_TEST_MQTT5_KEY_FILE");
+    static final String AWS_TEST_MQTT5_BASIC_AUTH_USERNAME = System.getProperty("AWS_TEST_MQTT5_BASIC_AUTH_USERNAME");
+    static final String AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD = System.getProperty("AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD");
+    static final String AWS_TEST_MQTT5_CERTIFICATE_FILE = System.getProperty("AWS_TEST_MQTT5_CERTIFICATE_FILE");
+    static final String AWS_TEST_MQTT5_KEY_FILE = System.getProperty("AWS_TEST_MQTT5_KEY_FILE");
     // MQTT5 Proxy
-    static final String AWS_TEST_MQTT5_PROXY_HOST = System.getenv("AWS_TEST_MQTT5_PROXY_HOST");
-    static final String AWS_TEST_MQTT5_PROXY_PORT = System.getenv("AWS_TEST_MQTT5_PROXY_PORT");
+    static final String AWS_TEST_MQTT5_PROXY_HOST = System.getProperty("AWS_TEST_MQTT5_PROXY_HOST");
+    static final String AWS_TEST_MQTT5_PROXY_PORT = System.getProperty("AWS_TEST_MQTT5_PROXY_PORT");
     // MQTT5 Endpoint/Host credentials
-    static final String AWS_TEST_MQTT5_IOT_CORE_HOST = System.getenv("AWS_TEST_MQTT5_IOT_CORE_HOST");
-    static final String AWS_TEST_MQTT5_IOT_CORE_REGION = System.getenv("AWS_TEST_MQTT5_IOT_CORE_REGION");
-    static final String AWS_TEST_MQTT5_IOT_CORE_RSA_CERT = System.getenv("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT");
-    static final String AWS_TEST_MQTT5_IOT_CORE_RSA_KEY = System.getenv("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY");
+    static final String AWS_TEST_MQTT5_IOT_CORE_HOST = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_HOST");
+    static final String AWS_TEST_MQTT5_IOT_CORE_REGION = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_REGION");
+    static final String AWS_TEST_MQTT5_IOT_CORE_RSA_CERT = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_RSA_CERT");
+    static final String AWS_TEST_MQTT5_IOT_CORE_RSA_KEY = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_RSA_KEY");
     // MQTT5 Static credential related
-    static final String AWS_TEST_MQTT5_ROLE_CREDENTIAL_ACCESS_KEY = System.getenv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_ACCESS_KEY");
-    static final String AWS_TEST_MQTT5_ROLE_CREDENTIAL_SECRET_ACCESS_KEY = System.getenv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SECRET_ACCESS_KEY");
-    static final String AWS_TEST_MQTT5_ROLE_CREDENTIAL_SESSION_TOKEN = System.getenv("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SESSION_TOKEN");
+    static final String AWS_TEST_MQTT5_ROLE_CREDENTIAL_ACCESS_KEY = System.getProperty("AWS_TEST_MQTT5_ROLE_CREDENTIAL_ACCESS_KEY");
+    static final String AWS_TEST_MQTT5_ROLE_CREDENTIAL_SECRET_ACCESS_KEY = System.getProperty("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SECRET_ACCESS_KEY");
+    static final String AWS_TEST_MQTT5_ROLE_CREDENTIAL_SESSION_TOKEN = System.getProperty("AWS_TEST_MQTT5_ROLE_CREDENTIAL_SESSION_TOKEN");
     // MQTT5 Cognito
-    static final String AWS_TEST_MQTT5_COGNITO_ENDPOINT = System.getenv("AWS_TEST_MQTT5_COGNITO_ENDPOINT");
-    static final String AWS_TEST_MQTT5_COGNITO_IDENTITY = System.getenv("AWS_TEST_MQTT5_COGNITO_IDENTITY");
+    static final String AWS_TEST_MQTT5_COGNITO_ENDPOINT = System.getProperty("AWS_TEST_MQTT5_COGNITO_ENDPOINT");
+    static final String AWS_TEST_MQTT5_COGNITO_IDENTITY = System.getProperty("AWS_TEST_MQTT5_COGNITO_IDENTITY");
     // MQTT5 Keystore
-    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FORMAT = System.getenv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FORMAT");
-    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FILE = System.getenv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FILE");
-    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_PASSWORD = System.getenv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_PASSWORD");
-    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_ALIAS = System.getenv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_ALIAS");
-    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_PASSWORD = System.getenv("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_PASSWORD");
+    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FORMAT = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FORMAT");
+    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FILE = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FILE");
+    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_PASSWORD = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_PASSWORD");
+    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_ALIAS = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_ALIAS");
+    static final String AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_PASSWORD = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_PASSWORD");
     // MQTT5 PKCS12
-    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY = System.getenv("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY");
-    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD = System.getenv("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD");
+    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY");
+    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD");
     // MQTT5 PKCS11
-    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_LIB = System.getenv("AWS_TEST_PKCS11_LIB");
-    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_TOKEN_LABEL = System.getenv("AWS_TEST_PKCS11_TOKEN_LABEL");
-    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_PIN = System.getenv("AWS_TEST_PKCS11_PIN");
-    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_PKEY_LABEL = System.getenv("AWS_TEST_PKCS11_PKEY_LABEL");
-    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_CERT_FILE = System.getenv("AWS_TEST_PKCS11_CERT_FILE");
+    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_LIB = System.getProperty("AWS_TEST_PKCS11_LIB");
+    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_TOKEN_LABEL = System.getProperty("AWS_TEST_PKCS11_TOKEN_LABEL");
+    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_PIN = System.getProperty("AWS_TEST_PKCS11_PIN");
+    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_PKEY_LABEL = System.getProperty("AWS_TEST_PKCS11_PKEY_LABEL");
+    static final String AWS_TEST_MQTT5_IOT_CORE_PKCS11_CERT_FILE = System.getProperty("AWS_TEST_PKCS11_CERT_FILE");
     // MQTT5 X509
-    static final String AWS_TEST_MQTT5_IOT_CORE_X509_CERT = System.getenv("AWS_TEST_MQTT5_IOT_CORE_X509_CERT");
-    static final String AWS_TEST_MQTT5_IOT_CORE_X509_KEY = System.getenv("AWS_TEST_MQTT5_IOT_CORE_X509_KEY");
-    static final String AWS_TEST_MQTT5_IOT_CORE_X509_ENDPOINT = System.getenv("AWS_TEST_MQTT5_IOT_CORE_X509_ENDPOINT");
-    static final String AWS_TEST_MQTT5_IOT_CORE_X509_ROLE_ALIAS = System.getenv("AWS_TEST_MQTT5_IOT_CORE_X509_ROLE_ALIAS");
-    static final String AWS_TEST_MQTT5_IOT_CORE_X509_THING_NAME = System.getenv("AWS_TEST_MQTT5_IOT_CORE_X509_THING_NAME");
+    static final String AWS_TEST_MQTT5_IOT_CORE_X509_CERT = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_X509_CERT");
+    static final String AWS_TEST_MQTT5_IOT_CORE_X509_KEY = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_X509_KEY");
+    static final String AWS_TEST_MQTT5_IOT_CORE_X509_ENDPOINT = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_X509_ENDPOINT");
+    static final String AWS_TEST_MQTT5_IOT_CORE_X509_ROLE_ALIAS = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_X509_ROLE_ALIAS");
+    static final String AWS_TEST_MQTT5_IOT_CORE_X509_THING_NAME = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_X509_THING_NAME");
     // MQTT5 Windows Cert Store
-    static final String AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS = System.getenv("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
-    static final String AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE = System.getenv("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE");
+    static final String AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
+    static final String AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE");
 
     private int OPERATION_TIMEOUT_TIME = 30;
 

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
@@ -38,75 +38,75 @@ import java.util.function.Consumer;
     private CompletableFuture<OnConnectionFailureReturn> onConnectionFailureFuture = new CompletableFuture<OnConnectionFailureReturn>();
     private CompletableFuture<OnConnectionClosedReturn> onConnectionClosedFuture = new CompletableFuture<OnConnectionClosedReturn>();
 
-    static final boolean AWS_TEST_IS_CI = System.getenv("AWS_TEST_IS_CI") != null;
-    static final String AWS_TEST_MQTT311_ROOTCA = System.getenv("AWS_TEST_MQTT311_ROOT_CA");
+    static final boolean AWS_TEST_IS_CI = System.getProperty("AWS_TEST_IS_CI") != null;
+    static final String AWS_TEST_MQTT311_ROOTCA = System.getProperty("AWS_TEST_MQTT311_ROOT_CA");
     // Static credential related
-    static final String AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY = System.getenv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY");
-    static final String AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY = System.getenv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY");
-    static final String AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN = System.getenv("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN");
+    static final String AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY = System.getProperty("AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY");
+    static final String AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY = System.getProperty("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY");
+    static final String AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN = System.getProperty("AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN");
     // Custom Key Ops
-    static final String AWS_TEST_MQTT311_CUSTOM_KEY_OPS_KEY = System.getenv("AWS_TEST_MQTT311_CUSTOM_KEY_OPS_KEY");
-    static final String AWS_TEST_MQTT311_CUSTOM_KEY_OPS_CERT = System.getenv("AWS_TEST_MQTT311_CUSTOM_KEY_OPS_CERT");
+    static final String AWS_TEST_MQTT311_CUSTOM_KEY_OPS_KEY = System.getProperty("AWS_TEST_MQTT311_CUSTOM_KEY_OPS_KEY");
+    static final String AWS_TEST_MQTT311_CUSTOM_KEY_OPS_CERT = System.getProperty("AWS_TEST_MQTT311_CUSTOM_KEY_OPS_CERT");
     // MQTT311 Cognito
-    static final String AWS_TEST_MQTT311_COGNITO_ENDPOINT = System.getenv("AWS_TEST_MQTT311_COGNITO_ENDPOINT");
-    static final String AWS_TEST_MQTT311_COGNITO_IDENTITY = System.getenv("AWS_TEST_MQTT311_COGNITO_IDENTITY");
+    static final String AWS_TEST_MQTT311_COGNITO_ENDPOINT = System.getProperty("AWS_TEST_MQTT311_COGNITO_ENDPOINT");
+    static final String AWS_TEST_MQTT311_COGNITO_IDENTITY = System.getProperty("AWS_TEST_MQTT311_COGNITO_IDENTITY");
     // MQTT311 Codebuild/Direct connections data
-    static final String AWS_TEST_MQTT311_DIRECT_MQTT_HOST = System.getenv("AWS_TEST_MQTT311_DIRECT_MQTT_HOST");
-    static final String AWS_TEST_MQTT311_DIRECT_MQTT_PORT = System.getenv("AWS_TEST_MQTT311_DIRECT_MQTT_PORT");
-    static final String AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST = System.getenv("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST");
-    static final String AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT = System.getenv("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT");
-    static final String AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST = System.getenv("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST");
-    static final String AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT = System.getenv("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT");
+    static final String AWS_TEST_MQTT311_DIRECT_MQTT_HOST = System.getProperty("AWS_TEST_MQTT311_DIRECT_MQTT_HOST");
+    static final String AWS_TEST_MQTT311_DIRECT_MQTT_PORT = System.getProperty("AWS_TEST_MQTT311_DIRECT_MQTT_PORT");
+    static final String AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST = System.getProperty("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST");
+    static final String AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT = System.getProperty("AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT");
+    static final String AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST = System.getProperty("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST");
+    static final String AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT = System.getProperty("AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT");
     // MQTT311 Codebuild/Websocket connections data
-    static final String AWS_TEST_MQTT311_WS_MQTT_HOST = System.getenv("AWS_TEST_MQTT311_WS_MQTT_HOST");
-    static final String AWS_TEST_MQTT311_WS_MQTT_PORT = System.getenv("AWS_TEST_MQTT311_WS_MQTT_PORT");
-    static final String AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST = System.getenv("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST");
-    static final String AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT = System.getenv("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT");
-    static final String AWS_TEST_MQTT311_WS_MQTT_TLS_HOST = System.getenv("AWS_TEST_MQTT311_WS_MQTT_TLS_HOST");
-    static final String AWS_TEST_MQTT311_WS_MQTT_TLS_PORT = System.getenv("AWS_TEST_MQTT311_WS_MQTT_TLS_PORT");
+    static final String AWS_TEST_MQTT311_WS_MQTT_HOST = System.getProperty("AWS_TEST_MQTT311_WS_MQTT_HOST");
+    static final String AWS_TEST_MQTT311_WS_MQTT_PORT = System.getProperty("AWS_TEST_MQTT311_WS_MQTT_PORT");
+    static final String AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST = System.getProperty("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST");
+    static final String AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT = System.getProperty("AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT");
+    static final String AWS_TEST_MQTT311_WS_MQTT_TLS_HOST = System.getProperty("AWS_TEST_MQTT311_WS_MQTT_TLS_HOST");
+    static final String AWS_TEST_MQTT311_WS_MQTT_TLS_PORT = System.getProperty("AWS_TEST_MQTT311_WS_MQTT_TLS_PORT");
     // MQTT311 Codebuild misc connections data
-    static final String AWS_TEST_MQTT311_BASIC_AUTH_USERNAME = System.getenv("AWS_TEST_MQTT311_BASIC_AUTH_USERNAME");
-    static final String AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD = System.getenv("AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD");
-    static final String AWS_TEST_MQTT311_CERTIFICATE_FILE = System.getenv("AWS_TEST_MQTT311_CERTIFICATE_FILE");
-    static final String AWS_TEST_MQTT311_KEY_FILE = System.getenv("AWS_TEST_MQTT311_KEY_FILE");
+    static final String AWS_TEST_MQTT311_BASIC_AUTH_USERNAME = System.getProperty("AWS_TEST_MQTT311_BASIC_AUTH_USERNAME");
+    static final String AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD = System.getProperty("AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD");
+    static final String AWS_TEST_MQTT311_CERTIFICATE_FILE = System.getProperty("AWS_TEST_MQTT311_CERTIFICATE_FILE");
+    static final String AWS_TEST_MQTT311_KEY_FILE = System.getProperty("AWS_TEST_MQTT311_KEY_FILE");
     // MQTT311 IoT Endpoint, Key, Cert
-    static final String AWS_TEST_MQTT311_IOT_CORE_HOST = System.getenv("AWS_TEST_MQTT311_IOT_CORE_HOST");
-    static final String AWS_TEST_MQTT311_IOT_CORE_RSA_CERT = System.getenv("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT");
-    static final String AWS_TEST_MQTT311_IOT_CORE_RSA_KEY = System.getenv("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY");
-    static final String AWS_TEST_MQTT311_IOT_CORE_ECC_CERT = System.getenv("AWS_TEST_MQTT311_IOT_CORE_ECC_CERT");
-    static final String AWS_TEST_MQTT311_IOT_CORE_ECC_KEY = System.getenv("AWS_TEST_MQTT311_IOT_CORE_ECC_KEY");
+    static final String AWS_TEST_MQTT311_IOT_CORE_HOST = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_HOST");
+    static final String AWS_TEST_MQTT311_IOT_CORE_RSA_CERT = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT");
+    static final String AWS_TEST_MQTT311_IOT_CORE_RSA_KEY = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY");
+    static final String AWS_TEST_MQTT311_IOT_CORE_ECC_CERT = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_ECC_CERT");
+    static final String AWS_TEST_MQTT311_IOT_CORE_ECC_KEY = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_ECC_KEY");
     // MQTT311 Proxy
-    static final String AWS_TEST_MQTT311_PROXY_HOST = System.getenv("AWS_TEST_MQTT311_PROXY_HOST");
-    static final String AWS_TEST_MQTT311_PROXY_PORT = System.getenv("AWS_TEST_MQTT311_PROXY_PORT");
+    static final String AWS_TEST_MQTT311_PROXY_HOST = System.getProperty("AWS_TEST_MQTT311_PROXY_HOST");
+    static final String AWS_TEST_MQTT311_PROXY_PORT = System.getProperty("AWS_TEST_MQTT311_PROXY_PORT");
     // MQTT311 Keystore
-    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT = System.getenv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT");
-    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FILE = System.getenv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FILE");
-    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_PASSWORD = System.getenv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_PASSWORD");
-    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS = System.getenv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS");
-    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD = System.getenv("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD");
+    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT");
+    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FILE = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FILE");
+    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_PASSWORD = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_PASSWORD");
+    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS");
+    static final String AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD");
     // MQTT311 PKCS12
-    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY = System.getenv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY");
-    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD = System.getenv("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD");
+    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY");
+    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD");
     // MQTT311 PKCS11
-    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_LIB = System.getenv("AWS_TEST_PKCS11_LIB");
-    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_TOKEN_LABEL = System.getenv("AWS_TEST_PKCS11_TOKEN_LABEL");
-    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_PIN = System.getenv("AWS_TEST_PKCS11_PIN");
-    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_PKEY_LABEL = System.getenv("AWS_TEST_PKCS11_PKEY_LABEL");
-    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_CERT_FILE = System.getenv("AWS_TEST_PKCS11_CERT_FILE");
+    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_LIB = System.getProperty("AWS_TEST_PKCS11_LIB");
+    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_TOKEN_LABEL = System.getProperty("AWS_TEST_PKCS11_TOKEN_LABEL");
+    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_PIN = System.getProperty("AWS_TEST_PKCS11_PIN");
+    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_PKEY_LABEL = System.getProperty("AWS_TEST_PKCS11_PKEY_LABEL");
+    static final String AWS_TEST_MQTT311_IOT_CORE_PKCS11_CERT_FILE = System.getProperty("AWS_TEST_PKCS11_CERT_FILE");
     // MQTT311 X509
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_CERT = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_CERT");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_KEY = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_KEY");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_CERT = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_CERT");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_KEY = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_KEY");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME");
     // MQTT311 Windows Cert Store
-    static final String AWS_TEST_MQTT311_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS = System.getenv("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
-    static final String AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE = System.getenv("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE");
+    static final String AWS_TEST_MQTT311_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
+    static final String AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE");
 
     // MQTT5 Custom Key Ops (so we don't have to make a new file just for a single test)
-    static final String AWS_TEST_MQTT5_IOT_CORE_HOST = System.getenv("AWS_TEST_MQTT5_IOT_CORE_HOST");
-    static final String AWS_TEST_MQTT5_CUSTOM_KEY_OPS_CERT = System.getenv("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_CERT");
-    static final String AWS_TEST_MQTT5_CUSTOM_KEY_OPS_KEY = System.getenv("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_KEY");
+    static final String AWS_TEST_MQTT5_IOT_CORE_HOST = System.getProperty("AWS_TEST_MQTT5_IOT_CORE_HOST");
+    static final String AWS_TEST_MQTT5_CUSTOM_KEY_OPS_CERT = System.getProperty("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_CERT");
+    static final String AWS_TEST_MQTT5_CUSTOM_KEY_OPS_KEY = System.getProperty("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_KEY");
 
     static final short TEST_PORT = 8883;
     static final short TEST_PORT_ALPN = 443;

--- a/src/test/java/software/amazon/awssdk/crt/test/Pkcs11LibTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Pkcs11LibTest.java
@@ -14,12 +14,12 @@ import software.amazon.awssdk.crt.io.Pkcs11Lib;
 public class Pkcs11LibTest extends CrtTestFixture {
 
     // The PKCS#11 tests are skipped unless the following env variables are set:
-    static String TEST_PKCS11_LIB = System.getenv("AWS_TEST_PKCS11_LIB");
-    static String TEST_PKCS11_TOKEN_LABEL = System.getenv("AWS_TEST_PKCS11_TOKEN_LABEL");
-    static String TEST_PKCS11_PIN = System.getenv("AWS_TEST_PKCS11_PIN");
-    static String TEST_PKCS11_PKEY_LABEL = System.getenv("AWS_TEST_PKCS11_PKEY_LABEL");
-    static String TEST_PKCS11_CERT_FILE = System.getenv("AWS_TEST_PKCS11_CERT_FILE");
-    static String TEST_PKCS11_CA_FILE = System.getenv("AWS_TEST_PKCS11_CA_FILE");
+    static String TEST_PKCS11_LIB = System.getProperty("AWS_TEST_PKCS11_LIB");
+    static String TEST_PKCS11_TOKEN_LABEL = System.getProperty("AWS_TEST_PKCS11_TOKEN_LABEL");
+    static String TEST_PKCS11_PIN = System.getProperty("AWS_TEST_PKCS11_PIN");
+    static String TEST_PKCS11_PKEY_LABEL = System.getProperty("AWS_TEST_PKCS11_PKEY_LABEL");
+    static String TEST_PKCS11_CERT_FILE = System.getProperty("AWS_TEST_PKCS11_CERT_FILE");
+    static String TEST_PKCS11_CA_FILE = System.getProperty("AWS_TEST_PKCS11_CA_FILE");
 
     static void assumeEnvironmentSetUpForPkcs11Tests() {
         Assume.assumeNotNull(TEST_PKCS11_LIB);

--- a/src/test/java/software/amazon/awssdk/crt/test/Pkcs11LibTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Pkcs11LibTest.java
@@ -1,6 +1,5 @@
 package software.amazon.awssdk.crt.test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/software/amazon/awssdk/crt/test/ProxyTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/ProxyTest.java
@@ -54,23 +54,23 @@ public class ProxyTest extends CrtTestFixture  {
         Basic
     }
 
-    private static String HTTP_PROXY_HOST = System.getenv("AWS_TEST_HTTP_PROXY_HOST");
-    private static String HTTP_PROXY_PORT = System.getenv("AWS_TEST_HTTP_PROXY_PORT");
-    private static String HTTPS_PROXY_HOST = System.getenv("AWS_TEST_HTTPS_PROXY_HOST");
-    private static String HTTPS_PROXY_PORT = System.getenv("AWS_TEST_HTTPS_PROXY_PORT");
-    private static String HTTP_PROXY_BASIC_HOST = System.getenv("AWS_TEST_HTTP_PROXY_BASIC_HOST");
-    private static String HTTP_PROXY_BASIC_PORT = System.getenv("AWS_TEST_HTTP_PROXY_BASIC_PORT");
+    private static String HTTP_PROXY_HOST = System.getProperty("AWS_TEST_HTTP_PROXY_HOST");
+    private static String HTTP_PROXY_PORT = System.getProperty("AWS_TEST_HTTP_PROXY_PORT");
+    private static String HTTPS_PROXY_HOST = System.getProperty("AWS_TEST_HTTPS_PROXY_HOST");
+    private static String HTTPS_PROXY_PORT = System.getProperty("AWS_TEST_HTTPS_PROXY_PORT");
+    private static String HTTP_PROXY_BASIC_HOST = System.getProperty("AWS_TEST_HTTP_PROXY_BASIC_HOST");
+    private static String HTTP_PROXY_BASIC_PORT = System.getProperty("AWS_TEST_HTTP_PROXY_BASIC_PORT");
 
-    private static String HTTP_PROXY_BASIC_AUTH_USERNAME = System.getenv("AWS_TEST_BASIC_AUTH_USERNAME");
-    private static String HTTP_PROXY_BASIC_AUTH_PASSWORD = System.getenv("AWS_TEST_BASIC_AUTH_PASSWORD");
+    private static String HTTP_PROXY_BASIC_AUTH_USERNAME = System.getProperty("AWS_TEST_BASIC_AUTH_USERNAME");
+    private static String HTTP_PROXY_BASIC_AUTH_PASSWORD = System.getProperty("AWS_TEST_BASIC_AUTH_PASSWORD");
 
-    static final String AWS_TEST_MQTT311_ROOTCA = System.getenv("AWS_TEST_MQTT311_ROOT_CA");
-    static final String AWS_TEST_MQTT311_IOT_CORE_HOST = System.getenv("AWS_TEST_MQTT311_IOT_CORE_HOST");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_CERT = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_CERT");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_KEY = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_KEY");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS");
-    static final String AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME = System.getenv("AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME");
+    static final String AWS_TEST_MQTT311_ROOTCA = System.getProperty("AWS_TEST_MQTT311_ROOT_CA");
+    static final String AWS_TEST_MQTT311_IOT_CORE_HOST = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_HOST");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_CERT = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_CERT");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_KEY = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_KEY");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS");
+    static final String AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME");
 
     private static String PROXY_TEST_CLIENTID = "ProxyTest-";
     private static final short MQTT_DIRECT_PORT = 8883;

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
@@ -45,10 +45,10 @@ import java.util.stream.DoubleStream;
 
 public class S3ClientTest extends CrtTestFixture {
 
-    static final String ENDPOINT = System.getenv("ENDPOINT") == null
+    static final String ENDPOINT = System.getProperty("ENDPOINT") == null
             ? "aws-crt-test-stuff-us-west-2.s3.us-west-2.amazonaws.com"
-            : System.getenv("ENDPOINT");
-    static final String REGION = System.getenv("REGION") == null ? "us-west-2" : System.getenv("REGION");
+            : System.getProperty("ENDPOINT");
+    static final String REGION = System.getProperty("REGION") == null ? "us-west-2" : System.getProperty("REGION");
 
     static final String COPY_SOURCE_BUCKET = "aws-crt-test-stuff-us-west-2";
     static final String COPY_SOURCE_KEY = "crt-canary-obj.txt";

--- a/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
@@ -7,11 +7,8 @@ import java.nio.file.Paths;
 
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.is;
-import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.io.Pkcs11Lib;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;

--- a/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TlsContextOptionsTest.java
@@ -95,10 +95,11 @@ public class TlsContextOptionsTest extends CrtTestFixture {
             + "54irVW5mNUDcA8s9+DloeTlUlJIr8J/RADC9rpqHLaZzcdvpIMhVsw==\n"
             + "-----END RSA PRIVATE KEY-----";
 
-    static final String AWS_TEST_MQTT311_IOT_CORE_RSA_CERT = System.getenv("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT");
-    static final String AWS_TEST_MQTT311_IOT_CORE_RSA_KEY = System.getenv("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY");
+    static final String AWS_TEST_MQTT311_IOT_CORE_RSA_CERT = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_RSA_CERT");
+    static final String AWS_TEST_MQTT311_IOT_CORE_RSA_KEY = System.getProperty("AWS_TEST_MQTT311_IOT_CORE_RSA_KEY");
 
     // Skip test if system property, or the file it describes, cannot be found
+    // TODO This seems unused. Can be removed?
     private String getPathStringFromEnvironmentVariable(String environmentVariable) {
         try {
             String pathStr = System.getenv(environmentVariable);


### PR DESCRIPTION
Change unit tests to setup using system properties instead of pulling directly from environment variables.

Android does not support environment variables in a way that can be used to run unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
