### PR TITLE
Release native references in failed tests

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -42,6 +42,9 @@ public class CrtTestFixture {
 
     // Setup System properties from environment variables set by builder for use by unit tests.
     private void SetupTestProperties(){
+        // Indicate that the system properties have been setup
+        System.setProperty("are.test.properties.setup", "true");
+
         SetPropertyFromEnv("AWS_TEST_IS_CI");
         SetPropertyFromEnv("AWS_TEST_MQTT311_ROOT_CA");
         SetPropertyFromEnv("ENDPOINT");
@@ -200,9 +203,6 @@ public class CrtTestFixture {
 
         SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_USERNAME");
         SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_PASSWORD");
-
-        // Indicate that the system properties have been setup
-        System.setProperty("are.test.properties.setup", "true");
     }
 
     @Before

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -219,9 +219,10 @@ public class CrtTestFixture {
         }
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup begin");
 
+        // TODO this CrtTestContext should be removed as we are using System Properties for tests now.
+        context = new CrtTestContext();
         // System properties for tests only need to be setup once
         if (System.getProperty("are.test.properties.setup") != "true"){
-            context = new CrtTestContext();
             CrtPlatform platform = CRT.getPlatformImpl();
             if (platform != null) {
                 platform.testSetup(context);

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -237,10 +237,6 @@ public class CrtTestFixture {
 
         context = null;
 
-        EventLoopGroup.closeStaticDefault();
-        HostResolver.closeStaticDefault();
-        ClientBootstrap.closeStaticDefault();
-
         CrtResource.waitForNoResources();
         if (CRT.getOSIdentifier() != "android") {
             try {

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -200,6 +200,9 @@ public class CrtTestFixture {
 
         SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_USERNAME");
         SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_PASSWORD");
+
+        // Indicate that the system properties have been setup
+        System.setProperty("are.test.properties.setup", "true");
     }
 
     @Before
@@ -216,12 +219,15 @@ public class CrtTestFixture {
         }
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup begin");
 
-        context = new CrtTestContext();
-        CrtPlatform platform = CRT.getPlatformImpl();
-        if (platform != null) {
-            platform.testSetup(context);
-        } else {
-            SetupTestProperties();
+        // System properties for tests only need to be setup once
+        if (System.getProperty("are.test.properties.setup") != null){
+            context = new CrtTestContext();
+            CrtPlatform platform = CRT.getPlatformImpl();
+            if (platform != null) {
+                platform.testSetup(context);
+            } else {
+                SetupTestProperties();
+            }
         }
 
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup end");

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -220,7 +220,7 @@ public class CrtTestFixture {
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup begin");
 
         // System properties for tests only need to be setup once
-        if (System.getProperty("are.test.properties.setup") != null){
+        if (System.getProperty("are.test.properties.setup") != "true"){
             context = new CrtTestContext();
             CrtPlatform platform = CRT.getPlatformImpl();
             if (platform != null) {

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
@@ -348,7 +348,9 @@ import java.util.function.Consumer;
                     connected.get();
                     result = true;
                 }
-                client.close();
+                finally {
+                    client.close();
+                }
 
             } catch (Exception ex) {
                 fail("Exception during connect: " + ex.toString());

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
@@ -135,109 +135,114 @@ import java.util.function.Consumer;
     MqttClientConnectionFixture() {
     }
 
-    boolean connectDirectWithConfig(TlsContext tlsContext, String endpoint, int port, String username, String password, HttpProxyOptions httpProxyOptions, EventLoopGroup elg, HostResolver hr, ClientBootstrap bootstrap)
+    boolean connectDirectWithConfig(TlsContext tlsContext, String endpoint, int port, String username, String password, HttpProxyOptions httpProxyOptions)
     {
         try {
-            return connectDirectWithConfigThrows(tlsContext, endpoint, port, username, password, httpProxyOptions, elg, hr, bootstrap);
+            return connectDirectWithConfigThrows(tlsContext, endpoint, port, username, password, httpProxyOptions);
         } catch (Exception ex) {
             fail("Exception during connect: " + ex.toString());
         }
         return false;
     }
 
-    boolean connectDirectWithConfigThrows(TlsContext tlsContext, String endpoint, int port, String username, String password, HttpProxyOptions httpProxyOptions, EventLoopGroup elg, HostResolver hr, ClientBootstrap bootstrap) throws Exception
+    boolean connectDirectWithConfigThrows(TlsContext tlsContext, String endpoint, int port, String username, String password, HttpProxyOptions httpProxyOptions) throws Exception
     {
-        // Connection callback events
-        MqttClientConnectionEvents events = new MqttClientConnectionEvents() {
-            @Override
-            public void onConnectionResumed(boolean sessionPresent) {
-                System.out.println("Connection resumed");
-            }
+        try(EventLoopGroup elg = new EventLoopGroup(1);
+            HostResolver hr = new HostResolver(elg);
+            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);) {
 
-            @Override
-            public void onConnectionInterrupted(int errorCode) {
-                if (!disconnecting) {
-                    System.out.println(
-                            "Connection interrupted: error: " + errorCode + " " + CRT.awsErrorString(errorCode));
+            // Connection callback events
+            MqttClientConnectionEvents events = new MqttClientConnectionEvents() {
+                @Override
+                public void onConnectionResumed(boolean sessionPresent) {
+                    System.out.println("Connection resumed");
                 }
-            }
 
-            @Override
-            public void onConnectionFailure(OnConnectionFailureReturn data) {
-                System.out.println("Connection failed with error: " + data.getErrorCode() + " " + CRT.awsErrorString(data.getErrorCode()));
-                onConnectionFailureFuture.complete(data);
-            }
-
-            @Override
-            public void onConnectionSuccess(OnConnectionSuccessReturn data) {
-                System.out.println("Connection success. Session present: " + data.getSessionPresent());
-                onConnectionSuccessFuture.complete(data);
-            }
-
-            @Override
-            public void onConnectionClosed(OnConnectionClosedReturn data) {
-                System.out.println("Connection disconnected successfully");
-                onConnectionClosedFuture.complete(data);
-            }
-        };
-
-        // Default settings
-        boolean cleanSession = true; // only true is supported right now
-        int keepAliveSecs = 0;
-        int protocolOperationTimeout = 60000;
-        String clientId = TEST_CLIENTID + (UUID.randomUUID()).toString();
-
-        try (MqttConnectionConfig config = new MqttConnectionConfig()) {
-
-            MqttClient client = null;
-            if (tlsContext != null)
-            {
-                client = new MqttClient(bootstrap, tlsContext);
-            }
-            else
-            {
-                client = new MqttClient(bootstrap);
-            }
-
-            config.setMqttClient(client);
-            config.setClientId(clientId);
-            config.setEndpoint(endpoint);
-            config.setPort(port);
-            config.setCleanSession(cleanSession);
-            config.setKeepAliveSecs(keepAliveSecs);
-            config.setProtocolOperationTimeoutMs(protocolOperationTimeout);
-            config.setConnectionCallbacks(events);
-
-            if (httpProxyOptions != null) {
-                config.setHttpProxyOptions(httpProxyOptions);
-            }
-            if (username != null) {
-                config.setUsername(username);
-            }
-            if (password != null)
-            {
-                config.setPassword(password);
-            }
-
-            if (connectionConfigTransformer != null) {
-                connectionConfigTransformer.accept(config);
-            }
-
-            try {
-                connection = new MqttClientConnection(config);
-                if (connectionMessageTransfomer != null) {
-                    connection.onMessage(connectionMessageTransfomer);
+                @Override
+                public void onConnectionInterrupted(int errorCode) {
+                    if (!disconnecting) {
+                        System.out.println(
+                                "Connection interrupted: error: " + errorCode + " " + CRT.awsErrorString(errorCode));
+                    }
                 }
-                CompletableFuture<Boolean> connected = connection.connect();
-                connected.get();
-            } finally {
-                client.close();
+
+                @Override
+                public void onConnectionFailure(OnConnectionFailureReturn data) {
+                    System.out.println("Connection failed with error: " + data.getErrorCode() + " " + CRT.awsErrorString(data.getErrorCode()));
+                    onConnectionFailureFuture.complete(data);
+                }
+
+                @Override
+                public void onConnectionSuccess(OnConnectionSuccessReturn data) {
+                    System.out.println("Connection success. Session present: " + data.getSessionPresent());
+                    onConnectionSuccessFuture.complete(data);
+                }
+
+                @Override
+                public void onConnectionClosed(OnConnectionClosedReturn data) {
+                    System.out.println("Connection disconnected successfully");
+                    onConnectionClosedFuture.complete(data);
+                }
+            };
+
+            // Default settings
+            boolean cleanSession = true; // only true is supported right now
+            int keepAliveSecs = 0;
+            int protocolOperationTimeout = 60000;
+            String clientId = TEST_CLIENTID + (UUID.randomUUID()).toString();
+
+            try (MqttConnectionConfig config = new MqttConnectionConfig()) {
+
+                MqttClient client = null;
+                if (tlsContext != null)
+                {
+                    client = new MqttClient(bootstrap, tlsContext);
+                }
+                else
+                {
+                    client = new MqttClient(bootstrap);
+                }
+
+                config.setMqttClient(client);
+                config.setClientId(clientId);
+                config.setEndpoint(endpoint);
+                config.setPort(port);
+                config.setCleanSession(cleanSession);
+                config.setKeepAliveSecs(keepAliveSecs);
+                config.setProtocolOperationTimeoutMs(protocolOperationTimeout);
+                config.setConnectionCallbacks(events);
+
+                if (httpProxyOptions != null) {
+                    config.setHttpProxyOptions(httpProxyOptions);
+                }
+                if (username != null) {
+                    config.setUsername(username);
+                }
+                if (password != null)
+                {
+                    config.setPassword(password);
+                }
+
+                if (connectionConfigTransformer != null) {
+                    connectionConfigTransformer.accept(config);
+                }
+
+                try {
+                    connection = new MqttClientConnection(config);
+                    if (connectionMessageTransfomer != null) {
+                        connection.onMessage(connectionMessageTransfomer);
+                    }
+                    CompletableFuture<Boolean> connected = connection.connect();
+                    connected.get();
+                } finally {
+                    client.close();
+                }
+                return true;
             }
-            return true;
         }
     }
 
-    boolean connectWebsocketsWithCredentialsProvider(CredentialsProvider credentialsProvider, String endpoint, int port, TlsContext tlsContext, String username, String password, HttpProxyOptions httpProxyOptions, EventLoopGroup elg, HostResolver hr, ClientBootstrap bootstrap)
+    boolean connectWebsocketsWithCredentialsProvider(CredentialsProvider credentialsProvider, String endpoint, int port, TlsContext tlsContext, String username, String password, HttpProxyOptions httpProxyOptions)
     {
         // Return result
         boolean result = false;
@@ -281,71 +286,74 @@ import java.util.function.Consumer;
             }
         };
 
+        try (EventLoopGroup elg = new EventLoopGroup(1);
+            HostResolver hr = new HostResolver(elg);
+            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);)
+        {
+            try (MqttConnectionConfig config = new MqttConnectionConfig();
+                 AwsSigningConfig signingConfig = new AwsSigningConfig();) {
 
-        try (MqttConnectionConfig config = new MqttConnectionConfig();
-             AwsSigningConfig signingConfig = new AwsSigningConfig();) {
-
-            MqttClient client = null;
-            if (tlsContext != null)
-            {
-                client = new MqttClient(bootstrap, tlsContext);
-            }
-            else
-            {
-                client = new MqttClient(bootstrap);
-            }
-
-            config.setMqttClient(client);
-            config.setClientId(clientId);
-            config.setEndpoint(endpoint);
-            config.setPort(port);
-            config.setCleanSession(cleanSession);
-            config.setKeepAliveSecs(keepAliveSecs);
-            config.setProtocolOperationTimeoutMs(protocolOperationTimeout);
-            config.setUseWebsockets(true);
-            config.setConnectionCallbacks(events);
-
-            if (username != null) {
-                config.setUsername(username);
-            }
-            if (password != null) {
-                config.setPassword(password);
-            }
-            if (httpProxyOptions != null) {
-                config.setHttpProxyOptions(httpProxyOptions);
-            }
-
-            if (connectionConfigTransformer != null) {
-                connectionConfigTransformer.accept(config);
-            }
-
-            // Make the websocket transformer
-            if (credentialsProvider != null) {
-                signingConfig.setAlgorithm(AwsSigningConfig.AwsSigningAlgorithm.SIGV4);
-                // NOTE: Missing a credentials provider gives a non-helpful error. This needs to be changed in Java V2...
-                signingConfig.setCredentialsProvider(credentialsProvider);
-            }
-            signingConfig.setSignatureType(AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_VIA_QUERY_PARAMS);
-            signingConfig.setRegion(TEST_REGION);
-            signingConfig.setService("iotdevicegateway");
-            signingConfig.setOmitSessionToken(true);
-            try (MqttClientConnectionSigv4HandshakeTransformer transformer = new MqttClientConnectionSigv4HandshakeTransformer(signingConfig);)
-            {
-                config.setWebsocketHandshakeTransform(transformer);
-                connection = new MqttClientConnection(config);
-                if (connectionMessageTransfomer != null) {
-                    connection.onMessage(connectionMessageTransfomer);
+                MqttClient client = null;
+                if (tlsContext != null)
+                {
+                    client = new MqttClient(bootstrap, tlsContext);
                 }
-                CompletableFuture<Boolean> connected = connection.connect();
-                connected.get();
-                result = true;
+                else
+                {
+                    client = new MqttClient(bootstrap);
+                }
+
+                config.setMqttClient(client);
+                config.setClientId(clientId);
+                config.setEndpoint(endpoint);
+                config.setPort(port);
+                config.setCleanSession(cleanSession);
+                config.setKeepAliveSecs(keepAliveSecs);
+                config.setProtocolOperationTimeoutMs(protocolOperationTimeout);
+                config.setUseWebsockets(true);
+                config.setConnectionCallbacks(events);
+
+                if (username != null) {
+                    config.setUsername(username);
+                }
+                if (password != null) {
+                    config.setPassword(password);
+                }
+                if (httpProxyOptions != null) {
+                    config.setHttpProxyOptions(httpProxyOptions);
+                }
+
+                if (connectionConfigTransformer != null) {
+                    connectionConfigTransformer.accept(config);
+                }
+
+                // Make the websocket transformer
+                if (credentialsProvider != null) {
+                    signingConfig.setAlgorithm(AwsSigningConfig.AwsSigningAlgorithm.SIGV4);
+                    // NOTE: Missing a credentials provider gives a non-helpful error. This needs to be changed in Java V2...
+                    signingConfig.setCredentialsProvider(credentialsProvider);
+                }
+                signingConfig.setSignatureType(AwsSigningConfig.AwsSignatureType.HTTP_REQUEST_VIA_QUERY_PARAMS);
+                signingConfig.setRegion(TEST_REGION);
+                signingConfig.setService("iotdevicegateway");
+                signingConfig.setOmitSessionToken(true);
+                try (MqttClientConnectionSigv4HandshakeTransformer transformer = new MqttClientConnectionSigv4HandshakeTransformer(signingConfig);)
+                {
+                    config.setWebsocketHandshakeTransform(transformer);
+                    connection = new MqttClientConnection(config);
+                    if (connectionMessageTransfomer != null) {
+                        connection.onMessage(connectionMessageTransfomer);
+                    }
+                    CompletableFuture<Boolean> connected = connection.connect();
+                    connected.get();
+                    result = true;
+                }
+                client.close();
+
+            } catch (Exception ex) {
+                fail("Exception during connect: " + ex.toString());
             }
-            client.close();
-
-        } catch (Exception ex) {
-            fail("Exception during connect: " + ex.toString());
         }
-
         return result;
     }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionMethodTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionMethodTest.java
@@ -67,6 +67,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                         null,
                         null);
                     disconnect();
+                }
+                finally {
                     close();
                 }
         }
@@ -98,6 +100,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                     null,
                     null);
                 disconnect();
+            }
+            finally {
                 close();
             }
     }
@@ -122,6 +126,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                     null,
                     null);
                 disconnect();
+            }
+            finally {
                 close();
             }
     }
@@ -157,6 +163,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                         null,
                         null);
                     disconnect();
+                }
+                finally {
                     close();
                 }
         }
@@ -187,6 +195,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
             CredentialsProvider provider = builder.build();) {
             connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
             disconnect();
+        }
+        finally {
             close();
         }
     }
@@ -208,6 +218,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                 CredentialsProvider provider = builder.build();) {
                 connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
                 disconnect();
+            }
+            finally {
                 close();
             }
         }
@@ -237,6 +249,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                 CredentialsProvider provider = builder.build();) {
                 connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
                 disconnect();
+            }
+            finally {
                 close();
             }
         }
@@ -270,6 +284,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                 CredentialsProvider provider = builder.build();) {
                 connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
                 disconnect();
+            }
+            finally {
                 close();
             }
         }
@@ -336,6 +352,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                         null,
                         null);
                     disconnect();
+                }
+                finally {
                     close();
                 }
             }
@@ -369,6 +387,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                         null,
                         null);
                     disconnect();
+                }
+                finally {
                     close();
                 }
             }
@@ -400,6 +420,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                         null,
                         proxyOptions);
                     disconnect();
+                }
+                finally {
                     close();
                 }
             }
@@ -470,6 +492,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                     null,
                     null);
                 disconnect();
+            }
+            finally {
                 close();
             }
         }
@@ -501,6 +525,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                     null,
                     proxyOptions);
                 disconnect();
+            }
+            finally {
                 close();
             }
         }

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionMethodTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionMethodTest.java
@@ -206,7 +206,7 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
                 TlsContext tlsContext = new TlsContext(tlsOptions);
                 CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null, elg, hr, bootstrap);
+                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
                 disconnect();
                 close();
             }
@@ -235,7 +235,7 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
                 TlsContext tlsContext = new TlsContext(tlsOptions);
                 CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null, elg, hr, bootstrap);
+                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
                 disconnect();
                 close();
             }
@@ -268,7 +268,7 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
                 TlsContext tlsContext = new TlsContext(tlsOptions);
                 CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null, elg, hr, bootstrap);
+                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
                 disconnect();
                 close();
             }

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionMethodTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionMethodTest.java
@@ -206,7 +206,7 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
                 TlsContext tlsContext = new TlsContext(tlsOptions);
                 CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
+                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null, elg, hr, bootstrap);
                 disconnect();
                 close();
             }
@@ -235,7 +235,7 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
                 TlsContext tlsContext = new TlsContext(tlsOptions);
                 CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
+                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null, elg, hr, bootstrap);
                 disconnect();
                 close();
             }
@@ -268,7 +268,7 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
             try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
                 TlsContext tlsContext = new TlsContext(tlsOptions);
                 CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
+                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null, elg, hr, bootstrap);
                 disconnect();
                 close();
             }


### PR DESCRIPTION
Some tests were not cleaning up native references because `close()` was being called in a failing try block. These calls have been moved to a finally block to insure native references get cleaned up so tests don't time out after failing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
