### PR TITLE
Unit Test Setup with @BeforeClass notation

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.crt.auth.credentials.Credentials;
 import software.amazon.awssdk.crt.auth.credentials.DefaultChainCredentialsProvider;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.After;
 import org.junit.Assume;
 
@@ -33,7 +34,7 @@ public class CrtTestFixture {
         return context;
     }
 
-    private void SetPropertyFromEnv(String name){
+    private static void SetPropertyFromEnv(String name){
         String propertyValue = System.getenv(name);
         if (propertyValue != null){
             System.setProperty(name, propertyValue);
@@ -41,10 +42,7 @@ public class CrtTestFixture {
     }
 
     // Setup System properties from environment variables set by builder for use by unit tests.
-    private void SetupTestProperties(){
-        // Indicate that the system properties have been setup
-        System.setProperty("are.test.properties.setup", "true");
-
+    private static void SetupTestProperties(){
         SetPropertyFromEnv("AWS_TEST_IS_CI");
         SetPropertyFromEnv("AWS_TEST_MQTT311_ROOT_CA");
         SetPropertyFromEnv("ENDPOINT");
@@ -205,6 +203,12 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_PASSWORD");
     }
 
+    @BeforeClass
+    public static void setupEnv()
+    {
+        SetupTestProperties();
+    }
+
     @Before
     public void setup() {
         // We only want to see the CRT logs if the test fails.
@@ -221,16 +225,10 @@ public class CrtTestFixture {
 
         // TODO this CrtTestContext should be removed as we are using System Properties for tests now.
         context = new CrtTestContext();
-        // System properties for tests only need to be setup once
-        if (System.getProperty("are.test.properties.setup") != "true"){
-            CrtPlatform platform = CRT.getPlatformImpl();
-            if (platform != null) {
-                platform.testSetup(context);
-            } else {
-                SetupTestProperties();
-            }
+        CrtPlatform platform = CRT.getPlatformImpl();
+        if (platform != null) {
+            platform.testSetup(context);
         }
-
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup end");
     }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -205,8 +205,9 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_BASIC_AUTH_PASSWORD");
     }
 
+    /* The function will be run once before any of the test methods in the class */
     @BeforeClass
-    public static void setupEnv() {
+    public static void setupOnce() {
         // We only want to see the CRT logs if the test fails.
         // Surefire has a redirectTestOutputToFile option, but that doesn't
         // capture what the CRT logger writes to stdout or stderr.
@@ -220,6 +221,7 @@ public class CrtTestFixture {
         SetupTestProperties();
     }
 
+    /* The setup function will be run before every test */
     @Before
     public void setup() {
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup begin");

--- a/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CrtTestFixture.java
@@ -34,15 +34,16 @@ public class CrtTestFixture {
         return context;
     }
 
-    private static void SetPropertyFromEnv(String name){
+    private static void SetPropertyFromEnv(String name) {
         String propertyValue = System.getenv(name);
-        if (propertyValue != null){
+        if (propertyValue != null) {
             System.setProperty(name, propertyValue);
         }
     }
 
-    // Setup System properties from environment variables set by builder for use by unit tests.
-    private static void SetupTestProperties(){
+    // Setup System properties from environment variables set by builder for use by
+    // unit tests.
+    private static void SetupTestProperties() {
         SetPropertyFromEnv("AWS_TEST_IS_CI");
         SetPropertyFromEnv("AWS_TEST_MQTT311_ROOT_CA");
         SetPropertyFromEnv("ENDPOINT");
@@ -52,7 +53,7 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_MQTT311_COGNITO_ENDPOINT");
         SetPropertyFromEnv("AWS_TEST_MQTT311_COGNITO_IDENTITY");
 
-        //Proxy
+        // Proxy
         SetPropertyFromEnv("AWS_TEST_HTTP_PROXY_HOST");
         SetPropertyFromEnv("AWS_TEST_HTTP_PROXY_PORT");
         SetPropertyFromEnv("AWS_TEST_HTTPS_PROXY_HOST");
@@ -195,7 +196,8 @@ public class CrtTestFixture {
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS");
         SetPropertyFromEnv("AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE");
 
-        // MQTT5 Custom Key Ops (so we don't have to make a new file just for a single test)
+        // MQTT5 Custom Key Ops (so we don't have to make a new file just for a single
+        // test)
         SetPropertyFromEnv("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_CERT");
         SetPropertyFromEnv("AWS_TEST_MQTT5_CUSTOM_KEY_OPS_KEY");
 
@@ -204,13 +206,7 @@ public class CrtTestFixture {
     }
 
     @BeforeClass
-    public static void setupEnv()
-    {
-        SetupTestProperties();
-    }
-
-    @Before
-    public void setup() {
+    public static void setupEnv() {
         // We only want to see the CRT logs if the test fails.
         // Surefire has a redirectTestOutputToFile option, but that doesn't
         // capture what the CRT logger writes to stdout or stderr.
@@ -221,9 +217,15 @@ public class CrtTestFixture {
         if (System.getProperty("aws.crt.aws_trace_log_per_test") != null) {
             Log.initLoggingToFile(Log.LogLevel.Trace, "log.txt");
         }
+        SetupTestProperties();
+    }
+
+    @Before
+    public void setup() {
         Log.log(Log.LogLevel.Debug, LogSubject.JavaCrtGeneral, "CrtTestFixture setup begin");
 
-        // TODO this CrtTestContext should be removed as we are using System Properties for tests now.
+        // TODO this CrtTestContext should be removed as we are using System Properties
+        // for tests now.
         context = new CrtTestContext();
         CrtPlatform platform = CRT.getPlatformImpl();
         if (platform != null) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Introduce `@BeforeClass` setup function so that the log/environment variable will be set only once for the unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
