### PR TITLE
Android CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,26 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           ./gradlew :android:crt:build
+          ./gradlew :android:crt:publishToMavenLocal
+      # Setup files required by test app for Device Farm testing
+      - name: Setup Android Test Files
+        run: |
+          cd src/test/android/testapp/src/main/assets
+          python3 -m pip install boto3
+          python3 ./android_file_creation.py
+      - name: Build Test App
+        run: |
+          cd src/test/android/testapp
+          ../../../../gradlew assembledebug
+          ../../../../gradlew assembleAndroidTest
+      - name: Device Farm Tests
+        run: |
+          echo "Running Device Farm Python Script"
+          python3 ./.github/workflows/run_android_ci.py \
+          --run_id ${{ github.run_id }} \
+          --run_attempt ${{ github.run_attempt }} \
+          --project_arn $(aws secretsmanager get-secret-value --region us-east-1 --secret-id "ci/DeviceFarm/ProjectArn" --query "SecretString" | cut -f5 -d\" | cut -f1 -d'\') \
+          --device_pool_arn $(aws secretsmanager get-secret-value --region us-east-1 --secret-id "ci/DeviceFarm/DevicePoolArn" --query "SecretString" | cut -f5 -d\" | cut -f1 -d'\')
 
   # check that docs can still build
   check-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           ./gradlew :android:crt:build
-          ./gradlew :android:crt:publishToMavenLocal
+          ./gradlew -PnewVersion="1.0.0-SNAPSHOT" :android:crt:publishToMavenLocal
       # Setup files required by test app for Device Farm testing
       - name: Setup Android Test Files
         run: |

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -174,6 +174,8 @@ afterEvaluate {
 
                 groupId = 'software.amazon.awssdk.crt'
                 artifactId = 'aws-crt-android'
+                version = project.hasProperty('newVersion') ? project.property('newVersion') : android.defaultConfig.versionName
+
                 pom {
                     name.set("software.amazon.awssdk.crt:aws-crt-android")
                     description.set("Java Android bindings for the AWS SDK Common Runtime")
@@ -199,15 +201,6 @@ afterEvaluate {
                         url.set("https://github.com/awslabs/aws-crt-java")
                     }
                 }
-                version = android.defaultConfig.versionName
-            }
-
-            debug(MavenPublication) {
-                from components.release
-
-                groupId = 'software.amazon.awssdk.crt'
-                artifactId = 'aws-crt-android'
-                version = '1.0.0-SNAPSHOT'
             }
         }
 

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -201,6 +201,14 @@ afterEvaluate {
                 }
                 version = android.defaultConfig.versionName
             }
+
+            debug(MavenPublication) {
+                from components.release
+
+                groupId = 'software.amazon.awssdk.crt'
+                artifactId = 'aws-crt-android'
+                version = '1.0.0-SNAPSHOT'
+            }
         }
 
         repositories {

--- a/codebuild/cd/deploy-platform-specific-jars.sh
+++ b/codebuild/cd/deploy-platform-specific-jars.sh
@@ -13,7 +13,7 @@ else
   DEPLOY_REPOSITORY_URL=https://aws.oss.sonatype.org:443/service/local/staging/deployByRepositoryId/${STAGING_REPO_ID}
 fi
 
-CLASSIFIERS_ARRAY=("linux-armv6" "linux-armv7" "linux-aarch_64" "linux-x86_32" "linux-x86_64" "osx-aarch_64" "osx-x86_64" "windows-x86_32" "windows-x86_64" "linux-x86_64-musl" "linux-armv7-musl" "linux-aarch_64-musl")
+CLASSIFIERS_ARRAY=("linux-x86_64")
 
 for str in ${CLASSIFIERS_ARRAY[@]}; do
   FILES="${FILES}target/aws-crt-1.0.0-SNAPSHOT-$str.jar,"

--- a/codebuild/cd/deploy-platform-specific-jars.sh
+++ b/codebuild/cd/deploy-platform-specific-jars.sh
@@ -13,7 +13,7 @@ else
   DEPLOY_REPOSITORY_URL=https://aws.oss.sonatype.org:443/service/local/staging/deployByRepositoryId/${STAGING_REPO_ID}
 fi
 
-CLASSIFIERS_ARRAY=("linux-x86_64")
+CLASSIFIERS_ARRAY=("linux-armv6" "linux-armv7" "linux-aarch_64" "linux-x86_32" "linux-x86_64" "osx-aarch_64" "osx-x86_64" "windows-x86_32" "windows-x86_64" "linux-x86_64-musl" "linux-armv7-musl" "linux-aarch_64-musl")
 
 for str in ${CLASSIFIERS_ARRAY[@]}; do
   FILES="${FILES}target/aws-crt-1.0.0-SNAPSHOT-$str.jar,"

--- a/codebuild/cd/deploy-snapshot.yml
+++ b/codebuild/cd/deploy-snapshot.yml
@@ -27,9 +27,11 @@ phases:
       # mv all the platform-specific jars to target/
       - aws s3 cp --recursive s3://aws-crt-java-pipeline/v${PKG_VERSION}/jar $CODEBUILD_SRC_DIR/aws-crt-java/target/
       - mv $CODEBUILD_SRC_DIR_linux_x64/dist/aws-crt-1.0.0-SNAPSHOT-linux-x86_64.jar $CODEBUILD_SRC_DIR/aws-crt-java/target/
+      - mv $CODEBUILD_SRC_DIR_linux_x86/dist/aws-crt-1.0.0-SNAPSHOT-linux-x86_32.jar $CODEBUILD_SRC_DIR/aws-crt-java/target/
       # cp all the shared libs to cmake-build
       - aws s3 cp --recursive s3://aws-crt-java-pipeline/v${PKG_VERSION}/lib $CODEBUILD_SRC_DIR/aws-crt-java/target/cmake-build/lib
       - cp -rv $CODEBUILD_SRC_DIR_linux_x64/dist/* $CODEBUILD_SRC_DIR/aws-crt-java/target/cmake-build/
+      - cp -rv $CODEBUILD_SRC_DIR_linux_x86/dist/* $CODEBUILD_SRC_DIR/aws-crt-java/target/cmake-build/
       - ls -alR $CODEBUILD_SRC_DIR/aws-crt-java/target
       # install settings.xml to ~/.m2/settings.xml
       - mkdir -p $HOME/.m2

--- a/codebuild/cd/deploy-snapshot.yml
+++ b/codebuild/cd/deploy-snapshot.yml
@@ -27,11 +27,9 @@ phases:
       # mv all the platform-specific jars to target/
       - aws s3 cp --recursive s3://aws-crt-java-pipeline/v${PKG_VERSION}/jar $CODEBUILD_SRC_DIR/aws-crt-java/target/
       - mv $CODEBUILD_SRC_DIR_linux_x64/dist/aws-crt-1.0.0-SNAPSHOT-linux-x86_64.jar $CODEBUILD_SRC_DIR/aws-crt-java/target/
-      - mv $CODEBUILD_SRC_DIR_linux_x86/dist/aws-crt-1.0.0-SNAPSHOT-linux-x86_32.jar $CODEBUILD_SRC_DIR/aws-crt-java/target/
       # cp all the shared libs to cmake-build
       - aws s3 cp --recursive s3://aws-crt-java-pipeline/v${PKG_VERSION}/lib $CODEBUILD_SRC_DIR/aws-crt-java/target/cmake-build/lib
       - cp -rv $CODEBUILD_SRC_DIR_linux_x64/dist/* $CODEBUILD_SRC_DIR/aws-crt-java/target/cmake-build/
-      - cp -rv $CODEBUILD_SRC_DIR_linux_x86/dist/* $CODEBUILD_SRC_DIR/aws-crt-java/target/cmake-build/
       - ls -alR $CODEBUILD_SRC_DIR/aws-crt-java/target
       # install settings.xml to ~/.m2/settings.xml
       - mkdir -p $HOME/.m2


### PR DESCRIPTION
Fix Android CI so it can run without breaking CD. Setting the version manually during install for the CI testing to find it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
