### PR TITLE
Cleanup CrtS3RuntimeException

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/s3/CrtS3RuntimeException.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/CrtS3RuntimeException.java
@@ -6,17 +6,14 @@ package software.amazon.awssdk.crt.s3;
 
 import software.amazon.awssdk.crt.CrtRuntimeException;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class CrtS3RuntimeException extends CrtRuntimeException {
 
-    private final int statusCode;
+    private final int responseStatus;
     private final byte[] errorPayload;
 
     public CrtS3RuntimeException(int errorCode, int responseStatus, byte[] errorPayload) {
         super(errorCode);
-        this.statusCode = responseStatus;
+        this.responseStatus = responseStatus;
         this.errorPayload = errorPayload;
     }
 
@@ -30,7 +27,7 @@ public class CrtS3RuntimeException extends CrtRuntimeException {
      */
     public CrtS3RuntimeException(int errorCode, int responseStatus, byte[] errorPayload, Throwable cause) {
         super(errorCode, cause);
-        this.statusCode = responseStatus;
+        this.responseStatus = responseStatus;
         this.errorPayload = errorPayload;
     }
 
@@ -39,8 +36,8 @@ public class CrtS3RuntimeException extends CrtRuntimeException {
      *
      * @return status code in int
      */
-    public int getStatusCode() {
-        return statusCode;
+    public int getResponseStatus() {
+        return responseStatus;
 
     }
 
@@ -54,6 +51,6 @@ public class CrtS3RuntimeException extends CrtRuntimeException {
 
     @Override
     public String toString() {
-        return String.format("%s: response status code(%d), error payload(%s)", super.toString(), statusCode, errorPayload);
+        return String.format("%s: response status code(%d), error payload(%s)", super.toString(), responseStatus, new String(errorPayload, java.nio.charset.StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/s3/CrtS3RuntimeException.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/CrtS3RuntimeException.java
@@ -12,31 +12,12 @@ import java.util.regex.Pattern;
 public class CrtS3RuntimeException extends CrtRuntimeException {
 
     private final int statusCode;
-    private final String awsErrorCode;
-    private final String awsErrorMessage;
-    private final String errorPayload;
-
-    private final static String codeBeginBlock = new String("<Code>");
-    private final static String codeEndBlock = new String("</Code>");
-    private final static String messageBeginBlock = new String("<Message>");
-    private final static String messageEndBlock = new String("</Message>");
-
-    public CrtS3RuntimeException(int errorCode, int responseStatus, String errorPayload) {
-        super(errorCode);
-        this.statusCode = responseStatus;
-        this.errorPayload = errorPayload;
-        this.awsErrorCode = GetElementFromPayload(errorPayload, codeBeginBlock, codeEndBlock);
-        this.awsErrorMessage = GetElementFromPayload(errorPayload, messageBeginBlock, messageEndBlock);
-    }
-
+    private final byte[] errorPayload;
 
     public CrtS3RuntimeException(int errorCode, int responseStatus, byte[] errorPayload) {
         super(errorCode);
-        String errorString = new String(errorPayload, java.nio.charset.StandardCharsets.UTF_8);
         this.statusCode = responseStatus;
-        this.errorPayload = errorString;
-        this.awsErrorCode = GetElementFromPayload(this.errorPayload, codeBeginBlock, codeEndBlock);
-        this.awsErrorMessage = GetElementFromPayload(this.errorPayload, messageBeginBlock, messageEndBlock);
+        this.errorPayload = errorPayload;
     }
 
 
@@ -49,47 +30,8 @@ public class CrtS3RuntimeException extends CrtRuntimeException {
      */
     public CrtS3RuntimeException(int errorCode, int responseStatus, byte[] errorPayload, Throwable cause) {
         super(errorCode, cause);
-        String errorString = new String(errorPayload, java.nio.charset.StandardCharsets.UTF_8);
         this.statusCode = responseStatus;
-        this.errorPayload = errorString;
-        this.awsErrorCode = GetElementFromPayload(this.errorPayload, codeBeginBlock, codeEndBlock);
-        this.awsErrorMessage = GetElementFromPayload(this.errorPayload, messageBeginBlock, messageEndBlock);
-    }
-
-    /**
-     * Helper function to get the detail of an element from xml payload. If not
-     * found, empty string will be returned.
-     */
-    private String GetElementFromPayload(String errorPayload, String beginBlock, String endBlock) {
-        Pattern regexFormat = Pattern.compile(beginBlock + ".*" + endBlock);
-        Matcher matcher = regexFormat.matcher(errorPayload);
-        String result = "";
-        if (matcher.find()) {
-            result = errorPayload.substring(matcher.start() + beginBlock.length(), matcher.end() - endBlock.length());
-        }
-        return result;
-    }
-
-    /**
-     * Returns the aws error code from S3 response. The {@code Code} element in xml
-     * response.
-     *
-     * @return errorCode, if no {@code Code} element in the response, empty string will be
-     *         returned
-     */
-    public String getAwsErrorCode() {
-        return awsErrorCode;
-    }
-
-    /**
-     * Returns the error message from S3 response. The detail among {@code Message}
-     * element in xml response.
-     *
-     * @return error message, if no {@code Message} element in the response, empty string
-     *         will be returned
-     */
-    public String getAwsErrorMessage() {
-        return awsErrorMessage;
+        this.errorPayload = errorPayload;
     }
 
     /**
@@ -106,12 +48,12 @@ public class CrtS3RuntimeException extends CrtRuntimeException {
      * Returns the error payload without any parsing from S3 response. Can be empty if there was no error body.
      * @return error payload
      */
-    public String getErrorPayload() {
+    public byte[] getErrorPayload() {
         return errorPayload;
     }
 
     @Override
     public String toString() {
-        return String.format("%s: response status code(%d). aws error code(%s), aws error message(%s)", super.toString(), statusCode, awsErrorCode, awsErrorMessage);
+        return String.format("%s: response status code(%d), error payload(%s)", super.toString(), statusCode, errorPayload);
     }
 }


### PR DESCRIPTION
*Description of changes:*
- Remove XML parsing from CrtS3RuntimeException; it's error-prone, especially with S3 where there's a lot of customization and no fixed API contract. Expose errorPayload directly as is. It's a breaking change, but not many people should be using it for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
