### PR TITLE
Android architecture detection

### DIFF
--- a/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
+++ b/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
@@ -29,7 +29,7 @@ public class CrtPlatformImpl extends CrtPlatform {
 
     public String getResourcePath(String cRuntime, String libraryName) {
         // Internal folder structure of Android aar libraries are different from jar libraries
-        String arch = normalize(System.getProperty("os.arch"));
+        String arch = normalize(System.getProperty("ro.product.cpu.abi"));
 
         if (arch.matches("^(x8664|amd64|ia32e|em64t|x64|x86_64)$")) {
             arch = "x86_64";
@@ -45,7 +45,7 @@ public class CrtPlatformImpl extends CrtPlatform {
             arch =  "arm64-v8a";
         } else if (arch.equals("armv7l")) {
             arch =  "armeabi-v7a";
-        } else if (arch.equals("armv8l")){
+        } else if (arch.equals("armv8a")){
             arch = "armeabi-v8a";
         } else {
             throw new RuntimeException("AWS CRT: architecture not supported on Android: " + arch);

--- a/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
+++ b/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
@@ -45,6 +45,8 @@ public class CrtPlatformImpl extends CrtPlatform {
             arch =  "arm64-v8a";
         } else if (arch.equals("armv7l")) {
             arch =  "armeabi-v7a";
+        } else if (arch.equals("armv8l")){
+            arch = "armeabi-v8a";
         } else {
             throw new RuntimeException("AWS CRT: architecture not supported on Android: " + arch);
         }

--- a/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
+++ b/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
@@ -29,8 +29,9 @@ public class CrtPlatformImpl extends CrtPlatform {
     }
 
     public String getResourcePath(String cRuntime, String libraryName) {
-        // Internal folder structure of Android aar libraries are different from jar libraries
-        String arch = Build.CPU_ABI; //normalize(System.getProperty("ro.product.cpu.abi"));
+        // Internal folder structure of Android aar libraries are different from jar libraries and arch must
+        // be retrieved using Build class instead of a system property.
+        String arch = Build.CPU_ABI;
 
         System.out.println("Build.CPU_ABI: " + arch);
 

--- a/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
+++ b/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.crt.BuildConfig;
 import software.amazon.awssdk.crt.CrtPlatform;
 import software.amazon.awssdk.crt.utils.PackageInfo;
 import java.util.Locale;
+import android.os.Build;
 
 public class CrtPlatformImpl extends CrtPlatform {
     public String getOSIdentifier() {
@@ -29,7 +30,9 @@ public class CrtPlatformImpl extends CrtPlatform {
 
     public String getResourcePath(String cRuntime, String libraryName) {
         // Internal folder structure of Android aar libraries are different from jar libraries
-        String arch = normalize(System.getProperty("ro.product.cpu.abi"));
+        String arch = Build.CPU_ABI; //normalize(System.getProperty("ro.product.cpu.abi"));
+
+        System.out.println("Build.CPU_ABI: " + arch);
 
         if (arch.matches("^(x8664|amd64|ia32e|em64t|x64|x86_64)$")) {
             arch = "x86_64";
@@ -41,12 +44,10 @@ public class CrtPlatformImpl extends CrtPlatform {
             } else {
                 throw new RuntimeException("AWS CRT: architecture not supported on Android: " + arch);
             }
-        } else if (arch.startsWith("arm64") || arch.startsWith("aarch64")) {
+        } else if (arch.startsWith("arm64") || arch.startsWith("aarch64") || arch.equals("armv8a")) {
             arch =  "arm64-v8a";
         } else if (arch.equals("armv7l")) {
             arch =  "armeabi-v7a";
-        } else if (arch.equals("armv8a")){
-            arch = "armeabi-v8a";
         } else {
             throw new RuntimeException("AWS CRT: architecture not supported on Android: " + arch);
         }

--- a/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
+++ b/android/crt/src/main/java/software/amazon/awssdk/crt/android/CrtPlatformImpl.java
@@ -33,8 +33,6 @@ public class CrtPlatformImpl extends CrtPlatform {
         // be retrieved using Build class instead of a system property.
         String arch = Build.CPU_ABI;
 
-        System.out.println("Build.CPU_ABI: " + arch);
-
         if (arch.matches("^(x8664|amd64|ia32e|em64t|x64|x86_64)$")) {
             arch = "x86_64";
         } else if (arch.matches("^(x8632|x86|i[3-6]86|ia32|x32)$")) {

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -37,13 +37,18 @@ public final class CRT {
         // Scan for and invoke any platform specific initialization
         s_platform = findPlatformImpl();
         jvmInit();
-        try {
-            // If the lib is already present/loaded or is in java.library.path, just use it
-            System.loadLibrary(CRT_LIB_NAME);
-        } catch (UnsatisfiedLinkError e) {
-            // otherwise, load from the jar this class is in
-            loadLibraryFromJar();
-        }
+        // try {
+        //     // If the lib is already present/loaded or is in java.library.path, just use it
+        //     System.loadLibrary(CRT_LIB_NAME);
+        // } catch (UnsatisfiedLinkError e) {
+        //     // otherwise, load from the jar this class is in
+        //     loadLibraryFromJar();
+        // }
+
+        // DEBUG
+        System.out.println("loadLibraryFromJar()");
+        loadLibraryFromJar();
+        // DEBUG
 
         // Initialize the CRT
         int memoryTracingLevel = 0;
@@ -316,6 +321,8 @@ public final class CRT {
                     libResourcePath = platformLibResourcePath;
                 }
             }
+
+            System.out.println("Loading: " + libResourcePath);
 
             try (InputStream in = CRT.class.getResourceAsStream(libResourcePath)) {
                 if (in == null) {

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -45,7 +45,6 @@ public final class CRT {
             loadLibraryFromJar();
         }
 
-
         // Initialize the CRT
         int memoryTracingLevel = 0;
         try {

--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -37,18 +37,14 @@ public final class CRT {
         // Scan for and invoke any platform specific initialization
         s_platform = findPlatformImpl();
         jvmInit();
-        // try {
-        //     // If the lib is already present/loaded or is in java.library.path, just use it
-        //     System.loadLibrary(CRT_LIB_NAME);
-        // } catch (UnsatisfiedLinkError e) {
-        //     // otherwise, load from the jar this class is in
-        //     loadLibraryFromJar();
-        // }
+        try {
+            // If the lib is already present/loaded or is in java.library.path, just use it
+            System.loadLibrary(CRT_LIB_NAME);
+        } catch (UnsatisfiedLinkError e) {
+            // otherwise, load from the jar this class is in
+            loadLibraryFromJar();
+        }
 
-        // DEBUG
-        System.out.println("loadLibraryFromJar()");
-        loadLibraryFromJar();
-        // DEBUG
 
         // Initialize the CRT
         int memoryTracingLevel = 0;
@@ -321,8 +317,6 @@ public final class CRT {
                     libResourcePath = platformLibResourcePath;
                 }
             }
-
-            System.out.println("Loading: " + libResourcePath);
 
             try (InputStream in = CRT.class.getResourceAsStream(libResourcePath)) {
                 if (in == null) {


### PR DESCRIPTION
Android architecture detection using the Android Build class is more reliable and accurate than using `System.getProperty("os.arch")`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
