### PR TITLE
Update Maven Deployment Script

### DIFF
--- a/codebuild/cd/test-platform-specific-jar-snapshot.sh
+++ b/codebuild/cd/test-platform-specific-jar-snapshot.sh
@@ -5,9 +5,9 @@ set -ex
 PLATFORM_ARRAY=("linux-armv6" "linux-armv7" "linux-aarch_64" "linux-x86_32" "linux-x86_64" "osx-aarch_64" "osx-x86_64" "windows-x86_32" "windows-x86_64" "linux-x86_64-musl" "linux-armv7-musl" "linux-aarch_64-musl")
 
 # test uber jar
-mvn -B dependency:get -DrepoUrl=https://aws.oss.sonatype.org/content/repositories/snapshots -Dartifact=software.amazon.awssdk.crt:aws-crt:${CRT_VERSION}-SNAPSHOT -Dtransitive=false
+mvn -B dependency:get -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots -Dartifact=software.amazon.awssdk.crt:aws-crt:${CRT_VERSION}-SNAPSHOT -Dtransitive=false
 
 for str in ${PLATFORM_ARRAY[@]}; do
   # Test platform specific jar
-  mvn -B dependency:get -DrepoUrl=https://aws.oss.sonatype.org/content/repositories/snapshots -Dartifact=software.amazon.awssdk.crt:aws-crt:${CRT_VERSION}-SNAPSHOT:jar:${str} -Dtransitive=false
+  mvn -B dependency:get -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots -Dartifact=software.amazon.awssdk.crt:aws-crt:${CRT_VERSION}-SNAPSHOT:jar:${str} -Dtransitive=false
 done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Deprecate parameter `repoUrl` and use `remoteRespositories`
Checkout the maven dependency doc here:
https://maven.apache.org/plugins-archives/maven-dependency-plugin-2.8/get-mojo.html#remoteRepositories



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
