### PR TITLE
Fix overridden timeout values for mqtt5 operations

### DIFF
--- a/src/native/mqtt5_client.c
+++ b/src/native/mqtt5_client.c
@@ -1203,7 +1203,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_publish_future = (*env)->NewGlobalRef(env, jni_publish_future);
 
-    struct aws_mqtt5_publish_completion_options completion_options;
+    struct aws_mqtt5_publish_completion_options completion_options{};
     completion_options.completion_callback = &s_aws_mqtt5_client_java_publish_completion;
     completion_options.completion_user_data = (void *)return_data;
 
@@ -1285,7 +1285,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_subscribe_future = (*env)->NewGlobalRef(env, jni_subscribe_future);
 
-    struct aws_mqtt5_subscribe_completion_options completion_options;
+    struct aws_mqtt5_subscribe_completion_options completion_options{};
     completion_options.completion_callback = &s_aws_mqtt5_client_java_subscribe_completion;
     completion_options.completion_user_data = (void *)return_data;
 
@@ -1366,7 +1366,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_unsubscribe_future = (*env)->NewGlobalRef(env, jni_unsubscribe_future);
 
-    struct aws_mqtt5_unsubscribe_completion_options completion_options;
+    struct aws_mqtt5_unsubscribe_completion_options completion_options{};
     completion_options.completion_callback = &s_aws_mqtt5_client_java_unsubscribe_completion;
     completion_options.completion_user_data = (void *)return_data;
 

--- a/src/native/mqtt5_client.c
+++ b/src/native/mqtt5_client.c
@@ -1205,7 +1205,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
 
     struct aws_mqtt5_publish_completion_options completion_options = {
         .completion_callback = &s_aws_mqtt5_client_java_publish_completion,
-        .completion_user_data = (void *)return_data,
+        .completion_user_data = return_data,
     };
 
     java_publish_packet = aws_mqtt5_packet_publish_view_create_from_java(env, allocator, jni_publish_packet);
@@ -1288,7 +1288,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
 
     struct aws_mqtt5_subscribe_completion_options completion_options = {
         .completion_callback = &s_aws_mqtt5_client_java_subscribe_completion,
-        .completion_user_data = (void *)return_data,
+        .completion_user_data = return_data,
     };
 
     java_subscribe_packet = aws_mqtt5_packet_subscribe_view_create_from_java(env, allocator, jni_subscribe_packet);
@@ -1370,7 +1370,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
 
     struct aws_mqtt5_unsubscribe_completion_options completion_options = {
         .completion_callback = &s_aws_mqtt5_client_java_unsubscribe_completion,
-        .completion_user_data = (void *)return_data,
+        .completion_user_data = return_data,
     };
 
     java_unsubscribe_packet =

--- a/src/native/mqtt5_client.c
+++ b/src/native/mqtt5_client.c
@@ -1203,9 +1203,10 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_publish_future = (*env)->NewGlobalRef(env, jni_publish_future);
 
-    struct aws_mqtt5_publish_completion_options completion_options {};
-    completion_options.completion_callback = &s_aws_mqtt5_client_java_publish_completion;
-    completion_options.completion_user_data = (void *)return_data;
+    struct aws_mqtt5_publish_completion_options completion_options = {
+        .completion_callback = &s_aws_mqtt5_client_java_publish_completion,
+        .completion_user_data = (void *)return_data,
+    };
 
     java_publish_packet = aws_mqtt5_packet_publish_view_create_from_java(env, allocator, jni_publish_packet);
     if (!java_publish_packet) {
@@ -1285,9 +1286,10 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_subscribe_future = (*env)->NewGlobalRef(env, jni_subscribe_future);
 
-    struct aws_mqtt5_subscribe_completion_options completion_options {};
-    completion_options.completion_callback = &s_aws_mqtt5_client_java_subscribe_completion;
-    completion_options.completion_user_data = (void *)return_data;
+    struct aws_mqtt5_subscribe_completion_options completion_options = {
+        .completion_callback = &s_aws_mqtt5_client_java_subscribe_completion,
+        .completion_user_data = (void *)return_data,
+    };
 
     java_subscribe_packet = aws_mqtt5_packet_subscribe_view_create_from_java(env, allocator, jni_subscribe_packet);
     if (java_subscribe_packet == NULL) {
@@ -1366,9 +1368,10 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_unsubscribe_future = (*env)->NewGlobalRef(env, jni_unsubscribe_future);
 
-    struct aws_mqtt5_unsubscribe_completion_options completion_options {};
-    completion_options.completion_callback = &s_aws_mqtt5_client_java_unsubscribe_completion;
-    completion_options.completion_user_data = (void *)return_data;
+    struct aws_mqtt5_unsubscribe_completion_options completion_options = {
+        .completion_callback = &s_aws_mqtt5_client_java_unsubscribe_completion,
+        .completion_user_data = (void *)return_data,
+    };
 
     java_unsubscribe_packet =
         aws_mqtt5_packet_unsubscribe_view_create_from_java(env, allocator, jni_unsubscribe_packet);

--- a/src/native/mqtt5_client.c
+++ b/src/native/mqtt5_client.c
@@ -1203,7 +1203,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_publish_future = (*env)->NewGlobalRef(env, jni_publish_future);
 
-    struct aws_mqtt5_publish_completion_options completion_options{};
+    struct aws_mqtt5_publish_completion_options completion_options {};
     completion_options.completion_callback = &s_aws_mqtt5_client_java_publish_completion;
     completion_options.completion_user_data = (void *)return_data;
 
@@ -1285,7 +1285,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_subscribe_future = (*env)->NewGlobalRef(env, jni_subscribe_future);
 
-    struct aws_mqtt5_subscribe_completion_options completion_options{};
+    struct aws_mqtt5_subscribe_completion_options completion_options {};
     completion_options.completion_callback = &s_aws_mqtt5_client_java_subscribe_completion;
     completion_options.completion_user_data = (void *)return_data;
 
@@ -1366,7 +1366,7 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_mqtt5_Mqtt5Client_mqtt5Cl
     return_data->java_client = java_client;
     return_data->jni_unsubscribe_future = (*env)->NewGlobalRef(env, jni_unsubscribe_future);
 
-    struct aws_mqtt5_unsubscribe_completion_options completion_options{};
+    struct aws_mqtt5_unsubscribe_completion_options completion_options {};
     completion_options.completion_callback = &s_aws_mqtt5_client_java_unsubscribe_completion;
     completion_options.completion_user_data = (void *)return_data;
 


### PR DESCRIPTION
Currently, subscribe, unsubscribe, and publish operations are enqueued with overridden timeouts set to garbage values.
This PR fixes it by explicitly setting the overridden timeout to 0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
