### PR TITLE
Check for null in http and s3 to prevent crash for use after free

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/http/Http2ClientConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2ClientConnection.java
@@ -130,6 +130,9 @@ public class Http2ClientConnection extends HttpClientConnection {
      */
     public void sendGoAway(final Http2ErrorCode Http2ErrorCode, final boolean allowMoreStreams,
             final byte[] debugData) {
+        if (isNull()) {
+            throw new IllegalStateException("Http2ClientConnection has been closed.");
+        }
         http2ClientConnectionSendGoAway(getNativeHandle(), (long) Http2ErrorCode.getValue(), allowMoreStreams,
                 debugData);
     }

--- a/src/main/java/software/amazon/awssdk/crt/http/Http2Stream.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2Stream.java
@@ -25,6 +25,9 @@ public class Http2Stream extends HttpStreamBase {
      * @param errorCode aws_http2_error_code. Reason to reset the stream.
      */
     public void resetStream(final Http2ClientConnection.Http2ErrorCode errorCode) {
+        if (isNull()) {
+            throw new IllegalStateException("Http2Stream has been closed.");
+        }
         http2StreamResetStream(getNativeHandle(), errorCode.getValue());
     }
 

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnection.java
@@ -105,7 +105,9 @@ public class HttpClientConnection extends CrtResource {
     }
 
     /**
-     * Returns true unless the underlying http connection is shutting down, or has been shutdown.
+     * Check the underlying http connection is still open or not.
+     *
+     * @return true unless the underlying http connection is shutting down, or has been shutdown.
      */
     public boolean isOpen() {
         if (isNull()) {

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnection.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpClientConnection.java
@@ -98,10 +98,26 @@ public class HttpClientConnection extends CrtResource {
      * the connection as well in order to release the native resources.
      */
     public void shutdown() {
+        if (isNull()) {
+            throw new IllegalStateException("HttpClientConnection has been closed and released back to the pool, cannot shutdown the connection.");
+        }
         httpClientConnectionShutdown(getNativeHandle());
     }
 
+    /**
+     * Returns true unless the underlying http connection is shutting down, or has been shutdown.
+     */
+    public boolean isOpen() {
+        if (isNull()) {
+            throw new IllegalStateException("HttpClientConnection has been closed.");
+        }
+        return httpClientConnectionIsOpen(getNativeHandle());
+    }
+
     public HttpVersion getVersion() {
+        if (isNull()) {
+            throw new IllegalStateException("HttpClientConnection has been closed.");
+        }
         short version = httpClientConnectionGetVersion(getNativeHandle());
         return HttpVersion.getEnumValueFromInteger((int) version);
     };
@@ -157,6 +173,7 @@ public class HttpClientConnection extends CrtResource {
                                                                      HttpStreamResponseHandlerNativeAdapter responseHandler) throws CrtRuntimeException;
 
     private static native void httpClientConnectionShutdown(long connectionBinding) throws CrtRuntimeException;
+    private static native boolean httpClientConnectionIsOpen(long connectionBinding) throws CrtRuntimeException;
 
     private static native void httpClientConnectionReleaseManaged(long connectionBinding) throws CrtRuntimeException;
     private static native short httpClientConnectionGetVersion(long connectionBinding) throws CrtRuntimeException;

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpStream.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpStream.java
@@ -43,6 +43,10 @@ public class HttpStream extends HttpStreamBase {
      */
     public void writeChunk(final byte[] chunkData, boolean isFinalChunk,
             final HttpStreamWriteChunkCompletionCallback chunkCompletionCallback) {
+        if (isNull()) {
+            throw new IllegalStateException("HttpStream has been closed.");
+        }
+
         if (chunkCompletionCallback == null) {
             throw new IllegalArgumentException("You must supply a chunkCompletionCallback");
         }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequest.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequest.java
@@ -49,6 +49,9 @@ public class S3MetaRequest extends CrtResource {
     public CompletableFuture<Void> getShutdownCompleteFuture() { return shutdownComplete; }
 
     public void cancel() {
+        if (isNull()) {
+            throw new IllegalStateException("S3MetaRequest has been closed.");
+        }
         s3MetaRequestCancel(getNativeHandle());
     }
 
@@ -59,6 +62,9 @@ public class S3MetaRequest extends CrtResource {
      * @return token to resume request. might be null if request has not started executing yet
      */
     public ResumeToken pause() {
+        if (isNull()) {
+            throw new IllegalStateException("S3MetaRequest has been closed.");
+        }
         return s3MetaRequestPause(getNativeHandle());
     }
 
@@ -86,6 +92,9 @@ public class S3MetaRequest extends CrtResource {
      * @see S3ClientOptions#withReadBackpressureEnabled
      */
     public void incrementReadWindow(long bytes) {
+        if (isNull()) {
+            throw new IllegalStateException("S3MetaRequest has been closed.");
+        }
         s3MetaRequestIncrementReadWindow(getNativeHandle(), bytes);
     }
 

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -743,6 +743,25 @@ JNIEXPORT void JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnection
     aws_http_connection_close(native_conn);
 }
 
+JNIEXPORT jboolean JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnection_httpClientConnectionIsOpen(
+    JNIEnv *env,
+    jclass jni_class,
+    jlong jni_connection) {
+
+    (void)jni_class;
+    aws_cache_jni_ids(env);
+
+    struct aws_http_connection_binding *connection_binding = (struct aws_http_connection_binding *)jni_connection;
+    struct aws_http_connection *native_conn = connection_binding->connection;
+
+    if (!native_conn) {
+        aws_jni_throw_runtime_exception(env, "HttpClientConnection.isOpen: Invalid aws_http_connection");
+        return;
+    }
+
+    return aws_http_connection_is_open(native_conn);
+}
+
 JNIEXPORT jshort JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnection_httpClientConnectionGetVersion(
     JNIEnv *env,
     jclass jni_class,

--- a/src/native/http_request_response.c
+++ b/src/native/http_request_response.c
@@ -756,7 +756,7 @@ JNIEXPORT jboolean JNICALL Java_software_amazon_awssdk_crt_http_HttpClientConnec
 
     if (!native_conn) {
         aws_jni_throw_runtime_exception(env, "HttpClientConnection.isOpen: Invalid aws_http_connection");
-        return;
+        return false;
     }
 
     return aws_http_connection_is_open(native_conn);

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
@@ -48,6 +48,7 @@ public class HttpClientConnectionTest extends HttpClientTestFixture {
                 resp.shutdownComplete = connectionPool.getShutdownCompleteFuture();
                 try (HttpClientConnection conn = connectionPool.acquireConnection().get(60, TimeUnit.SECONDS)) {
                     resp.actuallyConnected = true;
+                    assertTrue(conn.isOpen());
                 }
                 break;
             } catch (Exception e) {


### PR DESCRIPTION
*Issue #, if available:*

- Check for null in http and s3. Make sure we don't crash even for use after free
- also binding out the isOpen function for connection

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
