### PR TITLE
S3: cancel the meta request before release the native handler

### DIFF
--- a/codebuild/test-aws-java-sdk-v2.yml
+++ b/codebuild/test-aws-java-sdk-v2.yml
@@ -11,7 +11,6 @@ phases:
       - apt-get install gcc-7 cmake ninja-build -y
       - git submodule update --init --recursive
       - git clone https://github.com/aws/aws-sdk-java-v2.git
-      - git pull
       # change the version from SDK to local SNAPSHOT version
       - sed -i 's/<awscrt.version>.*<\/awscrt.version>/<awscrt.version>1.0.0-SNAPSHOT<\/awscrt.version>/g' aws-sdk-java-v2/pom.xml
       # check if it works

--- a/codebuild/test-aws-java-sdk-v2.yml
+++ b/codebuild/test-aws-java-sdk-v2.yml
@@ -11,6 +11,7 @@ phases:
       - apt-get install gcc-7 cmake ninja-build -y
       - git submodule update --init --recursive
       - git clone https://github.com/aws/aws-sdk-java-v2.git
+      - git pull
       # change the version from SDK to local SNAPSHOT version
       - sed -i 's/<awscrt.version>.*<\/awscrt.version>/<awscrt.version>1.0.0-SNAPSHOT<\/awscrt.version>/g' aws-sdk-java-v2/pom.xml
       # check if it works

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequest.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequest.java
@@ -42,6 +42,7 @@ public class S3MetaRequest extends CrtResource {
              * Cancel the meta request before drop the refcount.
              * The meta request is not referenced by Java any longer, everything from native to Java will be ignored.
              * Cancelling the meta request instead of letting it keep flowing.
+             * Note: If the meta request has not finished yet, it will be finished with `AWS_ERROR_S3_CANCELED`.
              **/
             s3MetaRequestCancel(getNativeHandle());
             s3MetaRequestDestroy(getNativeHandle());

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequest.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequest.java
@@ -38,6 +38,12 @@ public class S3MetaRequest extends CrtResource {
     @Override
     protected void releaseNativeHandle() {
         if (!isNull()) {
+            /**
+             * Cancel the meta request before drop the refcount.
+             * The meta request is not referenced by Java any longer, everything from native to Java will be ignored.
+             * Cancelling the meta request instead of letting it keep flowing.
+             **/
+            s3MetaRequestCancel(getNativeHandle());
             s3MetaRequestDestroy(getNativeHandle());
         }
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ExpressCredentialsProviderHandlerSample.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ExpressCredentialsProviderHandlerSample.java
@@ -67,8 +67,10 @@ public class S3ExpressCredentialsProviderHandlerSample implements S3ExpressCrede
                 .withMetaRequestType(MetaRequestType.DEFAULT).withHttpRequest(httpRequest)
                 .withResponseHandler(responseHandler).withSigningConfig(config);
 
-        try (S3MetaRequest metaRequest = client.makeMetaRequest(metaRequestOptions)) {
-        }
+        S3MetaRequest metaRequest = client.makeMetaRequest(metaRequestOptions);
+        future.whenComplete((r,t) -> {
+            metaRequest.close();
+        });
         return future;
 
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Cancel the meta request before Java side close on it. If Java side already dropped the meta request, it doesn't make sense to keep the meta request flowing in the native part.
- help to prevent the possible leak when the meta request was closed, but not cancelled, the data will keep flowing and stalled because of backpressure
- Add it to the java part to make it a little bit easier to track (The close method is not easy to track down to the `releaseNativeHandle` though)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
