### PR TITLE
fall back to system class loader

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/CRT.java
+++ b/src/main/java/software/amazon/awssdk/crt/CRT.java
@@ -407,6 +407,10 @@ public final class CRT {
 
     private static CrtPlatform findPlatformImpl() {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = ClassLoader.getSystemClassLoader();
+        }
+
         String[] platforms = new String[] {
                 // Search for OS specific test impl first
                 String.format("software.amazon.awssdk.crt.test.%s.CrtPlatformImpl", getOSIdentifier()),


### PR DESCRIPTION
*Issue #:* https://github.com/awslabs/aws-crt-java/issues/451

*Description of Changes:*
Fall back to system class loader. This matches what the [Java SDK does](https://github.com/aws/aws-sdk-java-v2/blob/bdbd87233649f168783ae010b7005c09d5606af2/utils/src/main/java/software/amazon/awssdk/utils/ClassLoaderHelper.java#L122-L129)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
