### PR TITLE
Update DeviceFarm tests to not use legacy host

### DIFF
--- a/src/test/android/testapp/instrumentedTestSpec.yml
+++ b/src/test/android/testapp/instrumentedTestSpec.yml
@@ -18,7 +18,7 @@ phases:
       # Alternatively, you may specify a customized command.
       # Please refer to Android's documentation (https://developer.android.com/studio/test/command-line#run-tests-with-adb)
       # for more options on running instrumentation tests from the command line.
-      - echo "Start Instrumentation test"
+      - echo "Start Instrumentation test From Repo"
       - |
         adb -s $DEVICEFARM_DEVICE_UDID shell "am instrument -r -w --no-window-animation \
         $DEVICEFARM_TEST_PACKAGE_NAME/$DEVICEFARM_TEST_PACKAGE_RUNNER 2>&1 || echo \": -1\"" |

--- a/src/test/android/testapp/instrumentedTestSpec.yml
+++ b/src/test/android/testapp/instrumentedTestSpec.yml
@@ -1,5 +1,7 @@
 version: 0.1
 
+android_test_host: amazon_linux_2
+
 # Phases are collection of commands that get executed on Device Farm.
 phases:
   # The install phase includes commands that install dependencies that your tests use.
@@ -18,7 +20,7 @@ phases:
       # Alternatively, you may specify a customized command.
       # Please refer to Android's documentation (https://developer.android.com/studio/test/command-line#run-tests-with-adb)
       # for more options on running instrumentation tests from the command line.
-      - echo "Start Instrumentation test From Repo"
+      - echo "Start Instrumentation test"
       - |
         adb -s $DEVICEFARM_DEVICE_UDID shell "am instrument -r -w --no-window-animation \
         $DEVICEFARM_TEST_PACKAGE_NAME/$DEVICEFARM_TEST_PACKAGE_RUNNER 2>&1 || echo \": -1\"" |


### PR DESCRIPTION
https://docs.aws.amazon.com/devicefarm/latest/developerguide/amazon-linux-2-migrating-to-amazon-linux-2.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
