### PR TITLE
fix resume token class cache

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/s3/ResumeToken.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/ResumeToken.java
@@ -55,7 +55,7 @@ public class ResumeToken {
 
         public ResumeToken build() {
             return new ResumeToken(this);
-        } 
+        }
     };
 
     private int nativeType;
@@ -71,6 +71,10 @@ public class ResumeToken {
         this.numPartsCompleted = builder.numPartsCompleted;
         this.uploadId = builder.uploadId;
     }
+    /**
+     * Default constructor
+     */
+    private ResumeToken() {}
 
     /******
      * Common Fields.
@@ -106,7 +110,7 @@ public class ResumeToken {
     }
 
     /******
-     * Upload Specific fields. 
+     * Upload Specific fields.
      ******/
     /**
      * @return upload Id

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -967,18 +967,23 @@ static void s_cache_s3_meta_request_resume_token(JNIEnv *env) {
     AWS_FATAL_ASSERT(cls);
     s3_meta_request_resume_token_properties.s3_meta_request_resume_token_class = (*env)->NewGlobalRef(env, cls);
 
-    s3_meta_request_resume_token_properties.s3_meta_request_resume_token_constructor_method_id =
-        (*env)->GetMethodID(env, s3_meta_request_progress_properties.s3_meta_request_progress_class, "<init>", "()V");
+    s3_meta_request_resume_token_properties.s3_meta_request_resume_token_constructor_method_id = (*env)->GetMethodID(
+        env, s3_meta_request_resume_token_properties.s3_meta_request_resume_token_class, "<init>", "()V");
+    AWS_FATAL_ASSERT(s3_meta_request_resume_token_properties.s3_meta_request_resume_token_constructor_method_id);
 
     s3_meta_request_resume_token_properties.native_type_field_id = (*env)->GetFieldID(env, cls, "nativeType", "I");
     AWS_FATAL_ASSERT(s3_meta_request_resume_token_properties.native_type_field_id);
     s3_meta_request_resume_token_properties.part_size_field_id = (*env)->GetFieldID(env, cls, "partSize", "J");
+    AWS_FATAL_ASSERT(s3_meta_request_resume_token_properties.part_size_field_id);
     s3_meta_request_resume_token_properties.total_num_parts_field_id =
         (*env)->GetFieldID(env, cls, "totalNumParts", "J");
+    AWS_FATAL_ASSERT(s3_meta_request_resume_token_properties.total_num_parts_field_id);
     s3_meta_request_resume_token_properties.num_parts_completed_field_id =
         (*env)->GetFieldID(env, cls, "numPartsCompleted", "J");
+    AWS_FATAL_ASSERT(s3_meta_request_resume_token_properties.num_parts_completed_field_id);
     s3_meta_request_resume_token_properties.upload_id_field_id =
         (*env)->GetFieldID(env, cls, "uploadId", "Ljava/lang/String;");
+    AWS_FATAL_ASSERT(s3_meta_request_resume_token_properties.upload_id_field_id);
 }
 
 struct java_aws_mqtt5_connack_packet_properties mqtt5_connack_packet_properties;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix the typo when cache the resume token class constructor, only problem is how does it ever work???
- It was caught by GraalVM... https://github.com/awslabs/aws-crt-java/actions/runs/9166326964/job/25201497152


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
