### PR TITLE
fix test leak for MQTT

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/CustomKeyOpsTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/CustomKeyOpsTest.java
@@ -256,14 +256,13 @@ public class CustomKeyOpsTest extends MqttClientConnectionFixture {
                 null,
                 null,
                 null);
-            disconnect();
-            close();
         }
         catch (Exception ex) {
             fail("Exception during connect: " + ex.toString());
+        } finally {
+            disconnect();
+            close();
         }
-        disconnect();
-        close();
     }
 
     @Test

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientConnectionTest.java
@@ -114,10 +114,6 @@ public class HttpClientConnectionTest extends HttpClientTestFixture {
         testConnectionWithAllCiphers(new URI("https://kms-fips.us-east-1.amazonaws.com:443"), true, null);
         testConnectionWithAllCiphers(new URI("https://kms.us-west-2.amazonaws.com:443"), true, null);
         testConnectionWithAllCiphers(new URI("https://kms-fips.us-west-2.amazonaws.com:443"), true, null);
-
-        // BadSSL
-        testConnectionWithAllCiphers(new URI("https://rsa2048.badssl.com/"), true, null);
-        testConnectionWithAllCiphers(new URI("http://http.badssl.com/"), true, null);
     }
 
     @Test

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import org.junit.After;
 
  class MissingCredentialsException extends RuntimeException {
      MissingCredentialsException(String message) {
@@ -140,6 +141,13 @@ import java.util.function.Consumer;
     Consumer<MqttMessage> connectionMessageTransfomer = null;
     protected void setConnectionMessageTransformer(Consumer<MqttMessage> connectionMessageTransfomer) {
         this.connectionMessageTransfomer = connectionMessageTransfomer;
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        close();
+        super.tearDown();
     }
 
     MqttClientConnectionFixture() {
@@ -386,7 +394,10 @@ import java.util.function.Consumer;
     }
 
     void close() {
-        connection.close();
+        if(connection!=null) {
+            connection.close();
+            connection = null;
+        }
     }
 
     CompletableFuture<Integer> publish(String topic, byte[] payload, QualityOfService qos) {
@@ -444,4 +455,3 @@ import java.util.function.Consumer;
         return onConnectionClosedFuture.get(60, TimeUnit.SECONDS);
     }
 }
-


### PR DESCRIPTION
*Issue #, if available:*

- Specifically, `IotServiceTest.testIotService`, when `connectDirectWithConfig` failed, there is no `close()` called for the `connection`, [here](https://github.com/awslabs/aws-crt-java/blob/main/src/test/java/software/amazon/awssdk/crt/test/IotServiceTest.java#L44C21-L44C44), while the connection may already be created by failed to `connect`, [here](https://github.com/awslabs/aws-crt-java/blob/main/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionFixture.java#L250), and result in a resource leak. And result in the test hanging as we wait for the resources to be cleaned up

*Description of changes:*
- Add a tear down override to make sure the connection is closed before exit
- Remove badssl tests, they are flaky and I don't know why we have those similar tests to different endpoint

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
