### PR TITLE
S3Client breaking change: DEFAULT requests must pass operation name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,9 +184,10 @@ set(TARGET_LIB_DIR "${AWS_LIBRARY_OUTPUT_DIR}/${TARGET_OS}/${TARGET_ARCH}/${AWS_
 
 # shared lib that contains the CRT and JNI bindings, to be loaded by java
 add_library(${PROJECT_NAME} SHARED ${CRT_JAVA_HEADERS} ${CRT_JAVA_SRC})
-aws_use_package(aws-c-http)
+
+# link the high-level libraries that will recursively pull in the rest
+# (don't repeat dependencies here, or the linker will spit out warnings)
 aws_use_package(aws-c-mqtt)
-aws_use_package(aws-c-auth)
 aws_use_package(aws-c-event-stream)
 aws_use_package(aws-c-s3)
 

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3FinishedResponseContext.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3FinishedResponseContext.java
@@ -10,6 +10,7 @@ public class S3FinishedResponseContext {
     private final int errorCode;
     private final int responseStatus;
     private final byte[] errorPayload;
+    private final String errorOperationName;
     private final ChecksumAlgorithm checksumAlgorithm;
     private final boolean didValidateChecksum;
 
@@ -24,10 +25,11 @@ public class S3FinishedResponseContext {
      * didValidateChecksum which is true if the response was validated.
      * cause of the error such as a Java exception in a callback. Maybe NULL if there was no exception in a callback.
      */
-    S3FinishedResponseContext(final int errorCode, final int responseStatus, final byte[] errorPayload, final ChecksumAlgorithm checksumAlgorithm, final boolean didValidateChecksum, Throwable cause, final HttpHeader[] errorHeaders) {
+    S3FinishedResponseContext(final int errorCode, final int responseStatus, final byte[] errorPayload, final String errorOperationName, final ChecksumAlgorithm checksumAlgorithm, final boolean didValidateChecksum, Throwable cause, final HttpHeader[] errorHeaders) {
         this.errorCode = errorCode;
         this.responseStatus = responseStatus;
         this.errorPayload = errorPayload;
+        this.errorOperationName = errorOperationName;
         this.checksumAlgorithm = checksumAlgorithm;
         this.didValidateChecksum = didValidateChecksum;
         this.cause = cause;
@@ -38,7 +40,7 @@ public class S3FinishedResponseContext {
         return this.errorCode;
     }
 
-    /*
+    /**
      * If the request didn't receive a response due to a connection
      * failure or some other issue the response status will be 0.
      */
@@ -46,14 +48,26 @@ public class S3FinishedResponseContext {
         return this.responseStatus;
     }
 
-    /*
+    /**
      * In the case of a failed http response get the payload of the response.
      */
     public byte[] getErrorPayload() {
         return this.errorPayload;
     }
 
-    /*
+    /**
+     * In the case of a failed http response, get the name of the S3 operation that failed.
+     * For example, if {@link S3MetaRequestOptions.MetaRequestType#PUT_OBJECT} fails
+     * this could be "PutObject", "CreateMultipartUpload", "UploadPart",
+     * "CompleteMultipartUpload", or others. For {@link S3MetaRequestOptions.MetaRequestType#DEFAULT},
+     * this is the name passed to {@link S3MetaRequestOptions#withOperationName}.
+     * May be null.
+     */
+    public String getErrorOperationName() {
+        return this.errorOperationName;
+    }
+
+    /**
      * if no checksum is found, or the request finished with an error the Algorithm will be None,
      * otherwise the algorithm will correspond to the one attached to the object when uploaded.
      */

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3FinishedResponseContext.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3FinishedResponseContext.java
@@ -40,7 +40,7 @@ public class S3FinishedResponseContext {
         return this.errorCode;
     }
 
-    /**
+    /*
      * If the request didn't receive a response due to a connection
      * failure or some other issue the response status will be 0.
      */
@@ -48,7 +48,7 @@ public class S3FinishedResponseContext {
         return this.responseStatus;
     }
 
-    /**
+    /*
      * In the case of a failed http response get the payload of the response.
      */
     public byte[] getErrorPayload() {
@@ -56,7 +56,7 @@ public class S3FinishedResponseContext {
     }
 
     /**
-     * In the case of a failed http response, get the name of the S3 operation that failed.
+	 * @return the name of the S3 operation that failed, in the case of a failed HTTP response.
      * For example, if {@link S3MetaRequestOptions.MetaRequestType#PUT_OBJECT} fails
      * this could be "PutObject", "CreateMultipartUpload", "UploadPart",
      * "CompleteMultipartUpload", or others. For {@link S3MetaRequestOptions.MetaRequestType#DEFAULT},
@@ -67,7 +67,7 @@ public class S3FinishedResponseContext {
         return this.errorOperationName;
     }
 
-    /**
+    /*
      * if no checksum is found, or the request finished with an error the Algorithm will be None,
      * otherwise the algorithm will correspond to the one attached to the object when uploaded.
      */

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
@@ -80,6 +80,7 @@ public class S3MetaRequestOptions {
     }
 
     private MetaRequestType metaRequestType;
+    private String operationName;
     private ChecksumConfig checksumConfig;
     private HttpRequest httpRequest;
     private Path requestFilePath;
@@ -97,6 +98,38 @@ public class S3MetaRequestOptions {
 
     public MetaRequestType getMetaRequestType() {
         return metaRequestType;
+    }
+
+    /**
+     * The S3 operation name (eg: "CreateBucket"),
+     * this MUST be set for {@link MetaRequestType#DEFAULT},
+     * it is not necessary for other meta request types.
+     *
+     * See <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html">
+     * S3 API documentation</a> for the canonical list of names.
+     *
+     * This name is used to fill out details in metrics and error reports.
+     * It also drives some operation-specific behavior.
+     * If you pass the wrong name, you risk getting the wrong behavior.
+     *
+     * For example, every operation except "GetObject" has its response checked
+     * for error, even if the HTTP status-code was 200 OK
+     * (see <a href=https://repost.aws/knowledge-center/s3-resolve-200-internalerror>knowledge center</a>).
+     * If you used the {@link MetaRequestType#DEFAULT DEFAULT} type to do
+     * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>,
+     * but mis-named it "Download", and the object looked like XML with an error code,
+     * then the meta-request would fail. You risk logging the full response body,
+     * and leaking sensitive data.
+     * @param operationName the operation name for this {@link MetaRequestType#DEFAULT} meta request
+     * @return this
+     */
+    public S3MetaRequestOptions withOperationName(String operationName) {
+        this.operationName = operationName;
+        return this;
+    }
+
+    public String getOperationName() {
+        return operationName;
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandlerNativeAdapter.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestResponseHandlerNativeAdapter.java
@@ -19,9 +19,9 @@ class S3MetaRequestResponseHandlerNativeAdapter {
         return this.responseHandler.onResponseBody(ByteBuffer.wrap(bodyBytesIn), objectRangeStart, objectRangeEnd);
     }
 
-    void onFinished(int errorCode, int responseStatus, byte[] errorPayload, int checksumAlgorithm, boolean didValidateChecksum, Throwable cause, final ByteBuffer headersBlob) {
+    void onFinished(int errorCode, int responseStatus, byte[] errorPayload, String errorOperationName, int checksumAlgorithm, boolean didValidateChecksum, Throwable cause, final ByteBuffer headersBlob) {
         HttpHeader[] errorHeaders = headersBlob == null ? null : HttpHeader.loadHeadersFromMarshalledHeadersBlob(headersBlob);
-        S3FinishedResponseContext context = new S3FinishedResponseContext(errorCode, responseStatus, errorPayload, ChecksumAlgorithm.getEnumValueFromInteger(checksumAlgorithm), didValidateChecksum, cause, errorHeaders);
+        S3FinishedResponseContext context = new S3FinishedResponseContext(errorCode, responseStatus, errorPayload, errorOperationName, ChecksumAlgorithm.getEnumValueFromInteger(checksumAlgorithm), didValidateChecksum, cause, errorHeaders);
         this.responseHandler.onFinished(context);
     }
 

--- a/src/main/resources/META-INF/native-image/software.amazon.awssdk/crt/aws-crt/jni-config.json
+++ b/src/main/resources/META-INF/native-image/software.amazon.awssdk/crt/aws-crt/jni-config.json
@@ -2044,6 +2044,7 @@
           "int",
           "int",
           "byte[]",
+          "java.lang.String",
           "int",
           "boolean",
           "java.lang.Throwable",

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -715,7 +715,7 @@ static void s_cache_s3_meta_request_response_handler_native_adapter_properties(J
     AWS_FATAL_ASSERT(s3_meta_request_response_handler_native_adapter_properties.onResponseBody);
 
     s3_meta_request_response_handler_native_adapter_properties.onFinished =
-        (*env)->GetMethodID(env, cls, "onFinished", "(II[BIZLjava/lang/Throwable;Ljava/nio/ByteBuffer;)V");
+        (*env)->GetMethodID(env, cls, "onFinished", "(II[BLjava/lang/String;IZLjava/lang/Throwable;Ljava/nio/ByteBuffer;)V");
     AWS_FATAL_ASSERT(s3_meta_request_response_handler_native_adapter_properties.onFinished);
 
     s3_meta_request_response_handler_native_adapter_properties.onResponseHeaders =

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -714,8 +714,8 @@ static void s_cache_s3_meta_request_response_handler_native_adapter_properties(J
         (*env)->GetMethodID(env, cls, "onResponseBody", "([BJJ)I");
     AWS_FATAL_ASSERT(s3_meta_request_response_handler_native_adapter_properties.onResponseBody);
 
-    s3_meta_request_response_handler_native_adapter_properties.onFinished =
-        (*env)->GetMethodID(env, cls, "onFinished", "(II[BLjava/lang/String;IZLjava/lang/Throwable;Ljava/nio/ByteBuffer;)V");
+    s3_meta_request_response_handler_native_adapter_properties.onFinished = (*env)->GetMethodID(
+        env, cls, "onFinished", "(II[BLjava/lang/String;IZLjava/lang/Throwable;Ljava/nio/ByteBuffer;)V");
     AWS_FATAL_ASSERT(s3_meta_request_response_handler_native_adapter_properties.onFinished);
 
     s3_meta_request_response_handler_native_adapter_properties.onResponseHeaders =

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ExpressCredentialsProviderHandlerSample.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ExpressCredentialsProviderHandlerSample.java
@@ -68,8 +68,11 @@ public class S3ExpressCredentialsProviderHandlerSample implements S3ExpressCrede
 
         AwsSigningConfig config = AwsSigningConfig.getDefaultS3SigningConfig(properties.getRegion(), null);
         S3MetaRequestOptions metaRequestOptions = new S3MetaRequestOptions()
-                .withMetaRequestType(MetaRequestType.DEFAULT).withHttpRequest(httpRequest)
-                .withResponseHandler(responseHandler).withSigningConfig(config);
+                .withMetaRequestType(MetaRequestType.DEFAULT)
+                .withOperationName("CreateSession")
+                .withHttpRequest(httpRequest)
+                .withResponseHandler(responseHandler)
+                .withSigningConfig(config);
 
         S3MetaRequest metaRequest = client.makeMetaRequest(metaRequestOptions);
         future.whenComplete((r,t) -> {


### PR DESCRIPTION
**Issue:**
see: https://github.com/awslabs/aws-c-s3/pull/439

**Description of changes:**
- When making requests with the `S3Client` of type `MetaRequestType.DEFAULT`, the user must specify the operation name (see [S3 API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html) for canonical list of names)
- Add S3 operation name to `S3FinishedResponseContext`. This can help you determine exactly which operation failed. E.g. if `MetaRequestType.PUT_OBJECT` fails, you can see whether it was "PutObject", "CreateMultipartUpload", "UploadPart", or "CompleteMultipartUpload" in particular that failed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
