### PR TITLE
Fix manylinux2014 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.58
+  BUILDER_VERSION: v0.9.60
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-java


### PR DESCRIPTION
**Issue:**
CI using our `manylinux2014` docker image is failing with:
> Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container

**Description of changes:**
Use latest aws-crt-builder, which has rebuilt its `manylinux2014` image, and slurped in the latest base image which updates these URLs. See: https://github.com/pypa/manylinux/commit/7beb9ae220bcf3da425d323817709c1a1e2bd35d

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
