### PR TITLE
Fix tls_ctx memleak in s3 client creation

### DIFF
--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -521,7 +521,9 @@ JNIEXPORT jlong JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientNew(
         env, &proxy_options, jni_proxy_host, jni_proxy_authorization_username, jni_proxy_authorization_password);
 
     aws_mem_release(aws_jni_get_allocator(), s3_tcp_keep_alive_options);
-
+    if (tls_options) {
+        aws_tls_connection_options_clean_up(tls_options);
+    }
     return (jlong)client;
 }
 


### PR DESCRIPTION
Reproduction scenario:

```
try(var tlsc = new TlsContext(); var c = new S3Client(new S3ClientOptions()
                    .withRegion("eu-west-1")
                    .withClientBootstrap(ClientBootstrap.getOrCreateStaticDefault())
                    .withTlsContext(tlsc)
            )) {
            }
```

--> this code will quickly go OOM without the fix in this commit

*Issue #, if available:*

*Description of changes:*
Make sure `tls_ctx` refcount is decremented by cleaning up `tls_options`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
