### PR TITLE
Recv file path

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/s3/S3Client.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3Client.java
@@ -157,6 +157,10 @@ public class S3Client extends CrtResource {
         if (options.getRequestFilePath() != null) {
             requestFilePath = options.getRequestFilePath().toString().getBytes(UTF8);
         }
+        byte[] responseFilePath = null;
+        if (options.getResponseFilePath() != null) {
+            responseFilePath = options.getResponseFilePath().toString().getBytes(UTF8);
+        }
 
         AwsSigningConfig signingConfig = options.getSigningConfig();
         boolean didCreateSigningConfig = false;
@@ -177,7 +181,9 @@ public class S3Client extends CrtResource {
                 ChecksumAlgorithm.marshallAlgorithmsForJNI(checksumConfig.getValidateChecksumAlgorithmList()),
                 httpRequestBytes, options.getHttpRequest().getBodyStream(), requestFilePath, signingConfig,
                 responseHandlerNativeAdapter, endpoint == null ? null : endpoint.toString().getBytes(UTF8),
-                options.getResumeToken(), options.getObjectSizeHint());
+                options.getResumeToken(), options.getObjectSizeHint(), responseFilePath,
+                options.getResponseFileOption().getNativeValue(), options.getResponseFilePosition(),
+                options.getResponseFileDeleteOnFailure());
 
         metaRequest.setMetaRequestNativeHandle(metaRequestNativeHandle);
 
@@ -246,5 +252,6 @@ public class S3Client extends CrtResource {
             int[] validateAlgorithms, byte[] httpRequestBytes,
             HttpRequestBodyStream httpRequestBodyStream, byte[] requestFilePath,
             AwsSigningConfig signingConfig, S3MetaRequestResponseHandlerNativeAdapter responseHandlerNativeAdapter,
-            byte[] endpoint, ResumeToken resumeToken, Long objectSizeHint);
+            byte[] endpoint, ResumeToken resumeToken, Long objectSizeHint, byte[] responseFilePath,
+            int responseFileOption, long responseFilePosition, boolean responseFileDeleteOnFailure);
 }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
@@ -384,7 +384,7 @@ public class S3MetaRequestOptions {
      * @param responseFilePath path to file to write response body to.
      * @return this
      */
-    public S3MetaRequestOptions withResponseFilePath(Path responseFilePath, ResponseFileOption responseFileOption) {
+    public S3MetaRequestOptions withResponseFilePath(Path responseFilePath) {
         this.responseFilePath = responseFilePath;
         return this;
     }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
@@ -400,7 +400,7 @@ public class S3MetaRequestOptions {
      *
      * By default, the option is set to {@link ResponseFileOption#CREATE_OR_REPLACE}.
      *
-     * @param recvFileOption The option for handling the response file.
+     * @param responseFileOption The option for handling the response file.
      * @return this
      */
     public S3MetaRequestOptions withResponseFileOption(ResponseFileOption responseFileOption) {
@@ -417,7 +417,7 @@ public class S3MetaRequestOptions {
      * This option is only applicable when {@link withResponseFileOption} is set
      * to {@link ResponseFileOption#WRITE_TO_POSITION}.
      *
-     * @param recvFilePosition The position to start writing to the response file.
+     * @param responseFilePosition The position to start writing to the response file.
      * @return this
      */
     public S3MetaRequestOptions withResponseFilePosition(long responseFilePosition) {
@@ -434,7 +434,7 @@ public class S3MetaRequestOptions {
      * from S3.
      * This option is only applicable when a response file path is set.
      *
-     * @param recvFileDeleteOnFailure True to delete the response file on failure,
+     * @param responseFileDeleteOnFailure True to delete the response file on failure,
      *                                false to leave it as-is.
      */
     public S3MetaRequestOptions withResponseFileDeleteOnFailure(boolean responseFileDeleteOnFailure) {

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
@@ -394,11 +394,12 @@ public class S3MetaRequestOptions {
     }
 
     /**
-     * Sets the option for how to handle the response file when downloading an object
-     * from S3.
+     * Sets the option for how to handle the response file when downloading an
+     * object from S3.
      * This option is only applicable when {@link withResponseFilePath} is set.
      *
-     * By default, the option is set to {@link ResponseFileOption#CREATE_OR_REPLACE}.
+     * By default, the option is set to
+     * {@link ResponseFileOption#CREATE_OR_REPLACE}.
      *
      * @param responseFileOption The option for handling the response file.
      * @return this
@@ -417,7 +418,8 @@ public class S3MetaRequestOptions {
      * This option is only applicable when {@link withResponseFileOption} is set
      * to {@link ResponseFileOption#WRITE_TO_POSITION}.
      *
-     * @param responseFilePosition The position to start writing to the response file.
+     * @param responseFilePosition The position to start writing to the response
+     *                             file.
      * @return this
      */
     public S3MetaRequestOptions withResponseFilePosition(long responseFilePosition) {
@@ -430,18 +432,19 @@ public class S3MetaRequestOptions {
     }
 
     /**
-     * Sets whether to delete the response file on failure when downloading an object
-     * from S3.
+     * Sets whether to delete the response file on failure when downloading an
+     * object from S3.
      * This option is only applicable when a response file path is set.
      *
-     * @param responseFileDeleteOnFailure True to delete the response file on failure,
-     *                                false to leave it as-is.
+     * @param responseFileDeleteOnFailure True to delete the response file on
+     *                                    failure,
+     *                                    False to leave it as-is.
+     * @return this
      */
     public S3MetaRequestOptions withResponseFileDeleteOnFailure(boolean responseFileDeleteOnFailure) {
         this.responseFileDeleteOnFailure = responseFileDeleteOnFailure;
         return this;
     }
-
     public boolean getResponseFileDeleteOnFailure() {
         return responseFileDeleteOnFailure;
     }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3MetaRequestOptions.java
@@ -5,6 +5,7 @@
 package software.amazon.awssdk.crt.s3;
 
 import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.crt.http.HttpStreamResponseHandler;
 import software.amazon.awssdk.crt.auth.credentials.CredentialsProvider;
 import software.amazon.awssdk.crt.auth.signing.AwsSigningConfig;
 
@@ -84,6 +85,10 @@ public class S3MetaRequestOptions {
     private ChecksumConfig checksumConfig;
     private HttpRequest httpRequest;
     private Path requestFilePath;
+    private Path responseFilePath;
+    private ResponseFileOption responseFileOption = ResponseFileOption.CREATE_OR_REPLACE;
+    private long responseFilePosition = 0;
+    private boolean responseFileDeleteOnFailure = false;
     private S3MetaRequestResponseHandler responseHandler;
     private CredentialsProvider credentialsProvider;
     private AwsSigningConfig signingConfig;
@@ -312,5 +317,132 @@ public class S3MetaRequestOptions {
 
     public Long getObjectSizeHint() {
         return objectSizeHint;
+    }
+
+    public enum ResponseFileOption {
+        /**
+         * Create a new file if it doesn't exist, otherwise replace the existing file.
+         */
+        CREATE_OR_REPLACE(0),
+
+        /**
+         * Always create a new file. If the file already exists,
+         * AWS_ERROR_S3_RECV_FILE_EXISTS will be raised.
+         */
+        CREATE_NEW(1),
+
+        /**
+         * Create a new file if it doesn't exist, otherwise append to the existing file.
+         */
+        CREATE_OR_APPEND(2),
+
+        /**
+         * Write to an existing file at the specified position, defined by the
+         * {@link withHttpRequest}.
+         * If the file does not exist, AWS_ERROR_S3_RECV_FILE_NOT_EXISTS will be raised.
+         * If {@link withHttpRequest} is not configured, start overwriting data at the
+         * beginning of the file (byte 0).
+         */
+        WRITE_TO_POSITION(3);
+
+        ResponseFileOption(int nativeValue) {
+            this.nativeValue = nativeValue;
+        }
+
+        public int getNativeValue() {
+            return nativeValue;
+        }
+
+        public static ResponseFileOption getEnumValueFromInteger(int value) {
+            ResponseFileOption enumValue = enumMapping.get(value);
+            if (enumValue != null) {
+                return enumValue;
+            }
+
+            throw new RuntimeException("Invalid S3 ResponseFileOption");
+        }
+
+        private static Map<Integer, ResponseFileOption> buildEnumMapping() {
+            Map<Integer, ResponseFileOption> enumMapping = new HashMap<Integer, ResponseFileOption>();
+            enumMapping.put(CREATE_OR_REPLACE.getNativeValue(), CREATE_OR_REPLACE);
+            enumMapping.put(CREATE_NEW.getNativeValue(), CREATE_NEW);
+            enumMapping.put(CREATE_OR_APPEND.getNativeValue(), CREATE_OR_APPEND);
+            enumMapping.put(WRITE_TO_POSITION.getNativeValue(), WRITE_TO_POSITION);
+            return enumMapping;
+        }
+
+        private int nativeValue;
+
+        private static Map<Integer, ResponseFileOption> enumMapping = buildEnumMapping();
+    }
+
+    /**
+     * If set, this file will be used to write the response body to a file.
+     * And the {@link HttpStreamResponseHandler#onResponseBody} will not be invoked.
+     * {@link withResponseFileOption} configures the write behavior.
+     *
+     * @param responseFilePath path to file to write response body to.
+     * @return this
+     */
+    public S3MetaRequestOptions withResponseFilePath(Path responseFilePath, ResponseFileOption responseFileOption) {
+        this.responseFilePath = responseFilePath;
+        return this;
+    }
+
+    public Path getResponseFilePath() {
+        return responseFilePath;
+    }
+
+    /**
+     * Sets the option for how to handle the response file when downloading an object
+     * from S3.
+     * This option is only applicable when {@link withResponseFilePath} is set.
+     *
+     * By default, the option is set to {@link ResponseFileOption#CREATE_OR_REPLACE}.
+     *
+     * @param recvFileOption The option for handling the response file.
+     * @return this
+     */
+    public S3MetaRequestOptions withResponseFileOption(ResponseFileOption responseFileOption) {
+        this.responseFileOption = responseFileOption;
+        return this;
+    }
+
+    public ResponseFileOption getResponseFileOption() {
+        return responseFileOption;
+    }
+
+    /**
+     * Sets the position to start writing to the response file.
+     * This option is only applicable when {@link withResponseFileOption} is set
+     * to {@link ResponseFileOption#WRITE_TO_POSITION}.
+     *
+     * @param recvFilePosition The position to start writing to the response file.
+     * @return this
+     */
+    public S3MetaRequestOptions withResponseFilePosition(long responseFilePosition) {
+        this.responseFilePosition = responseFilePosition;
+        return this;
+    }
+
+    public long getResponseFilePosition() {
+        return responseFilePosition;
+    }
+
+    /**
+     * Sets whether to delete the response file on failure when downloading an object
+     * from S3.
+     * This option is only applicable when a response file path is set.
+     *
+     * @param recvFileDeleteOnFailure True to delete the response file on failure,
+     *                                false to leave it as-is.
+     */
+    public S3MetaRequestOptions withResponseFileDeleteOnFailure(boolean responseFileDeleteOnFailure) {
+        this.responseFileDeleteOnFailure = responseFileDeleteOnFailure;
+        return this;
+    }
+
+    public boolean getResponseFileDeleteOnFailure() {
+        return responseFileDeleteOnFailure;
     }
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
@@ -126,7 +126,7 @@ public class S3ClientTest extends CrtTestFixture {
 
         }
     }
-        
+
     @Test
     public void testS3ClientCreateDestroyWithTLS() {
         skipIfAndroid();
@@ -376,7 +376,6 @@ public class S3ClientTest extends CrtTestFixture {
             HttpHeader[] headers = { new HttpHeader("Host", ENDPOINT) };
             HttpRequest httpRequest = new HttpRequest("GET", PRE_EXIST_1MB_PATH, headers, null);
 
-            // Path responsePath = Files.createTempFile("testS3GetFilePath", ".txt");
             S3MetaRequestOptions metaRequestOptions = new S3MetaRequestOptions()
                     .withMetaRequestType(MetaRequestType.GET_OBJECT).withHttpRequest(httpRequest)
                     .withResponseFilePath(responsePath)

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
@@ -336,6 +336,46 @@ public class S3ClientTest extends CrtTestFixture {
     }
 
     @Test
+    public void testS3GetWithResponseFilePath() {
+        skipIfAndroid();
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(hasAwsCredentials());
+        S3ClientOptions clientOptions = new S3ClientOptions().withRegion(REGION);
+        try (S3Client client = createS3Client(clientOptions)) {
+            CompletableFuture<Integer> onFinishedFuture = new CompletableFuture<>();
+            Path responsePath = Files.createTempFile("testS3GetFilePath", ".txt");
+            S3MetaRequestResponseHandler responseHandler = new S3MetaRequestResponseHandler() {
+                @Override
+                public void onFinished(S3FinishedResponseContext context) {
+                    Log.log(Log.LogLevel.Info, Log.LogSubject.JavaCrtS3,
+                            "Meta request finished with error code " + context.getErrorCode());
+                    if (context.getErrorCode() != 0) {
+                        onFinishedFuture.completeExceptionally(makeExceptionFromFinishedResponseContext(context));
+                        return;
+                    }
+                    onFinishedFuture.complete(Integer.valueOf(context.getErrorCode()));
+                }
+            };
+
+            HttpHeader[] headers = { new HttpHeader("Host", ENDPOINT) };
+            HttpRequest httpRequest = new HttpRequest("GET", PRE_EXIST_1MB_PATH, headers, null);
+
+            // Path responsePath = Files.createTempFile("testS3GetFilePath", ".txt");
+            S3MetaRequestOptions metaRequestOptions = new S3MetaRequestOptions()
+                    .withMetaRequestType(MetaRequestType.GET_OBJECT).withHttpRequest(httpRequest)
+                    .withResponseFilePath(responsePath)
+                    .withResponseHandler(responseHandler);
+
+            try (S3MetaRequest metaRequest = client.makeMetaRequest(metaRequestOptions)) {
+                Assert.assertEquals(Integer.valueOf(0), onFinishedFuture.get());
+            }
+            Files.deleteIfExists(responsePath);
+        } catch (Exception ex) {
+            Assert.fail(ex.getMessage());
+        }
+    }
+
+    @Test
     public void testS3GetWithSizeHint() {
         skipIfAndroid();
         skipIfNetworkUnavailable();


### PR DESCRIPTION
- binding for S3 meta request recv file path, so that C can handle the file write directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
