### PR TITLE
pin awscli to 2.17.51 for release pipeline on GLIBC<2.17

### DIFF
--- a/codebuild/cd/manylinux-x64-build.yml
+++ b/codebuild/cd/manylinux-x64-build.yml
@@ -7,7 +7,7 @@ phases:
   pre_build:
     commands:
       - export CC=gcc
-      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.17.51.zip" -o "awscliv2.zip"
       - unzip awscliv2.zip
       - ./aws/install
   build:

--- a/codebuild/cd/manylinux-x64-fips-build.yml
+++ b/codebuild/cd/manylinux-x64-fips-build.yml
@@ -7,7 +7,7 @@ phases:
   pre_build:
     commands:
       - export CC=gcc
-      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+      - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.17.51.zip" -o "awscliv2.zip"
       - unzip awscliv2.zip
       - ./aws/install
   build:


### PR DESCRIPTION
*Issue #, if available:*

- https://aws.amazon.com/blogs/developer/linux-support-updates-for-aws-cli-v2/
- Aws cil v2 recently requires GLIBC>=2.17, and we still use old version of glibc in our code pipeline to build the "as old as possible" support for the binary we release.
- Pin to 2.17.51 for aws cli so that we are not affected the change they made. And we use awscli to upload to s3 which should not affected by the version update.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
