### PR TITLE
Fix Android CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,12 +240,14 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: set up Gradle
-        uses: gradle/actions/setup-gradle@v4
       # Build and publish locally for the test app to find the SNAPSHOT version
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          ./gradlew :android:crt:build
+          # Manually set -Xmx (max heap size) to something huge (tested 2g and that works, but why not go bigger).
+          # Only in CI, gradle daemon runs out of memory during "lintAnalyzeDebug" task, unless you specify it this way.
+          # You'd that Java's default of 25% RAM (ubuntu24 runner has 12g, so max 4g) would be sufficient, but no.
+          # You'd think setting -Xmx via gradle.properties would help, but no.
+          ./gradlew :android:crt:build -Dorg.gradle.jvmargs="-Xmx8g"
           ./gradlew -PnewVersion="1.0.0-SNAPSHOT" :android:crt:publishToMavenLocal
       # Setup files required by test app for Device Farm testing
       - name: Setup Android Test Files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
       - 'main'
       - 'docs'
 
+# cancel in-progress builds after a new commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BUILDER_VERSION: v0.9.67
   BUILDER_SOURCE: releases

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
       # Build and publish locally for the test app to find the SNAPSHOT version
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          ./gradlew :android:crt:build --no-daemon
+          ./gradlew :android:crt:build -Dorg.gradle.jvmargs="-Xmx12g"
           ./gradlew -PnewVersion="1.0.0-SNAPSHOT" :android:crt:publishToMavenLocal
       # Setup files required by test app for Device Farm testing
       - name: Setup Android Test Files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
         run: |
           # Manually set -Xmx (max heap size) to something huge (tested 2g and that works, but why not go bigger).
           # Only in CI, gradle daemon runs out of memory during "lintAnalyzeDebug" task, unless you specify it this way.
-          # You'd that Java's default of 25% RAM (ubuntu24 runner has 12g, so max 4g) would be sufficient, but no.
+          # You'd think Java's default of 25% RAM (ubuntu24 runner has 12g, so max 4g) would be sufficient, but no.
           # You'd think setting -Xmx via gradle.properties would help, but no.
           ./gradlew :android:crt:build -Dorg.gradle.jvmargs="-Xmx8g"
           ./gradlew -PnewVersion="1.0.0-SNAPSHOT" :android:crt:publishToMavenLocal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
       # Build and publish locally for the test app to find the SNAPSHOT version
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          ./gradlew :android:crt:build
+          ./gradlew :android:crt:build --no-daemon
           ./gradlew -PnewVersion="1.0.0-SNAPSHOT" :android:crt:publishToMavenLocal
       # Setup files required by test app for Device Farm testing
       - name: Setup Android Test Files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
       # Build and publish locally for the test app to find the SNAPSHOT version
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          ./gradlew :android:crt:build -Dorg.gradle.jvmargs="-Xmx12g"
+          ./gradlew :android:crt:build -Dorg.gradle.jvmargs="-Xmx2g"
           ./gradlew -PnewVersion="1.0.0-SNAPSHOT" :android:crt:publishToMavenLocal
       # Setup files required by test app for Device Farm testing
       - name: Setup Android Test Files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,11 +235,12 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       # Build and publish locally for the test app to find the SNAPSHOT version
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
-          ./gradlew :android:crt:build -Dorg.gradle.jvmargs="-Xmx2g"
+          ./gradlew :android:crt:build
           ./gradlew -PnewVersion="1.0.0-SNAPSHOT" :android:crt:publishToMavenLocal
       # Setup files required by test app for Device Farm testing
       - name: Setup Android Test Files

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2G
+org.gradle.jvmargs=-Xmx8G
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx16G
+# org.gradle.jvmargs=-Xmx2g
+org.gradle.daemon=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# org.gradle.jvmargs=-Xmx2G
+org.gradle.jvmargs=-Xmx16G
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# org.gradle.jvmargs=-Xmx2g
+# org.gradle.jvmargs=-Xmx2G
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,7 +7,6 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # org.gradle.jvmargs=-Xmx2g
-org.gradle.daemon=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx8G
+# org.gradle.jvmargs=-Xmx2G
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
**Issue:**
The Android CI started failing due to:
```
Daemon will be stopped at the end of the build after running out of JVM memory
> Task :android:crt:lintAnalyzeDebug FAILED
```

This has been a recurring issue since we updated a bunch of build stuff as part of updating CMake https://github.com/awslabs/aws-crt-java/pull/837.

**Description of changes:**

Manually set -Xmx (max heap size) to something huge (tested 2g and that works, but why not go bigger) via the cmdline when invoking gradle in CI. Only in CI, gradle daemon runs out of memory during "lintAnalyzeDebug" task, unless you specify it this way. You'd think that Java's default of 25% RAM (ubuntu24 runner has 12g, so max 4g) would be sufficient, but no. You'd think setting -Xmx via gradle.properties would help, but no.

Also, make it so a new commit cancels any old in-progress builds. It's a waste of energy to continue these builds, some of which take a looooooong time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
