### PR TITLE
Flaky test pass1

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -2084,6 +2084,9 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                 eventsTwo.connectedFuture.get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
                 subscriber.subscribe(subscribePacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
 
+                // Paranoid about service-side eventual consistency.  Add a wait to reduce chances of a missed will publish.
+                Thread.sleep(2000);
+
                 publisher.stop(disconnectPacketBuilder.build());
 
                 publishEvents.publishReceivedFuture.get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -2171,11 +2171,6 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                 // Wait a little longer just to ensure that no packets beyond expectations are arrived.
                 publishEvents.afterCompletionFuture.get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
 
-                // Check that both clients received packets.
-                // PublishEvents_Futured_Counted also checks for duplicated packets, so this one assert is enough
-                // to ensure that AWS IoT Core sent different packets to different subscribers.
-                assertTrue(publishEvents.clientsReceived.size() == 2);
-
                 subscriberOneClient.stop();
                 subscriberTwoClient.stop();
                 publisherClient.stop();

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -1132,9 +1132,10 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
 
         @Override
         public void onConnectionFailure(Mqtt5Client client, OnConnectionFailureReturn onConnectionFailureReturn) {
-            connectedFuture.completeExceptionally(new Exception(
-                "[" + client_name + "] Could not connect! Error code is: " + onConnectionFailureReturn.getErrorCode()
-            ));
+            // failing the connected future here is not valid from a race condition standpoint.  It is possible that
+            // the interrupting client itself gets interrupted and fails to fully connect due to the original client
+            // interrupting it.  Eventually it will succeed (briefly) as the two clients fight over the client id
+            // with increasing reconnect backoff.
         }
 
         @Override

--- a/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
@@ -64,8 +64,7 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
                     };
 
                     CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE,
-                            messageHandler);
-                    subscribed.thenApply(unused -> subsAcked++);
+                            messageHandler).thenApply(unused -> subsAcked++);
                     int packetId = subscribed.get();
 
                     assertNotSame(0, packetId);
@@ -73,15 +72,13 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
 
                     MqttMessage message = new MqttMessage(TEST_TOPIC, TEST_PAYLOAD.getBytes(), QualityOfService.AT_LEAST_ONCE,
                             false);
-                    CompletableFuture<Integer> published = connection.publish(message);
-                    published.thenApply(unused -> pubsAcked++);
+                    CompletableFuture<Integer> published = connection.publish(message).thenApply(unused -> pubsAcked++);
                     packetId = published.get();
 
                     assertNotSame(0, packetId);
                     assertEquals("Published", 1, pubsAcked);
 
-                    published = connection.publish(message);
-                    published.thenApply(unused -> pubsAcked++);
+                    published = connection.publish(message).thenApply(unused -> pubsAcked++);
                     packetId = published.get();
 
                     assertNotSame(0, packetId);
@@ -93,8 +90,7 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
                     assertEquals("Received", message.getQos(), received.getQos());
                     assertEquals("Received", message.getRetain(), received.getRetain());
 
-                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC);
-                    unsubscribed.thenApply(unused -> subsAcked--);
+                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC).thenApply(unused -> subsAcked--);
                     packetId = unsubscribed.get();
 
                     assertNotSame(0, packetId);
@@ -141,30 +137,26 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
                     null);
 
                 try {
-                    CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE);
-                    subscribed.thenApply(unused -> subsAcked++);
+                    CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE).thenApply(unused -> subsAcked++);
                     int packetId = subscribed.get();
 
                     assertNotSame(0, packetId);
                     assertEquals("Single subscription", 1, subsAcked);
 
                     MqttMessage message = new MqttMessage(TEST_TOPIC, TEST_PAYLOAD.getBytes(), QualityOfService.AT_LEAST_ONCE);
-                    CompletableFuture<Integer> published = connection.publish(message);
-                    published.thenApply(unused -> pubsAcked++);
+                    CompletableFuture<Integer> published = connection.publish(message).thenApply(unused -> pubsAcked++);
                     packetId = published.get();
 
                     assertNotSame(0, packetId);
                     assertEquals("Published", 1, pubsAcked);
 
-                    published = connection.publish(message);
-                    published.thenApply(unused -> pubsAcked++);
+                    published = connection.publish(message).thenApply(unused -> pubsAcked++);
                     packetId = published.get();
 
                     assertNotSame(0, packetId);
                     assertEquals("Published", 2, pubsAcked);
 
-                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC);
-                    unsubscribed.thenApply(unused -> subsAcked--);
+                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC).thenApply(unused -> subsAcked--);
                     packetId = unsubscribed.get();
 
                     assertNotSame(0, packetId);

--- a/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/SelfPubSubTest.java
@@ -34,9 +34,6 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
     static final String TEST_TOPIC = "publish/me/senpai/" + UUID.randomUUID().toString();
     static final String TEST_PAYLOAD = "PUBLISH ME! SHINY AND CHROME!";
 
-    int pubsAcked = 0;
-    int subsAcked = 0;
-
     @Test
     public void testPubSub() {
         skipIfNetworkUnavailable();
@@ -64,25 +61,22 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
                     };
 
                     CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE,
-                            messageHandler).thenApply(unused -> subsAcked++);
+                            messageHandler);
                     int packetId = subscribed.get();
 
                     assertNotSame(0, packetId);
-                    assertEquals("Single subscription", 1, subsAcked);
 
                     MqttMessage message = new MqttMessage(TEST_TOPIC, TEST_PAYLOAD.getBytes(), QualityOfService.AT_LEAST_ONCE,
                             false);
-                    CompletableFuture<Integer> published = connection.publish(message).thenApply(unused -> pubsAcked++);
+                    CompletableFuture<Integer> published = connection.publish(message);
                     packetId = published.get();
 
                     assertNotSame(0, packetId);
-                    assertEquals("Published", 1, pubsAcked);
 
-                    published = connection.publish(message).thenApply(unused -> pubsAcked++);
+                    published = connection.publish(message);
                     packetId = published.get();
 
                     assertNotSame(0, packetId);
-                    assertEquals("Published", 2, pubsAcked);
 
                     MqttMessage received = receivedFuture.get();
                     assertEquals("Received", message.getTopic(), received.getTopic());
@@ -90,11 +84,10 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
                     assertEquals("Received", message.getQos(), received.getQos());
                     assertEquals("Received", message.getRetain(), received.getRetain());
 
-                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC).thenApply(unused -> subsAcked--);
+                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC);
                     packetId = unsubscribed.get();
 
                     assertNotSame(0, packetId);
-                    assertEquals("No Subscriptions", 0, subsAcked);
                 } catch (Exception ex) {
                     fail(ex.getMessage());
                 }
@@ -137,30 +130,26 @@ public class SelfPubSubTest extends MqttClientConnectionFixture {
                     null);
 
                 try {
-                    CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE).thenApply(unused -> subsAcked++);
+                    CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE);
                     int packetId = subscribed.get();
 
                     assertNotSame(0, packetId);
-                    assertEquals("Single subscription", 1, subsAcked);
 
                     MqttMessage message = new MqttMessage(TEST_TOPIC, TEST_PAYLOAD.getBytes(), QualityOfService.AT_LEAST_ONCE);
-                    CompletableFuture<Integer> published = connection.publish(message).thenApply(unused -> pubsAcked++);
+                    CompletableFuture<Integer> published = connection.publish(message);
                     packetId = published.get();
 
                     assertNotSame(0, packetId);
-                    assertEquals("Published", 1, pubsAcked);
 
-                    published = connection.publish(message).thenApply(unused -> pubsAcked++);
+                    published = connection.publish(message);
                     packetId = published.get();
 
                     assertNotSame(0, packetId);
-                    assertEquals("Published", 2, pubsAcked);
 
-                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC).thenApply(unused -> subsAcked--);
+                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC);
                     packetId = unsubscribed.get();
 
                     assertNotSame(0, packetId);
-                    assertEquals("No Subscriptions", 0, subsAcked);
                 } catch (Exception ex) {
                     fail(ex.getMessage());
                 }


### PR DESCRIPTION

* Update shared subscription test to remove invalid assertions on a property that does not necessarily hold (all subscriptions receive messages)
* Update SelfPubSub test to not use counting variables that are pointless (they won't ever be wrong) as well as unsafe from race conditions (they are set and read from different threads with no explicit synchronizations, also the future that was waited upon strictly happens-before the setting of the counter which leads to consistency issues)
* Update the double client id connection failure test to be more forgiving to potential race conditions between the two clients fighting over the client id
* Adds a delay between subscribe and disconnect in the will test.  Did not get an encouraging answer when the service team was queried about whether subscribe completion had any eventual consistency issues relative to a subsequent publish (connection will).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
