### PR TITLE
Add ML-KEM PQ TLS Policy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,18 +150,15 @@ a classifier-based jar, you must specify the classifier name yourself.
   <dependencies>
 ```
 
-## FIPS Compliance
+## FIPS Cryptography
 
-Currently the classifier `fips-where-available` provides an "uber" jar with FIPS compliance on *some platforms*.
-
-Platforms without FIPS compliance are also included in this jar, for compatibility's sake. Check `CRT.isFIPS()` at runtime to ensure you are on a FIPS compliant platform. The current breakdown is:
-* **FIPS compliant**: linux-aarch_64, linux-x86_64
-* **NOT compliant**: linux-armv6, linux-armv7, linux-armv7-musl, linux-aarch_64-musl, linux-x86_32, linux-x86_64-musl, osx-aarch_64, osx-x86_64, windows-x86_32, windows-x86_64
+Currently the classifier `fips-where-available` provides an "uber" jar with FIPS tested cryptography on *some platforms*.
+Platforms that were not part of the FIPS testing are also included in this jar, for compatibility's sake. Check `CRT.isFIPS()` at runtime to ensure that AWS-LC is being run in FIPS mode, and follow the [security policy of AWS-LC-FIPS 3.0.0 (static)](https://github.com/aws/aws-lc/blob/AWS-LC-FIPS-3.0.0/crypto/fipsmodule/policydocs/DRAFT-140-3-AmazonSecurityPolicy-3.0.0-static.pdf).
 
 > [!WARNING]
-> The classifier, and platforms with FIPS compliance are subject to change in the future.
+> The classifier, and platforms with FIPS testing are subject to change in the future.
 
-Platforms with FIPS compliance use [AWS-LC](https://github.com/aws/aws-lc) as their cryptographic module ([NIST Certificate #4816](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816)).
+Refer to the [NIST Cryptographic Module Validation Program's Modules In Progress List](https://csrc.nist.gov/Projects/cryptographic-module-validation-program/modules-in-process/modules-in-process-list) for the latest status of the static AWS-LC 3.0 Cryptographic Module. A complete list of supported operating environments will be made available in the vendor security policy once the validation certificate has been issued. We will also update our release notes and documentation to reflect any changes in FIPS certification status. Previous versions of AWS-LC have already received FIPS cryptographic module certificates ([NIST Certificate #4816](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816) & [NIST Certificate #4631](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4631)).
 
 ## GraalVM support
 

--- a/codebuild/cd/test-fips-branch.sh
+++ b/codebuild/cd/test-fips-branch.sh
@@ -9,12 +9,13 @@ cd ./crt/aws-lc || exit 1
 # Get the current commit hash
 current_commit=$(git rev-parse HEAD)
 
-# Check if the current commit is from the "fips-2022-11-02" branch
-if git merge-base --is-ancestor "$current_commit" "origin/fips-2022-11-02"; then
-    echo "Current aws-lc commit is from the 'fips-2022-11-02' branch"
+# Check if the current commit is from the FIPS branch
+fips_branch="fips-2024-09-27"
+if git merge-base --is-ancestor "$current_commit" "origin/$fips_branch"; then
+    echo "Current aws-lc commit is from the '$fips_branch' branch"
     status=0
 else
-    echo "Error: Current aws-lc commit is not from the 'fips-2022-11-02' branch"
+    echo "Error: Current aws-lc commit is not from the '$fips_branch' branch"
     status=1
 fi
 

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
@@ -18,54 +18,48 @@ public enum TlsCipherPreference {
     TLS_CIPHER_SYSTEM_DEFAULT(0),
 
     /**
-     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_2_2023 instead.
      */
     @Deprecated
     TLS_CIPHER_KMS_PQ_TLSv1_0_2019_06(1),
 
     /**
-     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_2_2023 instead.
      */
     @Deprecated
     TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2019_11(2),
 
     /**
-     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_2_2023 instead.
      */
     @Deprecated
     TLS_CIPHER_PREF_KMS_PQ_TLSv1_0_2020_02(3),
 
     /**
-     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_2_2023 instead.
      */
     @Deprecated
     TLS_CIPHER_PREF_KMS_PQ_SIKE_TLSv1_0_2020_02(4),
 
     /**
-     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 instead.
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_2_2023 instead.
      */
     @Deprecated
     TLS_CIPHER_PREF_KMS_PQ_TLSv1_0_2020_07(5),
 
     /**
-     * This TlsCipherPreference supports TLS 1.0 through TLS 1.3, and contains Kyber Round 3 as its highest priority
-     * PQ algorithm. PQ algorithms in this preference list will be used in hybrid mode, and will be combined with a
-     * classical ECDHE key exchange.
-     *
-     * NIST has announced that Kyber will be first post-quantum key-agreement algorithm that it will standardize.
-     * However, the NIST standardization process might introduce minor changes that may cause the final Kyber standard
-     * to differ from the Kyber Round 3 implementation available in this preference list.
-     *
-     * Since this TlsCipherPreference contains algorithms that have not yet been officially standardized by NIST, this
-     * preference list, and any of the PQ algorithms in it, may stop being supported at any time.
-     *
-     * For more info see:
-     *   - https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid
-     *   - https://datatracker.ietf.org/doc/html/draft-ietf-tls-hybrid-design
-     *   - https://aws.amazon.com/blogs/security/how-to-tune-tls-for-hybrid-post-quantum-cryptography-with-kyber/
-     *   - https://nvlpubs.nist.gov/nistpubs/ir/2022/NIST.IR.8413.pdf
+     * @deprecated This TlsCipherPreference is no longer supported. Use TLS_CIPHER_PREF_PQ_TLSv1_2_2023 instead.
      */
-    TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05(6);
+    @Deprecated
+    TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05(6),
+
+    /**
+     * This  TlsCipherPreference is a clone of the "AWS-CRT-SDK-TLSv1.2-2023" s2n TLS Policy, but with the following PQ SupportedGroups added:
+     *  - X25519MLKEM768, P256MLKEM768, SecP256r1Kyber768Draft00, X25519Kyber768Draft00, secp384r1_kyber-768-r3, secp521r1_kyber-1024-r3, secp256r1_kyber-512-r3, x25519_kyber-512-r3
+     *
+     *  Both X25519MLKEM768 and P256MLKEM768 will be standardized by the IETF soon. Hybrid Groups that contain Kyber may be removed in the future.
+     */
+    TLS_CIPHER_PREF_PQ_TLSv1_2_2023(7);
 
     private int val;
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
1. Updates AWS-LC to release `AWS-LC-FIPS-3.0.0` (with ML-KEM support)
2. Fixes `test-fips-branch.sh` script to work with AWS-LC-FIPS 3.0.0 release
3. Adds new PQ TLS Policy to CRT Java enum with MLKEM support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
