### PR TITLE
CD fix for Windows TLS 1.3

### DIFF
--- a/codebuild/cd/windows-vs2015-x64-build.bat
+++ b/codebuild/cd/windows-vs2015-x64-build.bat
@@ -5,6 +5,7 @@ echo PATH=%PATH%
 echo JAVA_HOME=%JAVA_HOME%
 
 set AWS_CMAKE_GENERATOR=Visual Studio 14 2015 Win64
+set AWS_WINDOWS_SDK_VERSION=10.0.17763.0
 
 git submodule update --init
 

--- a/codebuild/cd/windows-vs2015-x86-build.bat
+++ b/codebuild/cd/windows-vs2015-x86-build.bat
@@ -5,6 +5,7 @@ echo PATH=%PATH%
 echo JAVA_HOME=%JAVA_HOME%
 
 set AWS_CMAKE_GENERATOR=Visual Studio 14 2015
+set AWS_WINDOWS_SDK_VERSION=10.0.17763.0
 
 git submodule update --init
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
         <cmake.min_osx_version>-DOSX_DEPLOYMENT_TARGET_DUMMY=1</cmake.min_osx_version>
         <cmake.crt_fips>OFF</cmake.crt_fips>
         <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+        <!-- Default Windows SDK flag property (empty if not overridden)-->
+        <cmake.windows.sdk.flag></cmake.windows.sdk.flag>
     </properties>
 
     <profiles>
@@ -79,6 +81,18 @@
                 <cmake.buildconfig>RelWithDebInfo</cmake.buildconfig>
                 <cmake.cflags/>
             </properties>
+        </profile>
+        <!-- Profile to set the Windows SDK version if AWS_WINDOWS_SDK_VERSION is defined -->
+        <profile>
+          <id>windows-sdk-version</id>
+          <activation>
+            <property>
+              <name>env.AWS_WINDOWS_SDK_VERSION</name>
+            </property>
+          </activation>
+          <properties>
+            <cmake.windows.sdk.flag>-DCMAKE_SYSTEM_VERSION=${env.AWS_WINDOWS_SDK_VERSION}</cmake.windows.sdk.flag>
+          </properties>
         </profile>
         <!-- Unix/Linux/OSX profiles: use makefiles and the "all" compile target -->
         <profile>
@@ -187,6 +201,8 @@
                                         <argument>--no-warn-unused-cli</argument>
                                         <argument>${cmake.generator}</argument>
                                         <argument>${cmake.toolset}</argument>
+                                        <!-- Conditionally add the Windows SDK flag -->
+                                        <argument>${cmake.windows.sdk.flag}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
For building Windows on Jenkins with TLS 1.3 support, the Windows SDK version 10.0.17763.0 must be used for schannel.h to contain SCH_CREDENTIALS and TLS_PARAMETERS used for TLS 1.3.

The env AWS_WINDOWS_SDK_VERSION is set to 10.0.17763.0 in the windows cd .bat files. The pom.xml has been modified to check for this env and if it exists, add it to the cmake command when building for Windows.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
