### PR TITLE
update submodule aws-c-io to remove TLS 1.3 for win

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
         role-duration-seconds: 14400 # these tests run slow and easily reach default cred expiry, hence change expiry to 4hrs
     - name: Install qemu/docker
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      run: docker run --privileged --rm tonistiigi/binfmt --install all
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
@@ -193,7 +193,7 @@ jobs:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Install qemu/docker
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      run: docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
 
   linux-musl-arm:
-    runs-on: ubuntu-22.04 # temporarily downgrade to old ubuntu as 24.04 likes to segfault in the middle of the build
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         image:


### PR DESCRIPTION
Pull in the reverted aws-c-io submodule.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
