### PR TITLE
switch to critical mem access for checksums

### DIFF
--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -47,6 +47,11 @@ void aws_jni_throw_runtime_exception(JNIEnv *env, const char *msg, ...);
 void aws_jni_throw_null_pointer_exception(JNIEnv *env, const char *msg, ...);
 
 /*******************************************************************************
+ * Throws java OutOfMemoryError
+ ******************************************************************************/
+void aws_jni_throw_out_of_memory_exception(JNIEnv *env, const char *msg, ...);
+
+/*******************************************************************************
  * Throws java IllegalArgumentException
  ******************************************************************************/
 void aws_jni_throw_illegal_argument_exception(JNIEnv *env, const char *msg, ...);
@@ -180,10 +185,31 @@ void aws_jni_byte_cursor_from_jstring_release(JNIEnv *env, jstring str, struct a
  ******************************************************************************/
 struct aws_byte_cursor aws_jni_byte_cursor_from_jbyteArray_acquire(JNIEnv *env, jbyteArray str);
 
+/*******************************************************************************
+ * aws_jni_byte_cursor_from_jbyteArray_critical_acquire - Creates an aws_byte_cursor from the
+ * bytes extracted from the supplied jbyteArray.
+ * The aws_byte_cursor MUST be given to aws_jni_byte_cursor_from jstring_release() when
+ * it's no longer needed, or it will leak.
+ *
+ * If there is an error, the returned aws_byte_cursor.ptr will be NULL and
+ * and a java exception is being thrown.
+ * **** WARNING: Here be dragons ****
+ * This function uses critical jvm functions to access memory, which is faster, but comes
+ * with a litany of limitations, so use at your own risk.
+ * Spending too much time in a critical section will stall gc and mem functionality, so under
+ * no conditions use jni functions while in critical section on current thread (ok, on other threads).
+ ******************************************************************************/
+struct aws_byte_cursor aws_jni_byte_cursor_from_jbyteArray_critical_acquire(JNIEnv *env, jbyteArray str);
+
 /********************************************************************************
  * aws_jni_byte_cursor_from_jbyteArray_release - Releases the array back to the JVM
  ********************************************************************************/
 void aws_jni_byte_cursor_from_jbyteArray_release(JNIEnv *env, jbyteArray str, struct aws_byte_cursor cur);
+
+/********************************************************************************
+ * aws_jni_byte_cursor_from_jbyteArray_release - Releases critical array access back to JVM
+ ********************************************************************************/
+void aws_jni_byte_cursor_from_jbyteArray_critical_release(JNIEnv *env, jbyteArray str, struct aws_byte_cursor cur);
 
 /*******************************************************************************
  * aws_jni_byte_cursor_from_direct_byte_buffer - Creates an aws_byte_cursor from the

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -207,7 +207,7 @@ struct aws_byte_cursor aws_jni_byte_cursor_from_jbyteArray_critical_acquire(JNIE
 void aws_jni_byte_cursor_from_jbyteArray_release(JNIEnv *env, jbyteArray str, struct aws_byte_cursor cur);
 
 /********************************************************************************
- * aws_jni_byte_cursor_from_jbyteArray_release - Releases critical array access back to JVM
+ * aws_jni_byte_cursor_from_jbyteArray_critical_release - Releases critical array access back to JVM
  ********************************************************************************/
 void aws_jni_byte_cursor_from_jbyteArray_critical_release(JNIEnv *env, jbyteArray str, struct aws_byte_cursor cur);
 

--- a/src/native/crt.h
+++ b/src/native/crt.h
@@ -177,7 +177,7 @@ void aws_jni_byte_cursor_from_jstring_release(JNIEnv *env, jstring str, struct a
 /*******************************************************************************
  * aws_jni_byte_cursor_from_jbyteArray_acquire - Creates an aws_byte_cursor from the
  * bytes extracted from the supplied jbyteArray.
- * The aws_byte_cursor MUST be given to aws_jni_byte_cursor_from jstring_release() when
+ * The aws_byte_cursor MUST be given to aws_jni_byte_cursor_from_jbyteArray_release() when
  * it's no longer needed, or it will leak.
  *
  * If there is an error, the returned aws_byte_cursor.ptr will be NULL and
@@ -188,7 +188,7 @@ struct aws_byte_cursor aws_jni_byte_cursor_from_jbyteArray_acquire(JNIEnv *env, 
 /*******************************************************************************
  * aws_jni_byte_cursor_from_jbyteArray_critical_acquire - Creates an aws_byte_cursor from the
  * bytes extracted from the supplied jbyteArray.
- * The aws_byte_cursor MUST be given to aws_jni_byte_cursor_from jstring_release() when
+ * The aws_byte_cursor MUST be given to aws_jni_byte_cursor_from_jbyteArray_critical_release() when
  * it's no longer needed, or it will leak.
  *
  * If there is an error, the returned aws_byte_cursor.ptr will be NULL and


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
GetByteArrayElements is proving to be really slow in some cases due to excessive copying. Switch over to GetPrimitiveArrayCritical for checksums.
This approach mimics what OpenJDK does for zlib crcs (minus the intrinsics annotations)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
