### PR TITLE
Simplification of Builder Use

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/packets/PublishPacket.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/packets/PublishPacket.java
@@ -182,6 +182,32 @@ public class PublishPacket {
     }
 
     /**
+     * Creates a {@link PublishPacket} containing only the most common fields:
+     * <em>topic</em>, <em>QoS</em>, and <em>payload</em>.
+     * <p>
+     * Internally this is just syntactic sugar around
+     * {@link PublishPacketBuilder#PublishPacketBuilder(String, QOS, byte[])}
+     * followed by {@link PublishPacketBuilder#build()}.
+     * All optional MQTT 5 properties (retain flag, user properties, etc.)
+     * are left {@code null} / unset.
+     *
+     * @param topic   The topic this message should be published to.
+     * @param qos     The MQTT quality of service level the message should be delivered with.
+     * @param payload The payload for the publish message.
+     * @return a fully-validated, immutable {@code PublishPacket} ready for use
+     *
+     * @throws NullPointerException if {@code topic}, {@code qos}, or
+     *                              {@code payload} is {@code null}
+     */
+    public static PublishPacket of(String topic, QOS qos, byte[] payload) {
+        Objects.requireNonNull(topic, "topic");
+        Objects.requireNonNull(qos, "qos");
+        Objects.requireNonNull(payload, "payload");
+
+        return new PublishPacketBuilder(topic, qos, payload).build();
+    }
+
+    /**
      * Creates a Mqtt5Client options instance
      * @throws CrtRuntimeException If the system is unable to allocate space for a native MQTT client structure
      */

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/packets/SubscribePacket.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/packets/SubscribePacket.java
@@ -29,6 +29,27 @@ public class SubscribePacket {
     }
 
     /**
+     * Creates a {@link SubscribePacket} containing only a single subscription topic and qos:
+     * <em>topicFilter</em>, <em>QoS</em>.
+     * <p>
+     * Internally this is just syntactic sugar around
+     * {@link SubscribePacketBuilder#SubscribePacketBuilder(String, QOS)}
+     * followed by {@link SubscribePacketBuilder#build()}.
+     * 
+     * @param topicFilter The topic filter to subscribe to.
+     * @param qos The maximum QoS on which the subscriber will accept publish messages.
+     * @return an immutable {@code SubscribePacket} ready for use
+     * 
+     * @throws NullPointerException if {@code topicFilter} or {@code qos} is {@code null}
+     */
+    public static SubscribePacket of(String topicFilter, QOS qos) {
+        Objects.requireNonNull(topicFilter, "topicFilter");
+        Objects.requireNonNull(qos, "qos");
+
+        return new SubscribePacketBuilder(topicFilter, qos).build();
+    }
+
+    /**
      * Returns the list of subscriptions that the client wishes to listen to
      *
      * See <a href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901168">MQTT5 Subscribe Payload</a>

--- a/src/main/java/software/amazon/awssdk/crt/mqtt5/packets/UnsubscribePacket.java
+++ b/src/main/java/software/amazon/awssdk/crt/mqtt5/packets/UnsubscribePacket.java
@@ -21,6 +21,25 @@ public class UnsubscribePacket {
     }
 
     /**
+     * Creates an {@link UnsubscribePacket} containing only a single subscription topic to unsubscribe from:
+     * <em>topicFilter</em>.
+     * <p>
+     * Internally this is just syntactic sugar around
+     * {@link UnsubscribePacketBuilder#UnsubscribePacketBuilder(String)}
+     * followed by {@link UnsubscribePacketBuilder#build()}.
+     * 
+     * @param topicFilter The topic filter to unsubscribe from.
+     * @return an immutable {@code UnsubscribePacket} ready for use
+     * 
+     * @throws NullPointerException if {@code topicFilter} is {@code null}
+     */
+    public static UnsubscribePacket of(String topicFilter) {
+        Objects.requireNonNull(topicFilter, "topicFilter");
+
+        return new UnsubscribePacketBuilder(topicFilter).build();
+    }
+
+    /**
      * Returns a list of subscriptions that the client wishes to unsubscribe from.
      *
      * @return List of subscriptions that the client wishes to unsubscribe from.


### PR DESCRIPTION
Simplify and/or remove builder for creation of MQTT5 related objects.

Common PublishPacket, SubscribePacket, and UnsubscribePacket can be created directly without use of a builder.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
