### PR TITLE
Socket timeout retry wrapper around various HTTP and MQTT tests

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
@@ -24,6 +24,8 @@ import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
 import software.amazon.awssdk.crt.http.Http2ClientConnection.Http2ErrorCode;
 import software.amazon.awssdk.crt.CrtResource;
 
+import software.amazon.awssdk.crt.test.TestUtils;
+
 public class Http2ClientConnectionTest extends HttpClientTestFixture {
 
     private final static String HOST = "https://postman-echo.com";
@@ -56,7 +58,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        doRetryableTest(() -> { this.doHttp2ConnectionGetVersionTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionGetVersionTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }
@@ -94,7 +96,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }
@@ -129,7 +131,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         /* empty settings is allowed to send */
         skipIfNetworkUnavailable();
 
-        doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsEmptyTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsEmptyTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }
@@ -166,7 +168,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        doRetryableTest(() -> { this.doHttp2ConnectionPingTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionPingTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }
@@ -210,7 +212,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        doRetryableTest(() -> { this.doHttp2ConnectionPingExceptionPingDataLengthTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionPingExceptionPingDataLengthTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }
@@ -248,7 +250,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
          */
         skipIfNetworkUnavailable();
 
-        doRetryableTest(() -> { this.doHttp2ConnectionSendGoAwayTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionSendGoAwayTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }
@@ -286,7 +288,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
          */
         skipIfNetworkUnavailable();
 
-        doRetryableTest(() -> { this.doHttp2ConnectionUpdateConnectionWindowTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateConnectionWindowTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
@@ -57,7 +57,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionGetVersionTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doHttp2ConnectionGetVersionTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -95,7 +95,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doHttp2ConnectionUpdateSettingsTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -130,7 +130,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         /* empty settings is allowed to send */
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsEmptyTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doHttp2ConnectionUpdateSettingsEmptyTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -167,7 +167,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionPingTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doHttp2ConnectionPingTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -211,7 +211,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionPingExceptionPingDataLengthTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doHttp2ConnectionPingExceptionPingDataLengthTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -249,7 +249,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
          */
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionSendGoAwayTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doHttp2ConnectionSendGoAwayTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -287,7 +287,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
          */
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateConnectionWindowTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doHttp2ConnectionUpdateConnectionWindowTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
@@ -29,30 +29,64 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
     private final static String HOST = "https://postman-echo.com";
     private final static HttpVersion EXPECTED_VERSION = HttpVersion.HTTP_2;
 
+    private void doHttp2ConnectionGetVersionTest() {
+        try {
+            CompletableFuture<Void> shutdownComplete = null;
+            boolean actuallyConnected = false;
+            URI uri = new URI(HOST);
+
+            try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
+                shutdownComplete = connPool.getShutdownCompleteFuture();
+                try (HttpClientConnection conn = connPool.acquireConnection().get(60, TimeUnit.SECONDS)) {
+                    actuallyConnected = true;
+                    Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
+                }
+            }
+
+            Assert.assertTrue(actuallyConnected);
+
+            shutdownComplete.get(60, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     public void testHttp2ConnectionGetVersion() throws Exception {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        CompletableFuture<Void> shutdownComplete = null;
-        boolean actuallyConnected = false;
-        URI uri = new URI(HOST);
+        doRetryableTest(() -> { this.doHttp2ConnectionGetVersionTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
 
-        try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
-            shutdownComplete = connPool.getShutdownCompleteFuture();
-            try (HttpClientConnection conn = connPool.acquireConnection().get(60, TimeUnit.SECONDS)) {
-                actuallyConnected = true;
-                Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
+        CrtResource.waitForNoResources();
+    }
+
+    private void doHttp2ConnectionUpdateSettingsTest() {
+        try {
+            CompletableFuture<Void> shutdownComplete = null;
+            boolean actuallyConnected = false;
+            URI uri = new URI(HOST);
+
+            try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
+                shutdownComplete = connPool.getShutdownCompleteFuture();
+                try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
+                        TimeUnit.SECONDS);) {
+                    actuallyConnected = true;
+                    Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
+                    List<Http2ConnectionSetting> settings = new ArrayList<Http2ConnectionSetting>();
+                    conn.updateSettings(Http2ConnectionSetting.builder()
+                            .enablePush(false)
+                            .enablePush(false)
+                            .build()).get(5, TimeUnit.SECONDS);
+                }
             }
+
+            Assert.assertTrue(actuallyConnected);
+
+            shutdownComplete.get(60, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
-        Assert.assertTrue(actuallyConnected);
-
-        shutdownComplete.get(60, TimeUnit.SECONDS);
-
-        CrtResource.waitForNoResources();
     }
 
     @Test
@@ -60,31 +94,33 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        CompletableFuture<Void> shutdownComplete = null;
-        boolean actuallyConnected = false;
-        URI uri = new URI(HOST);
+        doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
 
-        try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
-            shutdownComplete = connPool.getShutdownCompleteFuture();
-            try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
-                    TimeUnit.SECONDS);) {
-                actuallyConnected = true;
-                Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
-                List<Http2ConnectionSetting> settings = new ArrayList<Http2ConnectionSetting>();
-                conn.updateSettings(Http2ConnectionSetting.builder()
-                        .enablePush(false)
-                        .enablePush(false)
-                        .build()).get(5, TimeUnit.SECONDS);
+        CrtResource.waitForNoResources();
+    }
+
+    private void doHttp2ConnectionUpdateSettingsEmptyTest() {
+        try {
+            CompletableFuture<Void> shutdownComplete = null;
+            boolean actuallyConnected = false;
+            URI uri = new URI(HOST);
+
+            try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
+                shutdownComplete = connPool.getShutdownCompleteFuture();
+                try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
+                        TimeUnit.SECONDS);) {
+                    actuallyConnected = true;
+                    Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
+                    conn.updateSettings(Http2ConnectionSetting.builder().build()).get(5, TimeUnit.SECONDS);
+                }
             }
+
+            Assert.assertTrue(actuallyConnected);
+
+            shutdownComplete.get(60, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
-        Assert.assertTrue(actuallyConnected);
-
-        shutdownComplete.get(60, TimeUnit.SECONDS);
-
-        CrtResource.waitForNoResources();
     }
 
     @Test
@@ -93,27 +129,36 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         /* empty settings is allowed to send */
         skipIfNetworkUnavailable();
 
-        CompletableFuture<Void> shutdownComplete = null;
-        boolean actuallyConnected = false;
-        URI uri = new URI(HOST);
+        doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsEmptyTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
 
-        try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
-            shutdownComplete = connPool.getShutdownCompleteFuture();
-            try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
-                    TimeUnit.SECONDS);) {
-                actuallyConnected = true;
-                Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
-                conn.updateSettings(Http2ConnectionSetting.builder().build()).get(5, TimeUnit.SECONDS);
+        CrtResource.waitForNoResources();
+    }
+
+    private void doHttp2ConnectionPingTest() {
+        try {
+            CompletableFuture<Void> shutdownComplete = null;
+            boolean actuallyConnected = false;
+            URI uri = new URI(HOST);
+
+            try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
+                shutdownComplete = connPool.getShutdownCompleteFuture();
+                try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
+                        TimeUnit.SECONDS);) {
+                    actuallyConnected = true;
+                    Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
+                    long time = conn.sendPing("12345678".getBytes()).get(5, TimeUnit.SECONDS);
+                    Assert.assertNotNull(time);
+                    time = conn.sendPing(null).get(5, TimeUnit.SECONDS);
+                    Assert.assertNotNull(time);
+                }
             }
+
+            Assert.assertTrue(actuallyConnected);
+
+            shutdownComplete.get(60, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
-        Assert.assertTrue(actuallyConnected);
-
-        shutdownComplete.get(60, TimeUnit.SECONDS);
-
-        CrtResource.waitForNoResources();
     }
 
     @Test
@@ -121,30 +166,43 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        CompletableFuture<Void> shutdownComplete = null;
-        boolean actuallyConnected = false;
-        URI uri = new URI(HOST);
+        doRetryableTest(() -> { this.doHttp2ConnectionPingTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
 
-        try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
-            shutdownComplete = connPool.getShutdownCompleteFuture();
-            try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
-                    TimeUnit.SECONDS);) {
-                actuallyConnected = true;
-                Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
-                long time = conn.sendPing("12345678".getBytes()).get(5, TimeUnit.SECONDS);
-                Assert.assertNotNull(time);
-                time = conn.sendPing(null).get(5, TimeUnit.SECONDS);
-                Assert.assertNotNull(time);
+        CrtResource.waitForNoResources();
+    }
+
+    private void doHttp2ConnectionPingExceptionPingDataLengthTest() {
+        try {
+            CompletableFuture<Void> shutdownComplete = null;
+            boolean exception = false;
+            URI uri = new URI(HOST);
+
+            try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
+                shutdownComplete = connPool.getShutdownCompleteFuture();
+                try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
+                        TimeUnit.SECONDS);) {
+                    Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
+                    long time = conn.sendPing("123".getBytes()).get(5, TimeUnit.SECONDS);
+                    Assert.assertNotNull(time);
+                }
+            } catch (ExecutionException e) {
+                try {
+                    throw e.getCause();
+                } catch (CrtRuntimeException causeException) {
+                    exception = true;
+                    Assert.assertEquals(causeException.errorName, "AWS_ERROR_INVALID_ARGUMENT");
+                } catch (Throwable throwable) {
+                    /* Unexpected exception */
+                    throwable.printStackTrace();
+                }
             }
+
+            Assert.assertTrue(exception);
+
+            shutdownComplete.get(60, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
-        Assert.assertTrue(actuallyConnected);
-
-        shutdownComplete.get(60, TimeUnit.SECONDS);
-
-        CrtResource.waitForNoResources();
     }
 
     @Test
@@ -152,35 +210,33 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        CompletableFuture<Void> shutdownComplete = null;
-        boolean exception = false;
-        URI uri = new URI(HOST);
-
-        try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
-            shutdownComplete = connPool.getShutdownCompleteFuture();
-            try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
-                    TimeUnit.SECONDS);) {
-                Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
-                long time = conn.sendPing("123".getBytes()).get(5, TimeUnit.SECONDS);
-                Assert.assertNotNull(time);
-            }
-        } catch (ExecutionException e) {
-            try {
-                throw e.getCause();
-            } catch (CrtRuntimeException causeException) {
-                exception = true;
-                Assert.assertEquals(causeException.errorName, "AWS_ERROR_INVALID_ARGUMENT");
-            } catch (Throwable throwable) {
-                /* Unexpected exception */
-                throwable.printStackTrace();
-            }
-        }
-
-        Assert.assertTrue(exception);
-
-        shutdownComplete.get(60, TimeUnit.SECONDS);
+        doRetryableTest(() -> { this.doHttp2ConnectionPingExceptionPingDataLengthTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
+    }
+
+    private void doHttp2ConnectionSendGoAwayTest() {
+        try {
+            CompletableFuture<Void> shutdownComplete = null;
+            boolean actuallyConnected = false;
+            URI uri = new URI(HOST);
+
+            try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
+                shutdownComplete = connPool.getShutdownCompleteFuture();
+                try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
+                        TimeUnit.SECONDS);) {
+                    actuallyConnected = true;
+                    Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
+                    conn.sendGoAway(Http2ErrorCode.INTERNAL_ERROR, false, null);
+                }
+            }
+
+            Assert.assertTrue(actuallyConnected);
+
+            shutdownComplete.get(60, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
@@ -192,27 +248,33 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
          */
         skipIfNetworkUnavailable();
 
-        CompletableFuture<Void> shutdownComplete = null;
-        boolean actuallyConnected = false;
-        URI uri = new URI(HOST);
+        doRetryableTest(() -> { this.doHttp2ConnectionSendGoAwayTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
 
-        try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
-            shutdownComplete = connPool.getShutdownCompleteFuture();
-            try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
-                    TimeUnit.SECONDS);) {
-                actuallyConnected = true;
-                Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
-                conn.sendGoAway(Http2ErrorCode.INTERNAL_ERROR, false, null);
+        CrtResource.waitForNoResources();
+    }
+
+    private void doHttp2ConnectionUpdateConnectionWindowTest() {
+        try {
+            CompletableFuture<Void> shutdownComplete = null;
+            boolean actuallyConnected = false;
+            URI uri = new URI(HOST);
+
+            try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
+                shutdownComplete = connPool.getShutdownCompleteFuture();
+                try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
+                        TimeUnit.SECONDS);) {
+                    actuallyConnected = true;
+                    Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
+                    conn.updateConnectionWindow(100);
+                }
             }
+
+            Assert.assertTrue(actuallyConnected);
+
+            shutdownComplete.get(60, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
-        Assert.assertTrue(actuallyConnected);
-
-        shutdownComplete.get(60, TimeUnit.SECONDS);
-
-        CrtResource.waitForNoResources();
     }
 
     @Test
@@ -224,25 +286,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
          */
         skipIfNetworkUnavailable();
 
-        CompletableFuture<Void> shutdownComplete = null;
-        boolean actuallyConnected = false;
-        URI uri = new URI(HOST);
-
-        try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri, EXPECTED_VERSION)) {
-            shutdownComplete = connPool.getShutdownCompleteFuture();
-            try (Http2ClientConnection conn = (Http2ClientConnection) connPool.acquireConnection().get(60,
-                    TimeUnit.SECONDS);) {
-                actuallyConnected = true;
-                Assert.assertTrue(conn.getVersion() == EXPECTED_VERSION);
-                conn.updateConnectionWindow(100);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        Assert.assertTrue(actuallyConnected);
-
-        shutdownComplete.get(60, TimeUnit.SECONDS);
+        doRetryableTest(() -> { this.doHttp2ConnectionUpdateConnectionWindowTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2ClientConnectionTest.java
@@ -18,16 +18,15 @@ import software.amazon.awssdk.crt.CrtRuntimeException;
 import software.amazon.awssdk.crt.http.HttpVersion;
 import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.crt.http.Http2ConnectionSetting;
-import software.amazon.awssdk.crt.http.Http2ConnectionSettingListBuilder;
 import software.amazon.awssdk.crt.http.Http2ClientConnection;
 import software.amazon.awssdk.crt.http.HttpClientConnectionManager;
 import software.amazon.awssdk.crt.http.Http2ClientConnection.Http2ErrorCode;
 import software.amazon.awssdk.crt.CrtResource;
 
-import software.amazon.awssdk.crt.test.TestUtils;
-
 public class Http2ClientConnectionTest extends HttpClientTestFixture {
 
+    private final static int MAX_TEST_RETRIES = 5;
+    private final static int TEST_RETRY_SLEEP_MILLIS = 2000;
     private final static String HOST = "https://postman-echo.com";
     private final static HttpVersion EXPECTED_VERSION = HttpVersion.HTTP_2;
 
@@ -58,7 +57,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionGetVersionTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionGetVersionTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -96,7 +95,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -131,7 +130,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         /* empty settings is allowed to send */
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsEmptyTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateSettingsEmptyTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -168,7 +167,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionPingTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionPingTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -212,7 +211,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionPingExceptionPingDataLengthTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionPingExceptionPingDataLengthTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -250,7 +249,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
          */
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionSendGoAwayTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionSendGoAwayTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -288,7 +287,7 @@ public class Http2ClientConnectionTest extends HttpClientTestFixture {
          */
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateConnectionWindowTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ConnectionUpdateConnectionWindowTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -224,7 +224,7 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
          */
         skipIfNetworkUnavailable();
 
-        doRetryableTest(() -> { this.doHttp2ResetStreamTest(); }, (ex) -> { return isSocketTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doHttp2ResetStreamTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2RequestResponseTest.java
@@ -224,7 +224,7 @@ public class Http2RequestResponseTest extends HttpRequestResponseFixture {
          */
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttp2ResetStreamTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(this::doHttp2ResetStreamTest, TestUtils::isRetryableTimeout, 5, 2000);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpClientTestFixture.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpClientTestFixture.java
@@ -102,28 +102,4 @@ public class HttpClientTestFixture extends CrtTestFixture {
             CrtMemoryLeakDetector.leakCheck(NUM_ITERATIONS, fixedGrowth, fn);
         }
     }
-
-    protected void doRetryableTest(Runnable testFunction, Function<Exception, Boolean> shouldRetryPredicate, int maxAttempts, int sleepTimeMillis) throws Exception {
-        int attempt = 0;
-        while (attempt < maxAttempts) {
-            ++attempt;
-
-            try {
-                testFunction.run();
-                return;
-            } catch (Exception ex) {
-                if (!shouldRetryPredicate.apply(ex)) {
-                    throw ex;
-                }
-            }
-
-            Thread.sleep(sleepTimeMillis);
-        }
-
-        throw new Exception("Retryable test exceeded the maximum allowed attempts without succeeding");
-    }
-
-    static protected Boolean isSocketTimeout(Exception ex) {
-        return ex.toString().contains("socket operation timed out");
-    }
 }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -314,7 +314,7 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        TestUtils.doRetryableTest(() -> { this.doHttpRequestUnActivatedTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doHttpRequestUnActivatedTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpRequestResponseTest.java
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 
 public class HttpRequestResponseTest extends HttpRequestResponseFixture {
     private final static String HOST = "https://postman-echo.com";
+    private final int MAX_TEST_RETRIES = 5;
+    private final int TEST_RETRY_SLEEP_MILLIS = 2000;
 
     public TestHttpResponse testRequest(String method, String endpoint, String path, String requestBody,
             boolean useChunkedEncoding, int expectedStatus) throws Exception {
@@ -257,56 +259,62 @@ public class HttpRequestResponseTest extends HttpRequestResponseFixture {
         testHttpUpload(true);
     }
 
+    private void doHttpRequestUnActivatedTest() {
+        try {
+            URI uri = new URI(HOST);
+
+            HttpHeader[] requestHeaders = new HttpHeader[]{new HttpHeader("Host", uri.getHost())};
+
+            HttpRequest request = new HttpRequest("GET", "/get", requestHeaders, null);
+
+            CompletableFuture<Void> shutdownComplete = null;
+            try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri,
+                    HttpVersion.HTTP_1_1)) {
+                shutdownComplete = connPool.getShutdownCompleteFuture();
+                try (HttpClientConnection conn = connPool.acquireConnection().get(60, TimeUnit.SECONDS)) {
+                    HttpStreamResponseHandler streamHandler = new HttpStreamResponseHandler() {
+                        @Override
+                        public void onResponseHeaders(HttpStream stream, int responseStatusCode, int blockType,
+                                                      HttpHeader[] nextHeaders) {
+                            // do nothing
+                        }
+
+                        @Override
+                        public void onResponseHeadersDone(HttpStream stream, int blockType) {
+                            // do nothing
+                        }
+
+                        @Override
+                        public int onResponseBody(HttpStream stream, byte[] bodyBytesIn) {
+                            // do nothing
+                            return bodyBytesIn.length;
+                        }
+
+                        @Override
+                        public void onResponseComplete(HttpStream stream, int errorCode) {
+                            // do nothing.
+                        }
+                    };
+
+                    HttpStream stream = conn.makeRequest(request, streamHandler);
+                    stream.close();
+                }
+            }
+
+            if (shutdownComplete != null) {
+                shutdownComplete.get();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     public void testHttpRequestUnActivated() throws Exception {
         skipIfAndroid();
         skipIfNetworkUnavailable();
 
-        URI uri = new URI(HOST);
-
-        HttpHeader[] requestHeaders = new HttpHeader[] { new HttpHeader("Host", uri.getHost()) };
-
-        HttpRequest request = new HttpRequest("GET", "/get", requestHeaders, null);
-
-        CompletableFuture<Void> shutdownComplete = null;
-        try (HttpClientConnectionManager connPool = createConnectionPoolManager(uri,
-                HttpVersion.HTTP_1_1)) {
-            shutdownComplete = connPool.getShutdownCompleteFuture();
-            try (HttpClientConnection conn = connPool.acquireConnection().get(60, TimeUnit.SECONDS)) {
-                HttpStreamResponseHandler streamHandler = new HttpStreamResponseHandler() {
-                    @Override
-                    public void onResponseHeaders(HttpStream stream, int responseStatusCode, int blockType,
-                            HttpHeader[] nextHeaders) {
-                        // do nothing
-                    }
-
-                    @Override
-                    public void onResponseHeadersDone(HttpStream stream, int blockType) {
-                        // do nothing
-                    }
-
-                    @Override
-                    public int onResponseBody(HttpStream stream, byte[] bodyBytesIn) {
-                        // do nothing
-                        return bodyBytesIn.length;
-                    }
-
-                    @Override
-                    public void onResponseComplete(HttpStream stream, int errorCode) {
-                        // do nothing.
-                    }
-                };
-
-                HttpStream stream = conn.makeRequest(request, streamHandler);
-                stream.close();
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        if (shutdownComplete != null) {
-            shutdownComplete.get();
-        }
+        TestUtils.doRetryableTest(() -> { this.doHttpRequestUnActivatedTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/IotServiceTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/IotServiceTest.java
@@ -8,8 +8,8 @@ package software.amazon.awssdk.crt.test;
 import org.junit.Assume;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
@@ -20,54 +20,59 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.*;
 
 public class IotServiceTest extends MqttClientConnectionFixture {
+    private final static int MAX_TEST_RETRIES = 3;
+    private final static int TEST_RETRY_SLEEP_MILLIS = 2000;
+
     public IotServiceTest() {
     }
 
     static final String TEST_TOPIC = "sdk/test/java/" + UUID.randomUUID().toString();
     int subsAcked = 0;
 
-    @Test
-    public void testIotService() {
-        skipIfNetworkUnavailable();
-        Assume.assumeTrue(AWS_TEST_MQTT311_IOT_CORE_HOST != null);
-        Assume.assumeTrue(AWS_TEST_MQTT311_IOT_CORE_RSA_CERT != null);
-        Assume.assumeTrue(AWS_TEST_MQTT311_IOT_CORE_RSA_KEY != null);
+    private void doIotServiceTest() {
         Consumer<MqttMessage> messageHandler = (message) -> {};
         int port = 8883;
 
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
                 AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);)
-            {
-                try (TlsContext context = new TlsContext(contextOptions);)
-                {
-                    connectDirectWithConfig(
-                        context,
-                        AWS_TEST_MQTT311_IOT_CORE_HOST,
-                        port,
-                        null,
-                        null,
-                        null);
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+            TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                    context,
+                    AWS_TEST_MQTT311_IOT_CORE_HOST,
+                    port,
+                    null,
+                    null,
+                    null);
 
-                    CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE, messageHandler);
-                    subscribed.thenApply(packetId -> subsAcked++);
-                    subscribed.get();
+            CompletableFuture<Integer> subscribed = connection.subscribe(TEST_TOPIC, QualityOfService.AT_LEAST_ONCE, messageHandler);
+            subscribed.thenApply(packetId -> subsAcked++);
+            subscribed.get();
 
-                    assertEquals("Single subscription", 1, subsAcked);
+            assertEquals("Single subscription", 1, subsAcked);
 
-                    CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC);
-                    unsubscribed.thenApply(packetId -> subsAcked--);
-                    unsubscribed.get();
+            CompletableFuture<Integer> unsubscribed = connection.unsubscribe(TEST_TOPIC);
+            unsubscribed.thenApply(packetId -> subsAcked--);
+            unsubscribed.get();
 
-                    assertEquals("No Subscriptions", 0, subsAcked);
-                    disconnect();
-                    close();
-                }
-                catch (Exception ex)
-                {
-                    fail(ex.getMessage());
-                }
+            assertEquals("No Subscriptions", 0, subsAcked);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
+    }
 
-            }
+    @Test
+    public void testIotService() throws Exception {
+        skipIfNetworkUnavailable();
+        Assume.assumeTrue(AWS_TEST_MQTT311_IOT_CORE_HOST != null);
+        Assume.assumeTrue(AWS_TEST_MQTT311_IOT_CORE_RSA_CERT != null);
+        Assume.assumeTrue(AWS_TEST_MQTT311_IOT_CORE_RSA_KEY != null);
+
+        TestUtils.doRetryableTest(this::doIotServiceTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -47,13 +47,14 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /* For environment variable setup, see SetupCrossCICrtEnvironment in the CRT builder */
 public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
+
+    private final int MAX_TEST_RETRIES = 3;
+    private final int TEST_RETRY_SLEEP_MILLIS = 3000;
 
     public Mqtt5ClientTest() {
     }
@@ -316,7 +317,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_DIRECT_MQTT_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -352,7 +353,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT5_BASIC_AUTH_USERNAME, AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -384,7 +385,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -414,7 +415,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -459,7 +460,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT,
             AWS_TEST_MQTT5_PROXY_HOST, AWS_TEST_MQTT5_PROXY_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC5Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_UC5Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -531,7 +532,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT5_BASIC_AUTH_USERNAME, AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC6Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_UC6Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -578,7 +579,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_WS_MQTT_HOST, AWS_TEST_MQTT5_WS_MQTT_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnWS_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -623,7 +624,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT5_BASIC_AUTH_USERNAME, AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnWS_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -668,7 +669,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_WS_MQTT_TLS_HOST, AWS_TEST_MQTT5_WS_MQTT_TLS_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnWS_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -721,7 +722,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_WS_MQTT_TLS_HOST, AWS_TEST_MQTT5_WS_MQTT_TLS_PORT,
             AWS_TEST_MQTT5_PROXY_HOST, AWS_TEST_MQTT5_PROXY_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC5Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnWS_UC5Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -800,7 +801,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT5_BASIC_AUTH_USERNAME, AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC6Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnWS_UC6Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1230,7 +1231,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doConnNegativeID_UC7Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnNegativeID_UC7Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1443,7 +1444,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
         disconnectBuilder.withSessionExpiryIntervalSeconds(-100L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC2Test(disconnectBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC2Test(disconnectBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1457,7 +1458,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
         disconnectBuilder.withSessionExpiryIntervalSeconds(9223372036854775807L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC2Test(disconnectBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC2Test(disconnectBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1505,7 +1506,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
         publishBuilder.withMessageExpiryIntervalSeconds(-100L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC3Test(publishBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC3Test(publishBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1519,7 +1520,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         PublishPacketBuilder publishBuilder = new PublishPacketBuilder("test/topic", QOS.AT_LEAST_ONCE, "Hello World".getBytes());
         publishBuilder.withMessageExpiryIntervalSeconds(9223372036854775807L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC3Test(publishBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC3Test(publishBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1565,7 +1566,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder("test/topic", QOS.AT_LEAST_ONCE);
         subscribeBuilder.withSubscriptionIdentifier(-100L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC4Test(subscribeBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC4Test(subscribeBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1579,7 +1580,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder("test/topic", QOS.AT_LEAST_ONCE);
         subscribeBuilder.withSubscriptionIdentifier(9223372036854775807L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC4Test(subscribeBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC4Test(subscribeBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1627,7 +1628,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doNegotiated_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNegotiated_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1683,7 +1684,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doNegotiated_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNegotiated_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1759,7 +1760,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doNegotiated_Rejoin_AlwaysTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doNegotiated_Rejoin_AlwaysTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1822,7 +1823,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doOp_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1884,7 +1885,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doOp_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1938,7 +1939,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doOp_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2007,7 +2008,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doOp_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2093,7 +2094,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_SharedSubscriptionTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doOp_SharedSubscriptionTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2141,7 +2142,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC1Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC1Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2153,7 +2154,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
         PublishPacket publish = new PublishPacketBuilder().build();
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC1Test(publish); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC1Test(publish); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2194,7 +2195,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC2Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC2Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2206,7 +2207,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
         SubscribePacket subscribe = new SubscribePacketBuilder().build();
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC2Test(subscribe); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC2Test(subscribe); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2248,7 +2249,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC3Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC3Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2260,7 +2261,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
         UnsubscribePacket unsubscribe = new UnsubscribePacketBuilder().build();
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC3Test(unsubscribe); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC3Test(unsubscribe); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2371,7 +2372,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doQoS1_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doQoS1_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2491,7 +2492,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doRetain_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doRetain_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2545,7 +2546,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doInterrupt_Sub_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doInterrupt_Sub_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2594,7 +2595,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doInterrupt_Unsub_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doInterrupt_Unsub_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2643,7 +2644,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doInterrupt_Publish_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doInterrupt_Publish_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2720,7 +2721,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOperationStatistics_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doOperationStatistics_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2769,7 +2770,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FILE, AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_PASSWORD,
             AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_ALIAS, AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2802,7 +2803,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY,
             AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2835,7 +2836,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS,
             AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2878,7 +2879,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_IOT_CORE_PKCS11_TOKEN_LABEL, AWS_TEST_MQTT5_IOT_CORE_PKCS11_PIN,
             AWS_TEST_MQTT5_IOT_CORE_PKCS11_PKEY_LABEL, AWS_TEST_MQTT5_IOT_CORE_PKCS11_CERT_FILE);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2942,7 +2943,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
 
                 return credentialsBuilder.build();
             }
-        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2961,7 +2962,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
 
                 return credentialsBuilder.build();
             }
-        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2989,7 +2990,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                         return credentialsBuilder.build();
                     }
                 }
-        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -3019,7 +3020,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                         return credentialsBuilder.build();
                     }
                 }
-        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 5, 2000);
+        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -317,7 +317,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_DIRECT_MQTT_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -353,7 +353,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT5_BASIC_AUTH_USERNAME, AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_UC2Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -385,7 +385,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_UC3Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -415,7 +415,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_UC4Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -460,7 +460,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_DIRECT_MQTT_TLS_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_TLS_PORT,
             AWS_TEST_MQTT5_PROXY_HOST, AWS_TEST_MQTT5_PROXY_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC5Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_UC5Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -532,7 +532,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT5_BASIC_AUTH_USERNAME, AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_UC6Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_UC6Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -579,7 +579,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_WS_MQTT_HOST, AWS_TEST_MQTT5_WS_MQTT_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnWS_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -624,7 +624,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT5_BASIC_AUTH_USERNAME, AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnWS_UC2Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -669,7 +669,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_WS_MQTT_TLS_HOST, AWS_TEST_MQTT5_WS_MQTT_TLS_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnWS_UC3Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -722,7 +722,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_WS_MQTT_TLS_HOST, AWS_TEST_MQTT5_WS_MQTT_TLS_PORT,
             AWS_TEST_MQTT5_PROXY_HOST, AWS_TEST_MQTT5_PROXY_PORT);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC5Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnWS_UC5Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -801,7 +801,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT5_WS_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT5_BASIC_AUTH_USERNAME, AWS_TEST_MQTT5_BASIC_AUTH_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnWS_UC6Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnWS_UC6Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1231,7 +1231,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doConnNegativeID_UC7Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnNegativeID_UC7Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1444,7 +1444,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
         disconnectBuilder.withSessionExpiryIntervalSeconds(-100L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC2Test(disconnectBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC2Test(disconnectBuilder); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1458,7 +1458,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         DisconnectPacketBuilder disconnectBuilder = new DisconnectPacketBuilder();
         disconnectBuilder.withSessionExpiryIntervalSeconds(9223372036854775807L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC2Test(disconnectBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC2Test(disconnectBuilder); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1506,7 +1506,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         publishBuilder.withPayload("Hello World".getBytes()).withTopic("test/topic");
         publishBuilder.withMessageExpiryIntervalSeconds(-100L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC3Test(publishBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC3Test(publishBuilder); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1520,7 +1520,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         PublishPacketBuilder publishBuilder = new PublishPacketBuilder("test/topic", QOS.AT_LEAST_ONCE, "Hello World".getBytes());
         publishBuilder.withMessageExpiryIntervalSeconds(9223372036854775807L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC3Test(publishBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC3Test(publishBuilder); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1566,7 +1566,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder("test/topic", QOS.AT_LEAST_ONCE);
         subscribeBuilder.withSubscriptionIdentifier(-100L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC4Test(subscribeBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC4Test(subscribeBuilder); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1580,7 +1580,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         SubscribePacketBuilder subscribeBuilder = new SubscribePacketBuilder("test/topic", QOS.AT_LEAST_ONCE);
         subscribeBuilder.withSubscriptionIdentifier(9223372036854775807L);
 
-        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC4Test(subscribeBuilder); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doNewNegative_UC4Test(subscribeBuilder); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1628,7 +1628,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doNegotiated_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doNegotiated_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1684,7 +1684,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doNegotiated_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doNegotiated_UC2Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1760,7 +1760,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doNegotiated_Rejoin_AlwaysTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doNegotiated_Rejoin_AlwaysTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1823,7 +1823,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doOp_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1885,7 +1885,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doOp_UC2Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -1939,7 +1939,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doOp_UC3Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2008,7 +2008,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doOp_UC4Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2094,7 +2094,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOp_SharedSubscriptionTest(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doOp_SharedSubscriptionTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2142,7 +2142,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC1Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC1Test(null); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2154,7 +2154,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
         PublishPacket publish = new PublishPacketBuilder().build();
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC1Test(publish); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC1Test(publish); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2195,7 +2195,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC2Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC2Test(null); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2207,7 +2207,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
         SubscribePacket subscribe = new SubscribePacketBuilder().build();
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC2Test(subscribe); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC2Test(subscribe); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2249,7 +2249,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC3Test(null); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC3Test(null); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2261,7 +2261,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
         UnsubscribePacket unsubscribe = new UnsubscribePacketBuilder().build();
-        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC3Test(unsubscribe); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(() -> { this.doErrorOp_UC3Test(unsubscribe); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2372,7 +2372,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doQoS1_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doQoS1_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2492,7 +2492,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doRetain_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doRetain_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2546,7 +2546,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doInterrupt_Sub_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doInterrupt_Sub_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2595,7 +2595,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doInterrupt_Unsub_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doInterrupt_Unsub_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2644,7 +2644,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doInterrupt_Publish_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doInterrupt_Publish_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2721,7 +2721,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_RSA_CERT, AWS_TEST_MQTT5_IOT_CORE_RSA_KEY);
 
-        TestUtils.doRetryableTest(() -> { this.doOperationStatistics_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doOperationStatistics_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2770,7 +2770,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_FILE, AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_PASSWORD,
             AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_ALIAS, AWS_TEST_MQTT5_IOT_CORE_KEYSTORE_CERT_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_Cred_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2803,7 +2803,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY,
             AWS_TEST_MQTT5_IOT_CORE_PKCS12_KEY_PASSWORD);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC2Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_Cred_UC2Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2836,7 +2836,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_IOT_CORE_HOST, AWS_TEST_MQTT5_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS,
             AWS_TEST_MQTT5_IOT_CORE_WINDOWS_CERT_STORE);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC3Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_Cred_UC3Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2879,7 +2879,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             AWS_TEST_MQTT5_IOT_CORE_PKCS11_TOKEN_LABEL, AWS_TEST_MQTT5_IOT_CORE_PKCS11_PIN,
             AWS_TEST_MQTT5_IOT_CORE_PKCS11_PKEY_LABEL, AWS_TEST_MQTT5_IOT_CORE_PKCS11_CERT_FILE);
 
-        TestUtils.doRetryableTest(() -> { this.doConnDC_Cred_UC4Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        TestUtils.doRetryableTest(this::doConnDC_Cred_UC4Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2943,7 +2943,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
 
                 return credentialsBuilder.build();
             }
-        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        ); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2962,7 +2962,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
 
                 return credentialsBuilder.build();
             }
-        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        ); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -2990,7 +2990,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                         return credentialsBuilder.build();
                     }
                 }
-        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        ); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }
@@ -3020,7 +3020,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                         return credentialsBuilder.build();
                     }
                 }
-        ); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+        ); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
 
         CrtResource.waitForNoResources();
     }

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -2069,6 +2069,8 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                 subscriberOneClient.subscribe(subscribePacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
                 subscriberTwoClient.subscribe(subscribePacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
 
+                Thread.sleep(4000);
+                
                 for (int i = 0; i < messageCount; ++i) {
                     publishPacketBuilder.withPayload(String.valueOf(i).getBytes());
                     publisherClient.publish(publishPacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -282,17 +282,13 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
      * ============================================================
      */
 
-    /* Happy path. Direct connection with minimal configuration */
-    @Test
-    public void ConnDC_UC1() {
-        skipIfNetworkUnavailable();
-        Assume.assumeNotNull(AWS_TEST_MQTT5_DIRECT_MQTT_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_PORT);
+    private void doConnDC_UC1Test() {
         try {
             LifecycleEvents_Futured events = new LifecycleEvents_Futured();
 
             Mqtt5ClientOptionsBuilder builder = new Mqtt5ClientOptionsBuilder(
-                AWS_TEST_MQTT5_DIRECT_MQTT_HOST,
-                Long.parseLong(AWS_TEST_MQTT5_DIRECT_MQTT_PORT));
+                    AWS_TEST_MQTT5_DIRECT_MQTT_HOST,
+                    Long.parseLong(AWS_TEST_MQTT5_DIRECT_MQTT_PORT));
             builder.withLifecycleEvents(events);
 
             try (Mqtt5Client client = new Mqtt5Client(builder.build())) {
@@ -302,8 +298,19 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             }
 
         } catch (Exception ex) {
-            fail(ex.getMessage());
+            throw new RuntimeException(ex);
         }
+    }
+
+    /* Happy path. Direct connection with minimal configuration */
+    @Test
+    public void ConnDC_UC1() throws Exception {
+        skipIfNetworkUnavailable();
+        Assume.assumeNotNull(AWS_TEST_MQTT5_DIRECT_MQTT_HOST, AWS_TEST_MQTT5_DIRECT_MQTT_PORT);
+
+        TestUtils.doRetryableTest(() -> { this.doConnDC_UC1Test(); }, (ex) -> { return TestUtils.isRetryableTimeout(ex); }, 4, 2000);
+
+        CrtResource.waitForNoResources();
     }
 
     /* Direct connection with basic authentication */

--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -2070,7 +2070,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                 subscriberTwoClient.subscribe(subscribePacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
 
                 Thread.sleep(4000);
-                
+
                 for (int i = 0; i < messageCount; ++i) {
                     publishPacketBuilder.withPayload(String.valueOf(i).getBytes());
                     publisherClient.publish(publishPacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionMethodTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionMethodTest.java
@@ -7,10 +7,9 @@ package software.amazon.awssdk.crt.test;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Assume;
 
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.auth.credentials.CredentialsProvider;
 import software.amazon.awssdk.crt.auth.credentials.CognitoCredentialsProvider.CognitoCredentialsProviderBuilder;
 import software.amazon.awssdk.crt.auth.credentials.DefaultChainCredentialsProvider.DefaultChainCredentialsProviderBuilder;
@@ -26,9 +25,14 @@ import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.crt.io.TlsContextPkcs11Options;
 
+import java.util.function.Function;
+
 
 /* For environment variable setup, see SetupCrossCICrtEnvironment in the CRT builder */
 public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture {
+    private final static int MAX_TEST_RETRIES = 3;
+    private final static int TEST_RETRY_SLEEP_MILLIS = 2000;
+
     public MqttClientConnectionMethodTest() {}
 
     /**
@@ -37,15 +41,7 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
      * ============================================================
      */
 
-    /* MQTT311 ConnDC_Cred_UC1 - MQTT311 connect with Java Keystore */
-    @Test
-    public void ConnDC_Cred_UC1()
-    {
-        skipIfNetworkUnavailable();
-        Assume.assumeNotNull(
-            AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT,
-            AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FILE, AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_PASSWORD,
-            AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS, AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD);
+    private void doConnDC_Cred_UC1Test() {
         try {
             java.security.KeyStore keyStore;
             keyStore = java.security.KeyStore.getInstance(AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT);
@@ -57,117 +53,142 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                     keyStore,
                     AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS,
                     AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD);
-                    TlsContext context = new TlsContext(contextOptions);)
-                {
-                    connectDirectWithConfig(
-                        context,
-                        AWS_TEST_MQTT311_IOT_CORE_HOST,
-                        8883,
-                        null,
-                        null,
-                        null);
-                    disconnect();
-                }
-                finally {
-                    close();
-                }
+                 TlsContext context = new TlsContext(contextOptions)) {
+                connectDirect(
+                    context,
+                    AWS_TEST_MQTT311_IOT_CORE_HOST,
+                    8883,
+                    null,
+                    null,
+                    null);
+                disconnect();
+            } finally {
+                close();
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
         }
-        catch (Exception ex)
-        {
-            ex.printStackTrace();
-            assertTrue("Exception ocurred running Java Keystore test!", ex == null);
+    }
+
+    /* MQTT311 ConnDC_Cred_UC1 - MQTT311 connect with Java Keystore */
+    @Test
+    public void ConnDC_Cred_UC1() throws Exception {
+        skipIfNetworkUnavailable();
+        Assume.assumeNotNull(
+            AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FORMAT,
+            AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_FILE, AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_PASSWORD,
+            AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_ALIAS, AWS_TEST_MQTT311_IOT_CORE_KEYSTORE_CERT_PASSWORD);
+
+        TestUtils.doRetryableTest(this::doConnDC_Cred_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnDC_Cred_UC2Test() {
+        try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsPkcs12(
+                AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY,
+                AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                    context,
+                    AWS_TEST_MQTT311_IOT_CORE_HOST,
+                    8883,
+                    null,
+                    null,
+                    null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
         }
     }
 
     /* MQTT311 ConnDC_Cred_UC2 - MQTT311 connect with PKCS12 Key */
     @Test
-    public void ConnDC_Cred_UC2()
-    {
+    public void ConnDC_Cred_UC2() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY,
             AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD);
-        try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsPkcs12(
-                AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY,
-                AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                disconnect();
-            }
-            finally {
-                close();
-            }
+
+        TestUtils.doRetryableTest(this::doConnDC_Cred_UC2Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnDC_Cred_UC3Test() {
+        try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsWindowsCertStorePath(
+                AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                context,
+                AWS_TEST_MQTT311_IOT_CORE_HOST,
+                8883,
+                null,
+                null,
+                null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
     }
 
     /* MQTT311 ConnDC_Cred_UC3 - MQTT311 connect with Windows Cert Store */
     @Test
-    public void ConnDC_Cred_UC3()
+    public void ConnDC_Cred_UC3() throws Exception
     {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_WINDOWS_PFX_CERT_NO_PASS,
             AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE);
-        try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsWindowsCertStorePath(
-            AWS_TEST_MQTT311_IOT_CORE_WINDOWS_CERT_STORE);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                disconnect();
-            }
-            finally {
-                close();
-            }
+
+        TestUtils.doRetryableTest(this::doConnDC_Cred_UC3Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
-    /* MQTT311 ConnDC_Cred_UC4 - MQTT311 connect with PKCS11 */
-    @Test
-    public void ConnDC_Cred_UC4()
-    {
-        skipIfNetworkUnavailable();
-        Assume.assumeNotNull(
-            AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_PKCS11_LIB,
-            AWS_TEST_MQTT311_IOT_CORE_PKCS11_TOKEN_LABEL, AWS_TEST_MQTT311_IOT_CORE_PKCS11_PIN,
-            AWS_TEST_MQTT311_IOT_CORE_PKCS11_PKEY_LABEL, AWS_TEST_MQTT311_IOT_CORE_PKCS11_CERT_FILE);
+    private void doConnDC_Cred_UC4Test() {
         // The published Softhsm package on muslc (Alpine) crashes if we don't call C_Finalize at the end.
-        try (
-            Pkcs11Lib pkcs11Lib = new Pkcs11Lib(AWS_TEST_MQTT311_IOT_CORE_PKCS11_LIB, Pkcs11Lib.InitializeFinalizeBehavior.STRICT);
-            TlsContextPkcs11Options pkcs11Options = new TlsContextPkcs11Options(pkcs11Lib);
-        )
-        {
+        try (Pkcs11Lib pkcs11Lib = new Pkcs11Lib(AWS_TEST_MQTT311_IOT_CORE_PKCS11_LIB, Pkcs11Lib.InitializeFinalizeBehavior.STRICT);
+            TlsContextPkcs11Options pkcs11Options = new TlsContextPkcs11Options(pkcs11Lib)) {
             pkcs11Options.withTokenLabel(AWS_TEST_MQTT311_IOT_CORE_PKCS11_TOKEN_LABEL);
             pkcs11Options.withUserPin(AWS_TEST_MQTT311_IOT_CORE_PKCS11_PIN);
             pkcs11Options.withPrivateKeyObjectLabel(AWS_TEST_MQTT311_IOT_CORE_PKCS11_PKEY_LABEL);
             pkcs11Options.withCertificateFilePath(AWS_TEST_MQTT311_IOT_CORE_PKCS11_CERT_FILE);
 
             try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsPkcs11(pkcs11Options);
-                    TlsContext context = new TlsContext(contextOptions);)
-                {
-                    connectDirectWithConfig(
-                        context,
-                        AWS_TEST_MQTT311_IOT_CORE_HOST,
-                        8883,
-                        null,
-                        null,
-                        null);
-                    disconnect();
-                }
-                finally {
-                    close();
-                }
+                 TlsContext context = new TlsContext(contextOptions)) {
+                connectDirect(
+                    context,
+                    AWS_TEST_MQTT311_IOT_CORE_HOST,
+                    8883,
+                    null,
+                    null,
+                    null);
+                disconnect();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            } finally {
+                close();
+            }
         }
+    }
+
+    /* MQTT311 ConnDC_Cred_UC4 - MQTT311 connect with PKCS11 */
+    @Test
+    public void ConnDC_Cred_UC4() throws Exception {
+        skipIfNetworkUnavailable();
+        Assume.assumeNotNull(
+            AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_PKCS11_LIB,
+            AWS_TEST_MQTT311_IOT_CORE_PKCS11_TOKEN_LABEL, AWS_TEST_MQTT311_IOT_CORE_PKCS11_PIN,
+            AWS_TEST_MQTT311_IOT_CORE_PKCS11_PKEY_LABEL, AWS_TEST_MQTT311_IOT_CORE_PKCS11_CERT_FILE);
+
+        TestUtils.doRetryableTest(this::doConnDC_Cred_UC4Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
     /**
@@ -176,120 +197,120 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
      * ============================================================
      */
 
+    private void doWebsocketIotCoreConnectionTest(Function<ClientBootstrap, CredentialsProvider> providerBuilder) {
+        try (EventLoopGroup elg = new EventLoopGroup(1);
+             HostResolver hr = new HostResolver(elg);
+             ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
+             TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
+             TlsContext tlsContext = new TlsContext(tlsOptions);
+             CredentialsProvider provider = providerBuilder.apply(bootstrap)) {
+
+            connectWebsockets(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
+    }
+
     /* MQTT311 ConnWS_Cred_UC1 - static credentials connect */
     @Test
-    public void ConnWS_Cred_UC1()
-    {
+    public void ConnWS_Cred_UC1() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY,
             AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY, AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN);
 
-        StaticCredentialsProviderBuilder builder = new StaticCredentialsProviderBuilder();
-        builder.withAccessKeyId(AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY.getBytes());
-        builder.withSecretAccessKey(AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY.getBytes());
-        builder.withSessionToken(AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN.getBytes());
+        TestUtils.doRetryableTest(() -> {
+            this.doWebsocketIotCoreConnectionTest(
+                (bootstrap) -> {
+                    StaticCredentialsProviderBuilder builder = new StaticCredentialsProviderBuilder();
+                    builder.withAccessKeyId(AWS_TEST_MQTT311_ROLE_CREDENTIAL_ACCESS_KEY.getBytes());
+                    builder.withSecretAccessKey(AWS_TEST_MQTT311_ROLE_CREDENTIAL_SECRET_ACCESS_KEY.getBytes());
+                    builder.withSessionToken(AWS_TEST_MQTT311_ROLE_CREDENTIAL_SESSION_TOKEN.getBytes());
 
-        try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
-            TlsContext tlsContext = new TlsContext(tlsOptions);
-            CredentialsProvider provider = builder.build();) {
-            connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
-            disconnect();
-        }
-        finally {
-            close();
-        }
+                    return builder.build();
+                }
+        ); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
     /* MQTT311 ConnWS_Cred_UC2 - default credentials connect */
     @Test
-    public void ConnWS_Cred_UC2()
-    {
+    public void ConnWS_Cred_UC2() throws Exception {
         skipIfAndroid(); // Credential Provider support not yet added for Android
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT311_IOT_CORE_HOST);
-        try (EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);)
-        {
-            DefaultChainCredentialsProviderBuilder builder = new DefaultChainCredentialsProviderBuilder();
-            builder.withClientBootstrap(bootstrap);
-            try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
-                TlsContext tlsContext = new TlsContext(tlsOptions);
-                CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
-                disconnect();
-            }
-            finally {
-                close();
-            }
-        }
+
+        TestUtils.doRetryableTest(() -> {
+            this.doWebsocketIotCoreConnectionTest(
+                (bootstrap) -> {
+                    DefaultChainCredentialsProviderBuilder builder = new DefaultChainCredentialsProviderBuilder();
+                    builder.withClientBootstrap(bootstrap);
+
+                    return builder.build();
+                }
+        ); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
     /**
      * MQTT311 ConnWS_Cred_UC3 - Cognito Identity credentials connect
      */
     @Test
-    public void ConnWS_Cred_UC3()
-    {
+    public void ConnWS_Cred_UC3() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_COGNITO_ENDPOINT, AWS_TEST_MQTT311_COGNITO_IDENTITY);
-        try (EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            TlsContextOptions contextOptions = TlsContextOptions.createDefaultClient();
-            TlsContext context = new TlsContext(contextOptions);)
-        {
-            CognitoCredentialsProviderBuilder builder = new CognitoCredentialsProviderBuilder();
-            builder.withClientBootstrap(bootstrap);
-            builder.withTlsContext(context);
-            builder.withEndpoint(AWS_TEST_MQTT311_COGNITO_ENDPOINT);
-            builder.withIdentity(AWS_TEST_MQTT311_COGNITO_IDENTITY);
-            try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
-                TlsContext tlsContext = new TlsContext(tlsOptions);
-                CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
-                disconnect();
-            }
-            finally {
-                close();
-            }
-        }
+
+        TestUtils.doRetryableTest(() -> { this.doWebsocketIotCoreConnectionTest(
+                (bootstrap) -> {
+                    try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
+                         TlsContext tlsContext = new TlsContext(tlsOptions)) {
+                        CognitoCredentialsProviderBuilder credentialsBuilder = new CognitoCredentialsProviderBuilder();
+                        credentialsBuilder.withClientBootstrap(bootstrap);
+                        credentialsBuilder.withTlsContext(tlsContext);
+                        credentialsBuilder.withEndpoint(AWS_TEST_MQTT311_COGNITO_ENDPOINT);
+                        credentialsBuilder.withIdentity(AWS_TEST_MQTT311_COGNITO_IDENTITY);
+
+                        return credentialsBuilder.build();
+                    }
+                }
+        ); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
     /* MQTT311 ConnWS_Cred_UC4 - X509 credentials connect */
     @Test
-    public void ConnWS_Cred_UC4()
-    {
+    public void ConnWS_Cred_UC4() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_X509_CERT,
             AWS_TEST_MQTT311_IOT_CORE_X509_KEY, AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT,
             AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS, AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME);
-        try (EventLoopGroup elg = new EventLoopGroup(1);
-            HostResolver hr = new HostResolver(elg);
-            ClientBootstrap bootstrap = new ClientBootstrap(elg, hr);
-            TlsContextOptions x509TlsOptions = TlsContextOptions.createWithMtlsFromPath(
-                AWS_TEST_MQTT311_IOT_CORE_X509_CERT,
-                AWS_TEST_MQTT311_IOT_CORE_X509_KEY);
-            TlsContext x509TlsContext = new TlsContext(x509TlsOptions);)
-        {
-            X509CredentialsProviderBuilder builder = new X509CredentialsProviderBuilder();
-            builder.withTlsContext(x509TlsContext);
-            builder.withEndpoint(AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT);
-            builder.withRoleAlias(AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS);
-            builder.withThingName(AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME);
 
-            try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient();
-                TlsContext tlsContext = new TlsContext(tlsOptions);
-                CredentialsProvider provider = builder.build();) {
-                connectWebsocketsWithCredentialsProvider(provider, AWS_TEST_MQTT311_IOT_CORE_HOST, 443, tlsContext, null, null, null);
-                disconnect();
-            }
-            finally {
-                close();
-            }
-        }
+        TestUtils.doRetryableTest(() -> {
+            this.doWebsocketIotCoreConnectionTest(
+                (bootstrap) -> {
+                    try (TlsContextOptions x509ContextOptions = TlsContextOptions.createWithMtlsFromPath(
+                            AWS_TEST_MQTT311_IOT_CORE_X509_CERT, AWS_TEST_MQTT311_IOT_CORE_X509_KEY);
+                         TlsContext x509Context = new TlsContext(x509ContextOptions)) {
+                        X509CredentialsProviderBuilder credentialsBuilder = new X509CredentialsProviderBuilder();
+                        credentialsBuilder.withClientBootstrap(bootstrap);
+                        credentialsBuilder.withTlsContext(x509Context);
+                        credentialsBuilder.withEndpoint(AWS_TEST_MQTT311_IOT_CORE_X509_ENDPOINT);
+                        credentialsBuilder.withRoleAlias(AWS_TEST_MQTT311_IOT_CORE_X509_ROLE_ALIAS);
+                        credentialsBuilder.withThingName(AWS_TEST_MQTT311_IOT_CORE_X509_THING_NAME);
+
+                        return credentialsBuilder.build();
+                    }
+                }
+        ); }, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
     /**
@@ -298,135 +319,175 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
      * ============================================================
      */
 
+    private void doConnDC_UC1Test() {
+        try {
+            connectDirect(
+                null,
+                AWS_TEST_MQTT311_DIRECT_MQTT_HOST,
+                Integer.parseInt(AWS_TEST_MQTT311_DIRECT_MQTT_PORT),
+                null,
+                null,
+                null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
+    }
+
     /* MQTT311 ConnDC_UC1 - MQTT311 connect without authentication */
     @Test
-    public void ConnDC_UC1()
-    {
+    public void ConnDC_UC1() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT311_DIRECT_MQTT_HOST, AWS_TEST_MQTT311_DIRECT_MQTT_PORT);
-        connectDirectWithConfig(
-            null,
-            AWS_TEST_MQTT311_DIRECT_MQTT_HOST,
-            Integer.parseInt(AWS_TEST_MQTT311_DIRECT_MQTT_PORT),
-            null,
-            null,
-            null);
-        disconnect();
-        close();
+
+        TestUtils.doRetryableTest(this::doConnDC_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnDC_UC2Test() {
+        try {
+            connectDirect(
+                null,
+                AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST,
+                Integer.parseInt(AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT),
+                AWS_TEST_MQTT311_BASIC_AUTH_USERNAME,
+                AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD,
+                null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
     }
 
     /* MQTT311 ConnDC_UC2 - MQTT311 connect with basic authentication */
     @Test
-    public void ConnDC_UC2()
-    {
+    public void ConnDC_UC2() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT311_BASIC_AUTH_USERNAME, AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD);
-        connectDirectWithConfig(
-            null,
-            AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_HOST,
-            Integer.parseInt(AWS_TEST_MQTT311_DIRECT_MQTT_BASIC_AUTH_PORT),
-            AWS_TEST_MQTT311_BASIC_AUTH_USERNAME,
-            AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD,
-            null);
-        disconnect();
-        close();
+
+        TestUtils.doRetryableTest(this::doConnDC_UC2Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnDC_UC3Test() {
+        try (TlsContextOptions contextOptions = TlsContextOptions.createDefaultClient()) {
+            contextOptions.verifyPeer = false;
+            try (TlsContext context = new TlsContext(contextOptions)) {
+                connectDirect(
+                    context,
+                    AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST,
+                    Integer.parseInt(AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT),
+                    null,
+                    null,
+                    null);
+                disconnect();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            } finally {
+                close();
+            }
+        }
     }
 
     /* MQTT311 ConnDC_UC3 - MQTT311 connect with TLS */
     @Test
-    public void ConnDC_UC3()
-    {
+    public void ConnDC_UC3() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST, AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT);
-        try (TlsContextOptions contextOptions = TlsContextOptions.createDefaultClient();)
-            {
-                contextOptions.verifyPeer = false;
-                try (TlsContext context = new TlsContext(contextOptions);)
-                {
-                    connectDirectWithConfig(
-                        context,
-                        AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST,
-                        Integer.parseInt(AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT),
-                        null,
-                        null,
-                        null);
-                    disconnect();
-                }
-                finally {
-                    close();
-                }
-            }
+
+        TestUtils.doRetryableTest(this::doConnDC_UC3Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
-    /* MQTT311 ConnDC_UC4 - MQTT311 connect with mTLS */
-    @Test
-    public void ConnDC_UC4()
-    {
-        skipIfNetworkUnavailable();
-        Assume.assumeNotNull(
-            AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+    private void doConnDC_UC4Test() {
         int port = 8883;
 
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
                 AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
                 AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);)
+        {
+            if (TlsContextOptions.isAlpnSupported()) {
+                contextOptions.withAlpnList("x-amzn-mqtt-ca");
+                port = TEST_PORT_ALPN;
+            }
+            try (TlsContext context = new TlsContext(contextOptions);)
             {
-                if (TlsContextOptions.isAlpnSupported()) {
-                    contextOptions.withAlpnList("x-amzn-mqtt-ca");
-                    port = TEST_PORT_ALPN;
-                }
-                try (TlsContext context = new TlsContext(contextOptions);)
-                {
-                    connectDirectWithConfig(
+                connectDirect(
                         context,
                         AWS_TEST_MQTT311_IOT_CORE_HOST,
                         port,
                         null,
                         null,
                         null);
-                    disconnect();
-                }
-                finally {
-                    close();
-                }
+                disconnect();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            } finally {
+                close();
             }
+        }
     }
 
-    /* MQTT311 ConnDC_UC5 - MQTT311 connect with proxy */
+    /* MQTT311 ConnDC_UC4 - MQTT311 connect with mTLS */
     @Test
-    public void ConnDC_UC5()
-    {
+    public void ConnDC_UC4() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
-            AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST, AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT,
-            AWS_TEST_MQTT311_PROXY_HOST, AWS_TEST_MQTT311_PROXY_PORT);
+            AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+
+        TestUtils.doRetryableTest(this::doConnDC_UC4Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnDC_UC5Test() {
         HttpProxyOptions proxyOptions = new HttpProxyOptions();
         proxyOptions.setHost(AWS_TEST_MQTT311_PROXY_HOST);
         proxyOptions.setPort(Integer.parseInt(AWS_TEST_MQTT311_PROXY_PORT));
         proxyOptions.setConnectionType(HttpProxyConnectionType.Tunneling);
 
         try (TlsContextOptions contextOptions = TlsContextOptions.createDefaultClient();)
+        {
+            contextOptions.verifyPeer = false;
+            try (TlsContext context = new TlsContext(contextOptions);)
             {
-                contextOptions.verifyPeer = false;
-                try (TlsContext context = new TlsContext(contextOptions);)
-                {
-                    connectDirectWithConfig(
+                connectDirect(
                         context,
                         AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST,
                         Integer.parseInt(AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT),
                         null,
                         null,
                         proxyOptions);
-                    disconnect();
-                }
-                finally {
-                    close();
-                }
+                disconnect();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            } finally {
+                close();
             }
+        }
+    }
 
+    /* MQTT311 ConnDC_UC5 - MQTT311 connect with proxy */
+    @Test
+    public void ConnDC_UC5() throws Exception {
+        skipIfNetworkUnavailable();
+        Assume.assumeNotNull(
+            AWS_TEST_MQTT311_DIRECT_MQTT_TLS_HOST, AWS_TEST_MQTT311_DIRECT_MQTT_TLS_PORT,
+            AWS_TEST_MQTT311_PROXY_HOST, AWS_TEST_MQTT311_PROXY_PORT);
+
+        TestUtils.doRetryableTest(this::doConnDC_UC5Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
     /**
@@ -435,56 +496,71 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
      * ============================================================
      */
 
+    private void doConnWS_UC1Test() {
+        try {
+            connectWebsockets(
+                null,
+                AWS_TEST_MQTT311_WS_MQTT_HOST,
+                Integer.parseInt(AWS_TEST_MQTT311_WS_MQTT_PORT),
+                null,
+                null,
+                null,
+                null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
+    }
+
     /* MQTT311 ConnWS_UC1 - MQTT311 websocket minimal connect */
     @Test
-    public void ConnWS_UC1()
-    {
+    public void ConnWS_UC1() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT311_WS_MQTT_HOST, AWS_TEST_MQTT311_WS_MQTT_PORT);
-        connectWebsocketsWithCredentialsProvider(
-            null,
-            AWS_TEST_MQTT311_WS_MQTT_HOST,
-            Integer.parseInt(AWS_TEST_MQTT311_WS_MQTT_PORT),
-            null,
-            null,
-            null,
-            null);
-        disconnect();
-        close();
+
+        TestUtils.doRetryableTest(this::doConnWS_UC1Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnWS_UC2Test() {
+        try {
+            connectWebsockets(
+                null,
+                AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST,
+                Integer.parseInt(AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT),
+                null,
+                AWS_TEST_MQTT311_BASIC_AUTH_USERNAME,
+                AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD,
+                null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
     }
 
     /* MQTT311 ConnWS_UC2 - MQTT311 with basic auth */
     @Test
-    public void ConnWS_UC2()
-    {
+    public void ConnWS_UC2() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST, AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT,
             AWS_TEST_MQTT311_BASIC_AUTH_USERNAME, AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD);
-        connectWebsocketsWithCredentialsProvider(
-            null,
-            AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_HOST,
-            Integer.parseInt(AWS_TEST_MQTT311_WS_MQTT_BASIC_AUTH_PORT),
-            null,
-            AWS_TEST_MQTT311_BASIC_AUTH_USERNAME,
-            AWS_TEST_MQTT311_BASIC_AUTH_PASSWORD,
-            null);
-        disconnect();
-        close();
+
+        TestUtils.doRetryableTest(this::doConnWS_UC2Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 
-    /* MQTT311 ConnWS_UC3 - MQTT311 with TLS */
-    @Test
-    public void ConnWS_UC3()
-    {
-        skipIfNetworkUnavailable();
-        Assume.assumeNotNull(
-            AWS_TEST_MQTT311_WS_MQTT_TLS_HOST, AWS_TEST_MQTT311_WS_MQTT_TLS_PORT);
+    private void doConnWS_UC3Test() {
         try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
             tlsOptions.withVerifyPeer(false);
-            try (TlsContext tlsContext = new TlsContext(tlsOptions);)
-            {
-                connectWebsocketsWithCredentialsProvider(
+            try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
+                connectWebsockets(
                     null,
                     AWS_TEST_MQTT311_WS_MQTT_TLS_HOST,
                     Integer.parseInt(AWS_TEST_MQTT311_WS_MQTT_TLS_PORT),
@@ -493,21 +569,27 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                     null,
                     null);
                 disconnect();
-            }
-            finally {
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            } finally {
                 close();
             }
         }
     }
 
-    /* MQTT311 ConnWS_UC4 - MQTT311 with proxy */
+    /* MQTT311 ConnWS_UC3 - MQTT311 with TLS */
     @Test
-    public void ConnWS_UC4()
-    {
+    public void ConnWS_UC3() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
-            AWS_TEST_MQTT311_WS_MQTT_TLS_HOST, AWS_TEST_MQTT311_WS_MQTT_TLS_PORT,
-            AWS_TEST_MQTT311_PROXY_HOST, AWS_TEST_MQTT311_PROXY_PORT);
+            AWS_TEST_MQTT311_WS_MQTT_TLS_HOST, AWS_TEST_MQTT311_WS_MQTT_TLS_PORT);
+
+        TestUtils.doRetryableTest(this::doConnWS_UC3Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnWS_UC4Test() {
         HttpProxyOptions proxyOptions = new HttpProxyOptions();
         proxyOptions.setHost(AWS_TEST_MQTT311_PROXY_HOST);
         proxyOptions.setPort(Integer.parseInt(AWS_TEST_MQTT311_PROXY_PORT));
@@ -515,9 +597,8 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
 
         try (TlsContextOptions tlsOptions = TlsContextOptions.createDefaultClient()) {
             tlsOptions.withVerifyPeer(false);
-            try (TlsContext tlsContext = new TlsContext(tlsOptions);)
-            {
-                connectWebsocketsWithCredentialsProvider(
+            try (TlsContext tlsContext = new TlsContext(tlsOptions)) {
+                connectWebsockets(
                     null,
                     AWS_TEST_MQTT311_WS_MQTT_TLS_HOST,
                     Integer.parseInt(AWS_TEST_MQTT311_WS_MQTT_TLS_PORT),
@@ -526,10 +607,24 @@ public class MqttClientConnectionMethodTest extends MqttClientConnectionFixture 
                     null,
                     proxyOptions);
                 disconnect();
-            }
-            finally {
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            } finally {
                 close();
             }
         }
+    }
+
+    /* MQTT311 ConnWS_UC4 - MQTT311 with proxy */
+    @Test
+    public void ConnWS_UC4() throws Exception {
+        skipIfNetworkUnavailable();
+        Assume.assumeNotNull(
+            AWS_TEST_MQTT311_WS_MQTT_TLS_HOST, AWS_TEST_MQTT311_WS_MQTT_TLS_PORT,
+            AWS_TEST_MQTT311_PROXY_HOST, AWS_TEST_MQTT311_PROXY_PORT);
+
+        TestUtils.doRetryableTest(this::doConnWS_UC4Test, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttClientConnectionTest.java
@@ -15,175 +15,214 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 
- import org.junit.Test;
  import software.amazon.awssdk.crt.mqtt.*;
 
 /* For environment variable setup, see SetupCrossCICrtEnvironment in the CRT builder */
 public class MqttClientConnectionTest extends MqttClientConnectionFixture {
+    private final static int MAX_TEST_RETRIES = 3;
+    private final static int TEST_RETRY_SLEEP_MILLIS = 2000;
+
     public MqttClientConnectionTest() {
     }
 
-    @Test
-    public void testConnectDisconnect() {
-        skipIfNetworkUnavailable();
-        Assume.assumeNotNull(
-            AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
+    private void doConnectDisconnectTest() {
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                disconnect();
-                close();
-            }
+                AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                context,
+                AWS_TEST_MQTT311_IOT_CORE_HOST,
+                8883,
+                null,
+                null,
+                null);
+            disconnect();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            close();
+        }
     }
 
     @Test
-    public void testConnectPublishWaitStatisticsDisconnect() {
+    public void testConnectDisconnect() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY,
             AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
+
+        TestUtils.doRetryableTest(this::doConnectDisconnectTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnectPublishWaitStatisticsDisconnectTest() {
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                try {
-                    publish(
-                        "test/topic/" + (UUID.randomUUID()).toString(),
-                        "hello_world".getBytes(),
-                        QualityOfService.AT_LEAST_ONCE).get(60, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    fail("Exception ocurred during publish: " + ex.getMessage());
-                }
-                checkOperationStatistics(0, 0);
-                disconnect();
-                close();
-            }
+                AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                context,
+                AWS_TEST_MQTT311_IOT_CORE_HOST,
+                8883,
+                null,
+                null,
+                null);
+
+            publish(
+                    "test/topic/" + (UUID.randomUUID()).toString(),
+                    "hello_world".getBytes(),
+                    QualityOfService.AT_LEAST_ONCE).get(60, TimeUnit.SECONDS);
+
+            checkOperationStatistics(0, 0);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
     }
 
     @Test
-    public void testConnectPublishStatisticsWaitDisconnect() {
+    public void testConnectPublishWaitStatisticsDisconnect() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY,
             AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
+
+        TestUtils.doRetryableTest(this::doConnectPublishWaitStatisticsDisconnectTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnectPublishStatisticsWaitDisconnectTest() {
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
+                AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                context,
+                AWS_TEST_MQTT311_IOT_CORE_HOST,
+                8883,
+                null,
+                null,
+                null);
 
-                String topic = "test/topic/" + (UUID.randomUUID()).toString();
-                byte[] payload = "Hello_World".getBytes();
-                // Per packet: (The size of the topic, the size of the payload, 2 for the header and 2 for the packet ID)
-                Long expectedSize = (topic.length() + payload.length + 4l);
+            String topic = "test/topic/" + (UUID.randomUUID()).toString();
+            byte[] payload = "Hello_World".getBytes();
+            // Per packet: (The size of the topic, the size of the payload, 2 for the header and 2 for the packet ID)
+            Long expectedSize = (topic.length() + payload.length + 4l);
 
-                CompletableFuture<Integer> puback = publish(topic, payload, QualityOfService.AT_LEAST_ONCE);
-                checkOperationStatistics(1, expectedSize);
+            CompletableFuture<Integer> publishComplete = publish(topic, payload, QualityOfService.AT_LEAST_ONCE);
+            checkOperationStatistics(1, expectedSize);
 
-                // Publish
-                try {
-                    puback.get(60, TimeUnit.SECONDS);
-                } catch (Exception ex) {
-                    fail("Exception ocurred during publish: " + ex.getMessage());
-                }
+            publishComplete.get(60, TimeUnit.SECONDS);
 
-                checkOperationStatistics(0, 0);
-                disconnect();
-                close();
-            }
+            checkOperationStatistics(0, 0);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
+    }
+
+    @Test
+    public void testConnectPublishStatisticsWaitDisconnect() throws Exception{
+        skipIfNetworkUnavailable();
+        Assume.assumeNotNull(
+            AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY,
+            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
+
+        TestUtils.doRetryableTest(this::doConnectPublishStatisticsWaitDisconnectTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
     // NOTE: In the future, we will want to test offline publishes, but right now the test fixtures forces a clean session
     // and making publishes while a clean session is set causes an error.
 
+    private void doECCKeyConnectDisconnectTest() {
+        try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
+                AWS_TEST_MQTT311_IOT_CORE_ECC_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_ECC_KEY);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                    context,
+                    AWS_TEST_MQTT311_IOT_CORE_HOST,
+                    8883,
+                    null,
+                    null,
+                    null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
+    }
+
     @Test
-    public void testECCKeyConnectDisconnect() {
+    public void testECCKeyConnectDisconnect() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_ECC_KEY,
             AWS_TEST_MQTT311_IOT_CORE_ECC_CERT);
+
+        TestUtils.doRetryableTest(this::doECCKeyConnectDisconnectTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doConnectDisconnectEventsHappyTest() {
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_ECC_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_ECC_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                disconnect();
-                close();
+                AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                context,
+                AWS_TEST_MQTT311_IOT_CORE_HOST,
+                8883,
+                null,
+                null,
+                null);
+
+            OnConnectionSuccessReturn connectionResult = waitForConnectSuccess();
+            assertTrue("Connection success callback was empty", connectionResult != null);
+            assertTrue("Session present was NOT false", !connectionResult.getSessionPresent());
+
+            disconnect();
+            try {
+                OnConnectionClosedReturn result = waitForConnectClose();
+                assertTrue("Connection close callback was empty", result != null);
+            } catch (Exception ex) {
+                fail(ex.toString());
             }
+
+            assertEquals("Unexpected onConnectionSuccess call: ", 1, connectionEventsStatistics.onConnectionSuccessCalled);
+            assertEquals("Unexpected onConnectionClosed call: ", 1, connectionEventsStatistics.onConnectionClosedCalled);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
     }
 
     @Test
-    public void testConnectDisconnectEventsHappy() {
+    public void testConnectDisconnectEventsHappy() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY,
             AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
-        try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                try {
-                    OnConnectionSuccessReturn result = waitForConnectSuccess();
-                    assertTrue("Connection success callback was empty", result != null);
-                    assertTrue("Session present was NOT false", result.getSessionPresent() == false);
-                } catch (Exception ex) {
-                    fail(ex.toString());
-                }
-                disconnect();
-                try {
-                    OnConnectionClosedReturn result = waitForConnectClose();
-                    assertTrue("Connection close callback was empty", result != null);
-                } catch (Exception ex) {
-                    fail(ex.toString());
-                }
-                close();
 
-                assertEquals("Unexpected onConnectionSuccess call: ", 1, connectionEventsStatistics.onConnectionSuccessCalled);
-                assertEquals("Unexpected onConnectionClosed call: ", 1, connectionEventsStatistics.onConnectionClosedCalled);
-            }
+        TestUtils.doRetryableTest(this::doConnectDisconnectEventsHappyTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
      }
 
      @Test
@@ -193,32 +232,33 @@ public class MqttClientConnectionTest extends MqttClientConnectionFixture {
             AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY,
             AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                try {
-                connectDirectWithConfigThrows(
+                AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+            TlsContext context = new TlsContext(contextOptions)) {
+            try {
+                connectDirect(
                     context,
                     AWS_TEST_MQTT311_IOT_CORE_HOST,
                     123,
                     null,
                     null,
                     null);
-                } catch (Exception ex) {
-                    // Do nothing with the exception - we expect this to throw since we passed an incorrect port.
-                }
-                try {
-                    OnConnectionFailureReturn result = waitForConnectFailure();
-                    assertTrue("Connection error callback was empty", result != null);
-                    assertTrue("Error code was success when it should not be", result.getErrorCode() != 0);
-                } catch (Exception ex) {
-                    fail(ex.toString());
-                }
-                close();
-
-                assertEquals("Unexpected onConnectionFailure call: ", 1, connectionEventsStatistics.onConnectionFailureCalled);
-                assertEquals("Unexpected onConnectionClosed call: ", 0, connectionEventsStatistics.onConnectionClosedCalled);
+            } catch (Exception ex) {
+                // Do nothing with the exception - we expect this to throw since we passed an incorrect port.
             }
+
+            try {
+                OnConnectionFailureReturn result = waitForConnectFailure();
+                assertTrue("Connection error callback was empty", result != null);
+                assertTrue("Error code was success when it should not be", result.getErrorCode() != 0);
+            } catch (Exception ex) {
+                fail(ex.toString());
+            }
+
+            assertEquals("Unexpected onConnectionFailure call: ", 1, connectionEventsStatistics.onConnectionFailureCalled);
+            assertEquals("Unexpected onConnectionClosed call: ", 0, connectionEventsStatistics.onConnectionClosedCalled);
+        } finally {
+            close();
+        }
      }
 };

--- a/src/test/java/software/amazon/awssdk/crt/test/TestUtils.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TestUtils.java
@@ -27,7 +27,7 @@ public class TestUtils {
             Thread.sleep(sleepTimeMillis);
         }
 
-        throw new Exception("Retryable MQTT test exceeded the maximum allowed attempts without succeeding");
+        throw new Exception("Retryable network test exceeded the maximum allowed attempts without succeeding");
     }
 
     static public Boolean isRetryableTimeout(Exception ex) {

--- a/src/test/java/software/amazon/awssdk/crt/test/TestUtils.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TestUtils.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.awssdk.crt.test;
+
+import java.lang.Runnable;
+import java.lang.Thread;
+import java.util.function.Function;
+
+public class TestUtils {
+    static public void doRetryableTest(Runnable testFunction, Function<Exception, Boolean> shouldRetryPredicate, int maxAttempts, int sleepTimeMillis) throws Exception {
+        int attempt = 0;
+        while (attempt < maxAttempts) {
+            ++attempt;
+
+            try {
+                testFunction.run();
+                return;
+            } catch (Exception ex) {
+                if (!shouldRetryPredicate.apply(ex)) {
+                    throw ex;
+                }
+            }
+
+            Thread.sleep(sleepTimeMillis);
+        }
+
+        throw new Exception("Retryable MQTT test exceeded the maximum allowed attempts without succeeding");
+    }
+
+    static public Boolean isRetryableTimeout(Exception ex) {
+        String exceptionMsg = ex.toString();
+        return exceptionMsg.contains("socket operation timed out") || exceptionMsg.contains("tls negotiation timeout");
+    }
+}

--- a/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/WillTest.java
@@ -13,6 +13,7 @@ import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
 
+import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
@@ -21,8 +22,10 @@ import software.amazon.awssdk.crt.mqtt.QualityOfService;
 
 /* For environment variable setup, see SetupCrossCICrtEnvironment in the CRT builder */
 public class WillTest extends MqttClientConnectionFixture {
-    @Rule
+    private final static int MAX_TEST_RETRIES = 3;
+    private final static int TEST_RETRY_SLEEP_MILLIS = 2000;
 
+    @Rule
     public Timeout testTimeout = Timeout.seconds(15);
 
     public WillTest() {
@@ -32,75 +35,103 @@ public class WillTest extends MqttClientConnectionFixture {
     static final String TEST_WILL = "i am ghost nao";
     static final String TEST_EMPTY_WILL = "";
 
-    @Test
-    public void testWill() {
-        skipIfNetworkUnavailable();
-        Assume.assumeNotNull(AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY, AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
+    private void doWillTest() {
         setConnectionConfigTransformer((config) -> {
             config.setWillMessage(new MqttMessage(TEST_TOPIC, TEST_WILL.getBytes(), QualityOfService.AT_LEAST_ONCE));
         });
+
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                disconnect();
-                close();
-            }
+                AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                context,
+                AWS_TEST_MQTT311_IOT_CORE_HOST,
+                8883,
+                null,
+                null,
+                null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
     }
 
     @Test
-    public void testEmptyWill() {
+    public void testWill() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY, AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
+
+        TestUtils.doRetryableTest(this::doWillTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doEmptyWillTest() {
         setConnectionConfigTransformer((config) -> {
             config.setWillMessage(new MqttMessage(TEST_TOPIC, TEST_EMPTY_WILL.getBytes(), QualityOfService.AT_LEAST_ONCE));
         });
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                disconnect();
-                close();
-            }
+                AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                context,
+                AWS_TEST_MQTT311_IOT_CORE_HOST,
+                8883,
+                null,
+                null,
+                null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
     }
 
     @Test
-    public void testNullWill() {
+    public void testEmptyWill() throws Exception {
         skipIfNetworkUnavailable();
         Assume.assumeNotNull(AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY, AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
+
+        TestUtils.doRetryableTest(this::doEmptyWillTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
+    }
+
+    private void doNullWillTest() {
         setConnectionConfigTransformer((config) -> {
             config.setWillMessage(new MqttMessage(TEST_TOPIC, null, QualityOfService.AT_LEAST_ONCE));
         });
         try (TlsContextOptions contextOptions = TlsContextOptions.createWithMtlsFromPath(
-            AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
-            AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
-                TlsContext context = new TlsContext(contextOptions);)
-            {
-                connectDirectWithConfig(
-                    context,
-                    AWS_TEST_MQTT311_IOT_CORE_HOST,
-                    8883,
-                    null,
-                    null,
-                    null);
-                disconnect();
-                close();
-            }
+                AWS_TEST_MQTT311_IOT_CORE_RSA_CERT,
+                AWS_TEST_MQTT311_IOT_CORE_RSA_KEY);
+             TlsContext context = new TlsContext(contextOptions)) {
+            connectDirect(
+                context,
+                AWS_TEST_MQTT311_IOT_CORE_HOST,
+                8883,
+                null,
+                null,
+                null);
+            disconnect();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            close();
+        }
+    }
+
+    @Test
+    public void testNullWill() throws Exception {
+        skipIfNetworkUnavailable();
+        Assume.assumeNotNull(AWS_TEST_MQTT311_IOT_CORE_HOST, AWS_TEST_MQTT311_IOT_CORE_RSA_KEY, AWS_TEST_MQTT311_IOT_CORE_RSA_CERT);
+
+        TestUtils.doRetryableTest(this::doNullWillTest, TestUtils::isRetryableTimeout, MAX_TEST_RETRIES, TEST_RETRY_SLEEP_MILLIS);
+
+        CrtResource.waitForNoResources();
     }
 };


### PR DESCRIPTION
* HTTP tests targeting the postman server now retry on socket or TLS timeouts
* MQTT (both 311 and 5) tests that require a successful connection retry on socket or TLS timeouts

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
