### PR TITLE
Sleep in tests for at least specified time

### DIFF
--- a/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Mqtt5ClientTest.java
@@ -1207,7 +1207,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                 clientOne.start();
                 eventsOne.connectedFuture.get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
 
-                Thread.sleep(2000); // Sleep for 2 seconds to not hit IoT Core limits
+                TestUtils.sleepForAtLeastMilliseconds(2000); // Sleep for 2 seconds to not hit IoT Core limits
 
                 clientTwo.start();
                 eventsTwo.connectedFuture.get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
@@ -1732,7 +1732,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
             }
 
             /* Avoid accidentally triggering re-connect throttle */
-            Thread.sleep(2000);
+            TestUtils.sleepForAtLeastMilliseconds(2000);
 
             builder.withSessionBehavior(ClientSessionBehavior.REJOIN_ALWAYS);
             LifecycleEvents_Futured rejoinEvents = new LifecycleEvents_Futured();
@@ -1990,7 +1990,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                 subscriber.subscribe(subscribePacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
 
                 // Paranoid about service-side eventual consistency.  Add a wait to reduce chances of a missed will publish.
-                Thread.sleep(2000);
+                TestUtils.sleepForAtLeastMilliseconds(2000);
 
                 publisher.stop(disconnectPacketBuilder.build());
 
@@ -2069,7 +2069,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                 subscriberOneClient.subscribe(subscribePacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
                 subscriberTwoClient.subscribe(subscribePacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
 
-                Thread.sleep(4000);
+                TestUtils.sleepForAtLeastMilliseconds(4000);
 
                 for (int i = 0; i < messageCount; ++i) {
                     publishPacketBuilder.withPayload(String.valueOf(i).getBytes());
@@ -2457,7 +2457,7 @@ public class Mqtt5ClientTest extends Mqtt5ClientTestFixture {
                 publisher.publish(publishPacketBuilder.build()).get(OPERATION_TIMEOUT_TIME, TimeUnit.SECONDS);
 
                 // Wait 15 seconds to give the server time to clear everything out
-                Thread.sleep(15000);
+                TestUtils.sleepForAtLeastMilliseconds(15000);
 
                 // Connect the unsuccessful subscriber
                 unsuccessfulSubscriber.start();

--- a/src/test/java/software/amazon/awssdk/crt/test/MqttRequestResponseClientTests.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/MqttRequestResponseClientTests.java
@@ -203,7 +203,7 @@ public class MqttRequestResponseClientTests extends CrtTestFixture {
                         }
 
                         try {
-                            Thread.sleep(RETRY_DELAY_MILLIS);
+                            TestUtils.sleepForAtLeastMilliseconds(RETRY_DELAY_MILLIS);
                         } catch (Exception e) {
                             ; // don't care
                         }

--- a/src/test/java/software/amazon/awssdk/crt/test/TestUtils.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/TestUtils.java
@@ -24,7 +24,7 @@ public class TestUtils {
                 }
             }
 
-            Thread.sleep(sleepTimeMillis);
+            sleepForAtLeastMilliseconds(sleepTimeMillis);
         }
 
         throw new Exception("Retryable network test exceeded the maximum allowed attempts without succeeding");
@@ -33,5 +33,17 @@ public class TestUtils {
     static public Boolean isRetryableTimeout(Exception ex) {
         String exceptionMsg = ex.toString();
         return exceptionMsg.contains("socket operation timed out") || exceptionMsg.contains("tls negotiation timeout");
+    }
+
+    static public void sleepForAtLeastMilliseconds(long sleepMilliseconds) throws InterruptedException {
+        long startTimeNanoseconds = System.nanoTime();
+        long sleepNanoseconds = sleepMilliseconds * 1_000_000L;
+        long remainingMilliseconds = sleepMilliseconds;
+
+        while (remainingMilliseconds > 0) {
+            Thread.sleep(remainingMilliseconds);
+            long elapsedNanoseconds = System.nanoTime() - startTimeNanoseconds;
+            remainingMilliseconds = (sleepNanoseconds - elapsedNanoseconds + 1) / 1_000_000L;
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Thread.sleep() currently used in tests to add delays can sometimes sleep for less than specified time.

*Description of changes:*

The tests require a minimum sleeping time, slightly longer is fine. So, add a utility function that sleeps at least a specified amount of time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
