### PR TITLE
CI Jobs fail-fast False

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
   linux-compat:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         image:
           - manylinux2014-x64
@@ -56,6 +57,7 @@ jobs:
   linux-compiler-compat:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         compiler:
           - clang-6
@@ -146,6 +148,7 @@ jobs:
   linux-musl-x64:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         image:
           - alpine-3.16-x64
@@ -163,6 +166,7 @@ jobs:
   linux-musl-arm:
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         image:
           - alpine-3.16-armv7
@@ -183,6 +187,7 @@ jobs:
   raspberry:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         image:
           - raspbian-bullseye
@@ -217,6 +222,7 @@ jobs:
   windows-vc17:
     runs-on: windows-2025 # latest
     strategy:
+      fail-fast: false
       matrix:
         arch: [x86, x64]
     steps:


### PR DESCRIPTION
Set fail-fast to false on all CI jobs using a matrix. This will allow us to better track what is failing and why.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
