### PR TITLE
Android 16 KB page sizes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        // AGP 8.5.1+ aligns uncompressed .so at 16KB automatically
+        // Requires JDK 17+
+        classpath 'com.android.tools.build:gradle:8.5.1'
     }
 }
 

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -43,8 +43,11 @@ ext {
 }
 
 android {
-    compileSdk 33
-    ndkVersion "21.4.7075529" // LTS version
+    namespace "software.amazon.awssdk.crt"
+
+    compileSdk 35
+    // Pin NDK r28+ (16KB alignment & removal of PAGE_SIZE macro are default)
+    ndkVersion "28.0.12433566"
 
     useLibrary 'android.test.runner'
     useLibrary 'android.test.base'
@@ -67,8 +70,27 @@ android {
 
         externalNativeBuild {
             cmake {
+                // If built on NDK r27 you need `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON`
                 arguments "-DBUILD_DEPS=ON"
             }
+        }
+    }
+
+    buildFeatures {
+        buildConfig true
+    }
+
+    // Make sure JNI libs are packaged UNCOMPRESSED (so AGP can align them)
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging false
+        }
+    }
+
+    publishing {
+        // Creates the 'release' SoftwareComponent used by maven-publish
+        singleVariant("release") {
+            withSourcesJar()
         }
     }
 
@@ -163,8 +185,10 @@ afterEvaluate {
 
         publications {
             release(MavenPublication) {
-                from components.release
-
+                def comp = components.findByName("release")
+                if (comp != null) {
+                    from comp
+                }
                 groupId = 'software.amazon.awssdk.crt'
                 artifactId = 'aws-crt-android'
                 version = project.hasProperty('newVersion') ? project.property('newVersion') : android.defaultConfig.versionName

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Oct 16 16:47:56 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/android/testapp/build.gradle
+++ b/src/test/android/testapp/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.2"
+        classpath "com.android.tools.build:gradle:8.5.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play must support 16 KB page sizes on 64-bit devices as outlined here: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

This PR follows guidelines outlined here: https://developer.android.com/guide/practices/page-sizes

The most significant changes are bumping the gradle wrapper  from 7.4.2 to 8.5.1 and the NDK from 21.4.7075529 to 28.0.12433566


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
