### PR TITLE
Android aarMetadata minCompileSdk 30

### DIFF
--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -74,11 +74,11 @@ android {
                 arguments "-DBUILD_DEPS=ON"
             }
         }
-    }
 
-    aarMetadata {
+        aarMetadata {
         // Keeps from referencing newer resources/manifest attributes introduced after 30
         minCompileSdk = 30
+        }
     }
 
     buildFeatures {

--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -76,6 +76,11 @@ android {
         }
     }
 
+    aarMetadata {
+        // Keeps from referencing newer resources/manifest attributes introduced after 30
+        minCompileSdk = 30
+    }
+
     buildFeatures {
         // AGP 8 disables buildConfig generation by default. We set this to true
         // to resstore BuildConfig.VERSION_NAME for both debug and release build types.


### PR DESCRIPTION
Set the aarMetadata minCompileSdk to 30 for the Android library. This allows the library to be used with a minimum Compile SDK of 30 despite the compileSdkVersion 35 being used to build with 16 KB page file support.

We currently do not use any 30+ elements so this doesn't change anything in our package but will allow downstream use of our library without needing them to bump up to our compileSdkVersion which is set to 35.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
