### PR TITLE
Do not require `coreLibraryDesugaring` on Android

### DIFF
--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -138,17 +138,12 @@ android {
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
-        // Enable desugaring so that Android lint doesn't flag `java.time` usage. Downstream
-        // consumers will need to enable desugaring to use this library.
-        // See: https://developer.android.com/studio/write/java8-support#library-desugaring
-        coreLibraryDesugaringEnabled true
     }
 }
 
 build.dependsOn preBuild
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     androidTestImplementation 'org.mockito:mockito-core:3.11.2'
     androidTestImplementation 'androidx.appcompat:appcompat:1.3.1'
     androidTestImplementation 'junit:junit:4.13.2'

--- a/src/test/android/testapp/build.gradle
+++ b/src/test/android/testapp/build.gradle
@@ -68,7 +68,6 @@ android {
     compileOptions {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
-        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
@@ -84,7 +83,6 @@ dependencies {
     implementation 'androidx.core:core:1.2.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
 
     testImplementation 'junit:junit:4.13'
 


### PR DESCRIPTION
The `java.time` package is only available natively on Android API 28+. Using it forces consuming apps to enable `coreLibraryDesugaring` to support older API levels.

This library currently uses `java.time.Instant` only to log the current date, which can be done easily using the old `java.util.Date`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
