### PR TITLE
Support s2n security policy for TLS 1.2 and FIPS

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsCipherPreference.java
@@ -64,7 +64,13 @@ public enum TlsCipherPreference {
     /**
      * The latest recommended Post-quantum enabled TLS Policy. This policy may change over time.
      */
-    TLS_CIPHER_PQ_DEFAULT(8);
+    TLS_CIPHER_PQ_DEFAULT(8),
+
+    /**
+     * This security policy is based on AWS-CRT-SDK-TLSv1.2-2023 s2n TLS policy, with tightened security.
+     * It is FIPS-complaint.
+     */
+    TLS_CIPHER_PREF_TLSv1_2_2025(9);
 
     private int val;
 


### PR DESCRIPTION
Support [s2n policy](https://github.com/aws/s2n-tls/pull/5375) for TLS 1.2 and FIPS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
