### PR TITLE
noCertificateRevocation option binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,27 +376,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    # GraalVM native-image requires MSVC but its built-in VS detection fails on newer
-    # runner images (e.g. windows-2025 with VS2026). We use vswhere to locate vcvarsall.bat
-    # and export the MSVC environment ourselves, which works regardless of VS version/path.
-    - name: Setup MSVC environment
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-        if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
-        $vsPath = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-        if (-not $vsPath) { throw "No VS installation with C++ tools found" }
-        $vcvarsall = Join-Path $vsPath "VC\Auxiliary\Build\vcvarsall.bat"
-        if (-not (Test-Path $vcvarsall)) { throw "vcvarsall.bat not found at $vcvarsall" }
-        cmd /c "`"$vcvarsall`" x64 && set" | ForEach-Object {
-          if ($_ -match '^([^=]+)=(.*)$') {
-            "$($matches[1])=$($matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append
-          }
-        }
-        Write-Host "MSVC environment configured from: $vsPath"
     - name: Setup GraalVM
-      uses: graalvm/setup-graalvm@v1
+      uses: graalvm/setup-graalvm@v1.5.5
       with:
         java-version: ${{ matrix.java-version }}
         distribution: 'graalvm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,25 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+    # GraalVM native-image requires MSVC but its built-in VS detection fails on newer
+    # runner images (e.g. windows-2025 with VS2026). We use vswhere to locate vcvarsall.bat
+    # and export the MSVC environment ourselves, which works regardless of VS version/path.
+    - name: Setup MSVC environment
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
+        $vsPath = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if (-not $vsPath) { throw "No VS installation with C++ tools found" }
+        $vcvarsall = Join-Path $vsPath "VC\Auxiliary\Build\vcvarsall.bat"
+        if (-not (Test-Path $vcvarsall)) { throw "vcvarsall.bat not found at $vcvarsall" }
+        cmd /c "`"$vcvarsall`" x64 && set" | ForEach-Object {
+          if ($_ -match '^([^=]+)=(.*)$') {
+            "$($matches[1])=$($matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append
+          }
+        }
+        Write-Host "MSVC environment configured from: $vsPath"
     - name: Setup GraalVM
       uses: graalvm/setup-graalvm@v1.5.5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,25 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+    # GraalVM native-image requires MSVC but its built-in VS detection fails on newer
+    # runner images (e.g. windows-2025 with VS2026). We use vswhere to locate vcvarsall.bat
+    # and export the MSVC environment ourselves, which works regardless of VS version/path.
+    - name: Setup MSVC environment
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
+        $vsPath = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if (-not $vsPath) { throw "No VS installation with C++ tools found" }
+        $vcvarsall = Join-Path $vsPath "VC\Auxiliary\Build\vcvarsall.bat"
+        if (-not (Test-Path $vcvarsall)) { throw "vcvarsall.bat not found at $vcvarsall" }
+        cmd /c "`"$vcvarsall`" x64 && set" | ForEach-Object {
+          if ($_ -match '^([^=]+)=(.*)$') {
+            "$($matches[1])=$($matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append
+          }
+        }
+        Write-Host "MSVC environment configured from: $vsPath"
     - name: Setup GraalVM
       uses: graalvm/setup-graalvm@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,25 +376,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    # GraalVM native-image requires MSVC but its built-in VS detection fails on newer
-    # runner images (e.g. windows-2025 with VS2026). We use vswhere to locate vcvarsall.bat
-    # and export the MSVC environment ourselves, which works regardless of VS version/path.
-    - name: Setup MSVC environment
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-        if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
-        $vsPath = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-        if (-not $vsPath) { throw "No VS installation with C++ tools found" }
-        $vcvarsall = Join-Path $vsPath "VC\Auxiliary\Build\vcvarsall.bat"
-        if (-not (Test-Path $vcvarsall)) { throw "vcvarsall.bat not found at $vcvarsall" }
-        cmd /c "`"$vcvarsall`" x64 && set" | ForEach-Object {
-          if ($_ -match '^([^=]+)=(.*)$') {
-            "$($matches[1])=$($matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append
-          }
-        }
-        Write-Host "MSVC environment configured from: $vsPath"
     - name: Setup GraalVM
       uses: graalvm/setup-graalvm@v1
       with:

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -97,7 +97,7 @@ public final class TlsContextOptions extends CrtResource {
      *
      * Default is false (revocation checking enabled).
      */
-    public boolean certificateRevocationCheckDisabled = false;
+    public boolean noCertificateRevocation = false;
 
     private String certificate;
     private String privateKey;
@@ -138,7 +138,7 @@ public final class TlsContextOptions extends CrtResource {
                 caFile,
                 caDir,
                 verifyPeer,
-                certificateRevocationCheckDisabled,
+                noCertificateRevocation,
                 pkcs12Path,
                 pkcs12Password,
                 pkcs11Options,
@@ -576,8 +576,8 @@ public final class TlsContextOptions extends CrtResource {
      *
      * @return this
      */
-    public TlsContextOptions withCertificateRevocationCheckDisabled() {
-        this.certificateRevocationCheckDisabled = true;
+    public TlsContextOptions withNoCertificateRevocation() {
+        this.noCertificateRevocation = true;
         return this;
     }
 
@@ -596,7 +596,7 @@ public final class TlsContextOptions extends CrtResource {
                 String caFile,
                 String caDir,
                 boolean verifyPeer,
-                boolean certificateRevocationCheckDisabled,
+                boolean noCertificateRevocation,
                 String pkcs12Path,
                 String pkcs12Password,
                 TlsContextPkcs11Options pkcs11Options,

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -80,6 +80,25 @@ public final class TlsContextOptions extends CrtResource {
      */
     public boolean verifyPeer = false;
 
+    /**
+     * Set whether or not certificate revocation checking is disabled during TLS negotiation.
+     *
+     * On Windows (SChannel), when enabled (the default), the TLS handshake will make outbound
+     * network calls to CRL/OCSP revocation endpoints. In environments without internet access
+     * (e.g., private subnets with only VPC endpoints), this can cause the handshake to block
+     * for minutes while waiting for network timeouts.
+     * 
+     * On Linux, when enabled (the defualt), the TLS handhake will check the server-stapled
+     * OCSP.
+     * 
+     * On Apple platforms, the revocation check is always skipped.
+     *
+     * Set this to true to skip revocation checking entirely.
+     *
+     * Default is false (revocation checking enabled).
+     */
+    public boolean certificateRevocationCheckDisabled = false;
+
     private String certificate;
     private String privateKey;
     private String certificatePath;
@@ -119,6 +138,7 @@ public final class TlsContextOptions extends CrtResource {
                 caFile,
                 caDir,
                 verifyPeer,
+                certificateRevocationCheckDisabled,
                 pkcs12Path,
                 pkcs12Password,
                 pkcs11Options,
@@ -551,6 +571,16 @@ public final class TlsContextOptions extends CrtResource {
         return this.withVerifyPeer(true);
     }
 
+    /**
+     * Disables certificate revocation checking during TLS negotiation.
+     *
+     * @return this
+     */
+    public TlsContextOptions withCertificateRevocationCheckDisabled() {
+        this.certificateRevocationCheckDisabled = true;
+        return this;
+    }
+
     /*******************************************************************************
      * native methods
      ******************************************************************************/
@@ -566,6 +596,7 @@ public final class TlsContextOptions extends CrtResource {
                 String caFile,
                 String caDir,
                 boolean verifyPeer,
+                boolean certificateRevocationCheckDisabled,
                 String pkcs12Path,
                 String pkcs12Password,
                 TlsContextPkcs11Options pkcs11Options,

--- a/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
+++ b/src/main/java/software/amazon/awssdk/crt/io/TlsContextOptions.java
@@ -81,21 +81,17 @@ public final class TlsContextOptions extends CrtResource {
     public boolean verifyPeer = false;
 
     /**
-     * Set whether or not certificate revocation checking is disabled during TLS negotiation.
+     * Set to true to disable certificate revocation checking during TLS negotiation.
      *
-     * On Windows (SChannel), when enabled (the default), the TLS handshake will make outbound
-     * network calls to CRL/OCSP revocation endpoints. In environments without internet access
-     * (e.g., private subnets with only VPC endpoints), this can cause the handshake to block
-     * for minutes while waiting for network timeouts.
+     * On Windows (SChannel), this prevents the TLS handshake from making outbound network calls
+     * to CRL/OCSP revocation endpoints, which can block for minutes when the endpoints are unreachable
+     * (e.g., in private subnets without internet access).
+     *
+     * On Linux (s2n), this disables validation of OCSP stapled responses provided by the server.
+     *
+     * On Apple platforms, this is a no-op as revocation checking is not enabled by default.
      * 
-     * On Linux, when enabled (the defualt), the TLS handhake will check the server-stapled
-     * OCSP.
-     * 
-     * On Apple platforms, the revocation check is always skipped.
-     *
-     * Set this to true to skip revocation checking entirely.
-     *
-     * Default is false (revocation checking enabled).
+     * Default is false (revocation checking enabled where available).
      */
     public boolean noCertificateRevocation = false;
 

--- a/src/native/tls_context_options.c
+++ b/src/native/tls_context_options.c
@@ -88,6 +88,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     jstring jni_ca_filepath,
     jstring jni_ca_dirpath,
     jboolean jni_verify_peer,
+    jboolean jni_certificate_revocation_check_disabled,
     jstring jni_pkcs12_path,
     jstring jni_pkcs12_password,
     jobject jni_pkcs11_options,
@@ -304,6 +305,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     tls->options.minimum_tls_version = (enum aws_tls_versions)jni_min_tls_version;
     tls->options.cipher_pref = (enum aws_tls_cipher_pref)jni_cipher_pref;
     tls->options.verify_peer = jni_verify_peer != 0;
+    tls->options.disable_certificate_revocation_check = jni_certificate_revocation_check_disabled != 0;
 
     if (jni_alpn) {
         tls->alpn_list = aws_jni_new_string_from_jstring(env, jni_alpn);

--- a/src/native/tls_context_options.c
+++ b/src/native/tls_context_options.c
@@ -305,7 +305,7 @@ jlong JNICALL Java_software_amazon_awssdk_crt_io_TlsContextOptions_tlsContextOpt
     tls->options.minimum_tls_version = (enum aws_tls_versions)jni_min_tls_version;
     tls->options.cipher_pref = (enum aws_tls_cipher_pref)jni_cipher_pref;
     tls->options.verify_peer = jni_verify_peer != 0;
-    tls->options.disable_certificate_revocation_check = jni_certificate_revocation_check_disabled != 0;
+    tls->options.no_certificate_revocation = jni_certificate_revocation_check_disabled != 0;
 
     if (jni_alpn) {
         tls->alpn_list = aws_jni_new_string_from_jstring(env, jni_alpn);

--- a/src/test/java/software/amazon/awssdk/crt/test/HttpStreamManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/HttpStreamManagerTest.java
@@ -41,8 +41,8 @@ import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.crt.utils.ByteBufferUtils;
 
 public class HttpStreamManagerTest extends HttpRequestResponseFixture {
-    private final static String endpoint = "https://httpbin.org";
-    private final static String path = "/anything";
+    private final static String endpoint = "https://d1cz66xoahf9cl.cloudfront.net";
+    private final static String path = "/random_32_byte.data";
     private final String EMPTY_BODY = "";
     private final static int NUM_CONNECTIONS = 20;
     private final static Charset UTF8 = StandardCharsets.UTF_8;


### PR DESCRIPTION
Bind the tls option to disable certificate revocation checks.

Fix GraalVM windows-latest CI jobs. GitHub updated its windows runner and the versions of Java we are testing can't find a file. Added a step that locates the file so we can continue to use windows-latest without needing to use a later version of Java.

Update HttpStreamManager tests to not use httpbin.org which is flaky as hell.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
