### PR TITLE
Remove fix for s2n-tls on macOS x64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,18 +74,7 @@ if (BUILD_DEPS)
         )
 
         set(UNSAFE_TREAT_WARNINGS_AS_ERRORS OFF CACHE BOOL "Disable warnings-as-errors when building S2N")
-        # On Intel Macs, Homebrew installs to /usr/local which is in the default header search path.
-        # Without this, s2n's libcrypto detection picks up Homebrew's OpenSSL instead of bundled aws-lc.
-        # ARM Macs use /opt/homebrew (not in default search paths) so they don't need this.
-        if(APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-            set(_AWS_CRT_PREV_NO_SYSTEM_FROM_IMPORTED ${CMAKE_NO_SYSTEM_FROM_IMPORTED})
-            set(CMAKE_NO_SYSTEM_FROM_IMPORTED ON)
-        endif()
         add_subdirectory(crt/s2n)
-        if(APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-            set(CMAKE_NO_SYSTEM_FROM_IMPORTED ${_AWS_CRT_PREV_NO_SYSTEM_FROM_IMPORTED})
-            unset(_AWS_CRT_PREV_NO_SYSTEM_FROM_IMPORTED)
-        endif()
     endif()
     add_subdirectory(crt/aws-c-sdkutils)
     add_subdirectory(crt/aws-c-io)


### PR DESCRIPTION
*Issue #, if available:*

On macOS x64, XCode's Clang has -I/usr/local/include baked in, which can shadow libcrypto headers from imported targets (propagated with -isystem). Currently, CMake config sets`NO_SYSTEM_FROM_IMPORTED` flag forcing `-I` for imported target. With s2n-tls implemented this fix on their side, the local fix is not needed anymore.

*Description of changes:*

Update s2n-tls to get the fix. Remove the local fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
