### PR TITLE
Fix NPE in Http2StreamManager when configured with TlsConnectionOptio…

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/http/Http2StreamManager.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http2StreamManager.java
@@ -135,7 +135,12 @@ public class Http2StreamManager extends CrtResource {
          */
         addReferenceTo(clientBootstrap);
         if (useTls) {
-            addReferenceTo(tlsContext);
+            if (tlsContext != null) {
+                addReferenceTo(tlsContext);
+            }
+            if (tlsConnectionOptions != null) {
+                addReferenceTo(tlsConnectionOptions);
+            }
         }
     }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/Http2StreamManagerTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http2StreamManagerTest.java
@@ -55,6 +55,44 @@ public class Http2StreamManagerTest extends HttpClientTestFixture {
         }
     }
 
+    private Http2StreamManager createStreamManagerWithTlsConnectionOptions(URI uri, int numConnections) {
+        try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
+                HostResolver resolver = new HostResolver(eventLoopGroup);
+                ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver);
+                SocketOptions sockOpts = new SocketOptions();
+                TlsContextOptions tlsOpts = TlsContextOptions.createDefaultClient().withAlpnList("h2");
+                TlsContext tlsContext = createHttpClientTlsContext(tlsOpts);
+                TlsConnectionOptions tlsConnectionOptions = new TlsConnectionOptions(tlsContext)) {
+            tlsConnectionOptions.withServerName(uri.getHost());
+
+            Http2StreamManagerOptions options = new Http2StreamManagerOptions();
+            HttpClientConnectionManagerOptions connectionManagerOptions = new HttpClientConnectionManagerOptions();
+            // Configure TLS via TlsConnectionOptions only (no withTlsContext). This is the
+            // configuration that used to NPE in the Http2StreamManager constructor.
+            connectionManagerOptions.withClientBootstrap(bootstrap)
+                    .withSocketOptions(sockOpts)
+                    .withTlsConnectionOptions(tlsConnectionOptions)
+                    .withUri(uri)
+                    .withMaxConnections(numConnections);
+            options.withConnectionManagerOptions(connectionManagerOptions);
+
+            return Http2StreamManager.create(options);
+        }
+    }
+
+    @Test
+    public void testStreamManagerWithTlsConnectionOptions() throws Exception {
+        skipIfAndroid();
+        URI uri = new URI(endpoint);
+
+        try (Http2StreamManager streamManager = createStreamManagerWithTlsConnectionOptions(uri, NUM_CONNECTIONS)) {
+            Assert.assertNotNull(streamManager);
+        }
+
+        CrtResource.logNativeResources();
+        CrtResource.waitForNoResources();
+    }
+
     private Http2Request createHttp2Request(String method, String endpoint, String path, String requestBody)
             throws Exception {
         URI uri = new URI(endpoint);


### PR DESCRIPTION
…ns only



*Description of changes:*

Http2StreamManager's constructor unconditionally called `addReferenceTo(tlsContext)` on the TLS path, throwing a `NullPointerException `when an HTTPS pool was configured via withTlsConnectionOptions(...) only (tlsContext == null). It also never ref-counted tlsConnectionOptions, so that object's lifetime was not extended.

Mirror the `HttpClientConnectionManager` (H1) logic by null-checking each TLS field independently and referencing whichever is present. Add a regression test that constructs an HTTPS Http2StreamManager via withTlsConnectionOptions(...) only and asserts it builds and releases its native resources.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
