### PR TITLE
fix(security): Remove GPG key leak from build logs

### DIFF
--- a/android/crt/build.gradle
+++ b/android/crt/build.gradle
@@ -241,7 +241,6 @@ afterEvaluate {
                         (String) project.property("signingKey"),
                         (String) project.property("signingPassword")
                 )
-                println("key=" + project.property("signingKey"))
                 sign(publications)
             }
         }

--- a/codebuild/cd/publish-android.sh
+++ b/codebuild/cd/publish-android.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 set -o pipefail # Make sure one process in pipe fail gets bubble up
 
 git submodule update --init

--- a/codebuild/cd/publish-bundle.sh
+++ b/codebuild/cd/publish-bundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 set -o pipefail # Make sure one process in pipe fail gets bubble up
 
 # Configuration


### PR DESCRIPTION
*Description of changes:*

- Removed println("key=" + project.property("signingKey")) from `build.gradle`.
- Changed set -ex to set -e in `publish-android.sh` to disable bash xtrace.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
