### PR TITLE
Add abortStream method to Http1StreamManager and ensure streams are released to connection pool

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/http/Http1StreamManager.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http1StreamManager.java
@@ -7,6 +7,7 @@ package software.amazon.awssdk.crt.http;
 import software.amazon.awssdk.crt.CrtRuntimeException;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Manages a Pool of HTTP/1.1 Streams. Creates and manages HTTP/1.1 connections
@@ -97,6 +98,11 @@ public class Http1StreamManager implements AutoCloseable {
             if (throwable != null) {
                 completionFuture.completeExceptionally(throwable);
             } else {
+                // Guard ensures the connection is released exactly once, regardless of
+                // whether release happens via onResponseComplete, activate failure, or
+                // external cancellation (e.g., SDK timeout calling cancel+close).
+                AtomicBoolean connectionReleased = new AtomicBoolean(false);
+
                 try {
                     HttpStreamBase stream = conn.makeRequest(request, new HttpStreamBaseResponseHandler() {
                         @Override
@@ -118,8 +124,10 @@ public class Http1StreamManager implements AutoCloseable {
                         @Override
                         public void onResponseComplete(HttpStreamBase stream, int errorCode) {
                             streamHandler.onResponseComplete(stream, errorCode);
-                            /* Release the connection back */
-                            connManager.releaseConnection(conn);
+                            /* Release the connection back (at most once) */
+                            if (connectionReleased.compareAndSet(false, true)) {
+                                connManager.releaseConnection(conn);
+                            }
                         }
                     }, useManualDataWrites);
                     completionFuture.complete((HttpStream) stream);
@@ -134,16 +142,55 @@ public class Http1StreamManager implements AutoCloseable {
                     } catch (CrtRuntimeException e) {
                         /* If activate failed, complete callback will not be invoked */
                         streamHandler.onResponseComplete(stream, e.errorCode);
-                        /* Release the connection back */
+                        if (connectionReleased.compareAndSet(false, true)) {
+                            connManager.releaseConnection(conn);
+                        }
+                    }
+
+                    // If the stream was externally cancelled+closed between
+                    // completionFuture.complete() and stream.activate() above, activate()
+                    // becomes a no-op (stream handle is null) and onResponseComplete will
+                    // never fire. Detect this and release the connection.
+                    if (stream.isNull() && connectionReleased.compareAndSet(false, true)) {
                         connManager.releaseConnection(conn);
                     }
                 } catch (Exception ex) {
-                    connManager.releaseConnection(conn);
+                    if (connectionReleased.compareAndSet(false, true)) {
+                        connManager.releaseConnection(conn);
+                    }
                     completionFuture.completeExceptionally(ex);
                 }
             }
         });
         return completionFuture;
+    }
+
+    /**
+     * Abort an in-flight stream obtained from this manager. Cancels the HTTP exchange
+     * and ensures the underlying connection slot is properly released back to the pool.
+     *
+     * <p>This method is safe to call:
+     * <ul>
+     *   <li>With a null stream (e.g., if acquisition was still pending)</li>
+     *   <li>After the stream has already completed normally</li>
+     *   <li>Multiple times (idempotent)</li>
+     * </ul>
+     *
+     * <p>For HTTP/1.1, cancelling a stream closes the underlying TCP connection (it will
+     * not be returned to the pool for reuse). The connection <em>slot</em> is released so
+     * a new connection can be established.
+     *
+     * @param stream the stream to abort, or null if the stream was never acquired
+     */
+    public void abortStream(HttpStreamBase stream) {
+        if (stream != null && !stream.isNull()) {
+            stream.cancel();
+            stream.close();
+        }
+        // Connection release is handled by the AtomicBoolean guard:
+        // - If onResponseComplete fires (cancel triggers it on activated streams): released there
+        // - If stream was never activated or already closed: released by the isNull() check
+        //   after activate() in acquireStream()
     }
 
     /**

--- a/src/main/java/software/amazon/awssdk/crt/http/Http1StreamManager.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/Http1StreamManager.java
@@ -166,34 +166,6 @@ public class Http1StreamManager implements AutoCloseable {
     }
 
     /**
-     * Abort an in-flight stream obtained from this manager. Cancels the HTTP exchange
-     * and ensures the underlying connection slot is properly released back to the pool.
-     *
-     * <p>This method is safe to call:
-     * <ul>
-     *   <li>With a null stream (e.g., if acquisition was still pending)</li>
-     *   <li>After the stream has already completed normally</li>
-     *   <li>Multiple times (idempotent)</li>
-     * </ul>
-     *
-     * <p>For HTTP/1.1, cancelling a stream closes the underlying TCP connection (it will
-     * not be returned to the pool for reuse). The connection <em>slot</em> is released so
-     * a new connection can be established.
-     *
-     * @param stream the stream to abort, or null if the stream was never acquired
-     */
-    public void abortStream(HttpStreamBase stream) {
-        if (stream != null && !stream.isNull()) {
-            stream.cancel();
-            stream.close();
-        }
-        // Connection release is handled by the AtomicBoolean guard:
-        // - If onResponseComplete fires (cancel triggers it on activated streams): released there
-        // - If stream was never activated or already closed: released by the isNull() check
-        //   after activate() in acquireStream()
-    }
-
-    /**
      * @return concurrency metrics for the current manager
      */
     public HttpManagerMetrics getManagerMetrics() {

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpStreamManager.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpStreamManager.java
@@ -106,6 +106,33 @@ public class HttpStreamManager implements AutoCloseable {
         }
     }
 
+    /**
+     * Abort an in-flight stream obtained from this manager. Cancels the HTTP exchange
+     * and ensures the underlying connection/stream slot is properly released back to the
+     * pool so it can be reused by new requests.
+     *
+     * <p>This is the correct way to cancel an in-flight request from outside the stream
+     * callback lifecycle (e.g., on SDK timeout). Calling {@code stream.cancel()} and
+     * {@code stream.close()} directly may leak the connection slot.
+     *
+     * <p>Safe to call with null (e.g., if the stream was never acquired), after normal
+     * completion, or multiple times.
+     *
+     * @param stream the stream to abort, or null
+     */
+    public void abortStream(HttpStreamBase stream) {
+        if (this.h1StreamManager != null) {
+            this.h1StreamManager.abortStream(stream);
+        } else if (this.h2StreamManager != null) {
+            // HTTP/2 stream manager handles stream lifecycle natively;
+            // cancel+close is sufficient for H2 streams.
+            if (stream != null && !stream.isNull()) {
+                stream.cancel();
+                stream.close();
+            }
+        }
+    }
+
     @Override
     public void close() {
         if (this.h1StreamManager != null) {

--- a/src/main/java/software/amazon/awssdk/crt/http/HttpStreamManager.java
+++ b/src/main/java/software/amazon/awssdk/crt/http/HttpStreamManager.java
@@ -112,8 +112,12 @@ public class HttpStreamManager implements AutoCloseable {
      * pool so it can be reused by new requests.
      *
      * <p>This is the correct way to cancel an in-flight request from outside the stream
-     * callback lifecycle (e.g., on SDK timeout). Calling {@code stream.cancel()} and
-     * {@code stream.close()} directly may leak the connection slot.
+     * callback lifecycle (e.g., on SDK timeout). For HTTP/1.1, the connection release is
+     * guaranteed by the {@code AtomicBoolean} guard and {@code isNull()} check inside
+     * {@code Http1StreamManager.acquireStream()} — calling {@code cancel()} triggers
+     * {@code onResponseComplete} on activated streams, or the post-activate guard catches
+     * streams closed before activation. For HTTP/2, the native layer handles stream slot
+     * accounting internally.
      *
      * <p>Safe to call with null (e.g., if the stream was never acquired), after normal
      * completion, or multiple times.
@@ -121,15 +125,9 @@ public class HttpStreamManager implements AutoCloseable {
      * @param stream the stream to abort, or null
      */
     public void abortStream(HttpStreamBase stream) {
-        if (this.h1StreamManager != null) {
-            this.h1StreamManager.abortStream(stream);
-        } else if (this.h2StreamManager != null) {
-            // HTTP/2 stream manager handles stream lifecycle natively;
-            // cancel+close is sufficient for H2 streams.
-            if (stream != null && !stream.isNull()) {
-                stream.cancel();
-                stream.close();
-            }
+        if (stream != null && !stream.isNull()) {
+            stream.cancel();
+            stream.close();
         }
     }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/Http1StreamManagerAbortTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http1StreamManagerAbortTest.java
@@ -1,0 +1,637 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package software.amazon.awssdk.crt.test;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assert;
+import org.junit.Test;
+import software.amazon.awssdk.crt.CRT;
+import software.amazon.awssdk.crt.CrtResource;
+import software.amazon.awssdk.crt.http.Http1StreamManager;
+import software.amazon.awssdk.crt.http.HttpClientConnectionManagerOptions;
+import software.amazon.awssdk.crt.http.HttpHeader;
+import software.amazon.awssdk.crt.http.HttpManagerMetrics;
+import software.amazon.awssdk.crt.http.HttpRequest;
+import software.amazon.awssdk.crt.http.HttpStream;
+import software.amazon.awssdk.crt.http.HttpStreamBase;
+import software.amazon.awssdk.crt.http.HttpStreamBaseResponseHandler;
+import software.amazon.awssdk.crt.http.HttpStreamManager;
+import software.amazon.awssdk.crt.http.HttpStreamManagerOptions;
+import software.amazon.awssdk.crt.http.HttpVersion;
+import software.amazon.awssdk.crt.http.Http2StreamManagerOptions;
+import software.amazon.awssdk.crt.io.ClientBootstrap;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
+import software.amazon.awssdk.crt.io.SocketOptions;
+import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.crt.io.TlsContextOptions;
+
+/**
+ * Tests for {@link Http1StreamManager} connection release guarantees when streams
+ * are cancelled or aborted externally (e.g., due to SDK timeout).
+ *
+ * <p>These tests verify the fix for the connection pool exhaustion regression where
+ * calling {@code stream.cancel()} + {@code stream.close()} on a stream obtained from
+ * {@code Http1StreamManager} bypassed the connection release path, permanently leaking
+ * pool slots.
+ */
+public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
+    private final static String ENDPOINT = "https://d1cz66xoahf9cl.cloudfront.net";
+    private final static String PATH = "/random_32_byte.data";
+    private final static int MAX_CONNECTIONS = 3;
+
+    private Http1StreamManager createHttp1StreamManager(URI uri, int maxConnections) {
+        try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
+                HostResolver resolver = new HostResolver(eventLoopGroup);
+                ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver);
+                SocketOptions sockOpts = new SocketOptions();
+                TlsContextOptions tlsOpts = TlsContextOptions.createDefaultClient().withAlpnList("http/1.1");
+                TlsContext tlsContext = createHttpClientTlsContext(tlsOpts)) {
+            HttpClientConnectionManagerOptions options = new HttpClientConnectionManagerOptions()
+                    .withClientBootstrap(bootstrap)
+                    .withSocketOptions(sockOpts)
+                    .withTlsContext(tlsContext)
+                    .withUri(uri)
+                    .withMaxConnections(maxConnections);
+            return Http1StreamManager.create(options);
+        }
+    }
+
+    private HttpStreamManager createStreamManager(URI uri, int maxConnections) {
+        try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
+                HostResolver resolver = new HostResolver(eventLoopGroup);
+                ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver);
+                SocketOptions sockOpts = new SocketOptions();
+                TlsContextOptions tlsOpts = TlsContextOptions.createDefaultClient().withAlpnList("http/1.1");
+                TlsContext tlsContext = createHttpClientTlsContext(tlsOpts)) {
+            HttpClientConnectionManagerOptions h1Options = new HttpClientConnectionManagerOptions()
+                    .withClientBootstrap(bootstrap)
+                    .withSocketOptions(sockOpts)
+                    .withTlsContext(tlsContext)
+                    .withUri(uri)
+                    .withMaxConnections(maxConnections);
+            Http2StreamManagerOptions h2Options = new Http2StreamManagerOptions()
+                    .withConnectionManagerOptions(h1Options);
+            HttpStreamManagerOptions options = new HttpStreamManagerOptions()
+                    .withHTTP1ConnectionManagerOptions(h1Options)
+                    .withHTTP2StreamManagerOptions(h2Options)
+                    .withExpectedProtocol(HttpVersion.HTTP_1_1);
+            return HttpStreamManager.create(options);
+        }
+    }
+
+    private HttpRequest createRequest(URI uri) {
+        HttpHeader[] headers = new HttpHeader[] {
+                new HttpHeader("host", uri.getHost()),
+                new HttpHeader("content-length", "0")
+        };
+        return new HttpRequest("GET", PATH, headers, null);
+    }
+
+    /**
+     * Verify that {@code abortStream()} on an activated stream releases the
+     * connection slot back to the pool.
+     *
+     * <p>Sequence: acquire stream → stream activates → abort → verify pool slot freed.
+     *
+     * <p>The handler returns 0 from onResponseBody to prevent the response window from
+     * advancing, keeping the stream pinned in the "body in progress" state until we abort.
+     */
+    @Test
+    public void testAbortStreamAfterActivateReleasesConnection() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+            HttpRequest request = createRequest(uri);
+
+            final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
+            HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                    headersReceived.complete(null);
+                }
+
+                @Override
+                public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
+                    // Return 0 to not advance the window — keeps stream held open
+                    return 0;
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                }
+            };
+
+            HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+
+            // Wait until headers arrive so we know the stream is activated and in-flight
+            headersReceived.get(60, TimeUnit.SECONDS);
+
+            // At this point, 1 connection is leased
+            HttpManagerMetrics metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals("Should have 1 leased connection", 1, metrics.getLeasedConcurrency());
+
+            // Abort the stream via the manager API
+            streamManager.abortStream(stream);
+
+            // Give the native layer a moment to process the cancellation
+            Thread.sleep(500);
+
+            // Verify the connection slot was released
+            metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals("Leased concurrency should return to 0 after abort",
+                    0, metrics.getLeasedConcurrency());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+
+    /**
+     * Verify that direct {@code cancel()} + {@code close()} on an activated stream
+     * still releases the connection slot (due to the AtomicBoolean guard and
+     * onResponseComplete being triggered by cancel on an active stream).
+     *
+     * <p>This is the pattern used by the SDK's {@code ResponseHandlerHelper.closeConnection()}.
+     */
+    @Test
+    public void testDirectCancelCloseOnActivatedStreamReleasesConnection() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+            HttpRequest request = createRequest(uri);
+
+            final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
+            HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                    headersReceived.complete(null);
+                }
+
+                @Override
+                public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
+                    return 0; // Don't advance window — keep stream held
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                }
+            };
+
+            HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+
+            // Wait until headers arrive
+            headersReceived.get(60, TimeUnit.SECONDS);
+
+            HttpManagerMetrics metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals(1, metrics.getLeasedConcurrency());
+
+            // Simulate what the SDK does on timeout: direct cancel + close
+            stream.cancel();
+            stream.close();
+
+            Thread.sleep(500);
+
+            // Verify the connection slot was released
+            metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals("Leased concurrency should return to 0 after direct cancel+close",
+                    0, metrics.getLeasedConcurrency());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+
+    /**
+     * Verify that aborting all streams in a full pool does not permanently exhaust it.
+     * After aborting N streams (where N = maxConcurrency), a new request must still succeed.
+     *
+     * <p>This is the core regression test: before the fix, each abort would permanently
+     * leak a connection slot, and after maxConcurrency aborts the pool was permanently dead.
+     */
+    @Test
+    public void testPoolRecoveryAfterMultipleAborts() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+            HttpRequest request = createRequest(uri);
+
+            // Acquire and abort MAX_CONNECTIONS streams
+            for (int i = 0; i < MAX_CONNECTIONS; i++) {
+                final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
+                HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                    @Override
+                    public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                            HttpHeader[] nextHeaders) {
+                        headersReceived.complete(null);
+                    }
+
+                    @Override
+                    public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    }
+                };
+
+                HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+                headersReceived.get(60, TimeUnit.SECONDS);
+                streamManager.abortStream(stream);
+            }
+
+            // Allow time for all aborts to process
+            Thread.sleep(1000);
+
+            // Now verify the pool is alive: a new request should succeed
+            final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
+            final AtomicInteger responseStatus = new AtomicInteger(-1);
+
+            HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                    responseStatus.set(responseStatusCode);
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    reqCompleted.complete(null);
+                    stream.close();
+                }
+            };
+
+            HttpStream stream = streamManager.acquireStream(request, handler).get(10, TimeUnit.SECONDS);
+            reqCompleted.get(10, TimeUnit.SECONDS);
+
+            Assert.assertEquals("Pool should still serve requests after aborting all connections",
+                    200, responseStatus.get());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+
+    /**
+     * Same as {@link #testPoolRecoveryAfterMultipleAborts()} but using direct
+     * cancel+close (the SDK's actual pattern) instead of abortStream().
+     */
+    @Test
+    public void testPoolRecoveryAfterMultipleDirectCancelClose() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+            HttpRequest request = createRequest(uri);
+
+            for (int i = 0; i < MAX_CONNECTIONS; i++) {
+                final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
+                HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                    @Override
+                    public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                            HttpHeader[] nextHeaders) {
+                        headersReceived.complete(null);
+                    }
+
+                    @Override
+                    public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    }
+                };
+
+                HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+                headersReceived.get(60, TimeUnit.SECONDS);
+
+                // Direct cancel+close as the SDK does
+                stream.cancel();
+                stream.close();
+            }
+
+            Thread.sleep(1000);
+
+            // Pool should still work
+            final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
+            final AtomicInteger responseStatus = new AtomicInteger(-1);
+
+            HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                    responseStatus.set(responseStatusCode);
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    reqCompleted.complete(null);
+                    stream.close();
+                }
+            };
+
+            HttpStream stream = streamManager.acquireStream(request, handler).get(10, TimeUnit.SECONDS);
+            reqCompleted.get(10, TimeUnit.SECONDS);
+
+            Assert.assertEquals("Pool should still serve requests after direct cancel+close",
+                    200, responseStatus.get());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+
+    /**
+     * Verify that {@code abortStream(null)} is a safe no-op — covers the case where
+     * the stream was never acquired (e.g., the request timed out waiting for a connection).
+     */
+    @Test
+    public void testAbortStreamWithNullIsNoOp() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+            // Should not throw
+            streamManager.abortStream(null);
+
+            // Pool should still be usable
+            HttpManagerMetrics metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals(0, metrics.getLeasedConcurrency());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+
+    /**
+     * Verify that calling {@code abortStream()} multiple times on the same stream
+     * is idempotent and does not double-release the connection.
+     */
+    @Test
+    public void testAbortStreamIsIdempotent() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+            HttpRequest request = createRequest(uri);
+
+            final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
+            HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                    headersReceived.complete(null);
+                }
+
+                @Override
+                public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
+                    return 0; // Don't advance window — keep stream held
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                }
+            };
+
+            HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+            headersReceived.get(60, TimeUnit.SECONDS);
+
+            // Abort multiple times — should not throw or cause issues
+            streamManager.abortStream(stream);
+            streamManager.abortStream(stream);
+            streamManager.abortStream(stream);
+
+            Thread.sleep(500);
+
+            HttpManagerMetrics metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals("Should have 0 leased after idempotent aborts",
+                    0, metrics.getLeasedConcurrency());
+
+            // Pool should still function
+            final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
+            final AtomicInteger responseStatus = new AtomicInteger(-1);
+
+            HttpStreamBaseResponseHandler handler2 = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream2, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                    responseStatus.set(responseStatusCode);
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream2, int errorCode) {
+                    reqCompleted.complete(null);
+                    stream2.close();
+                }
+            };
+
+            HttpStream stream2 = streamManager.acquireStream(request, handler2).get(10, TimeUnit.SECONDS);
+            reqCompleted.get(10, TimeUnit.SECONDS);
+            Assert.assertEquals(200, responseStatus.get());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+
+    /**
+     * Verify that the {@link HttpStreamManager} facade's {@code abortStream()} method
+     * properly delegates to the underlying {@code Http1StreamManager} and releases
+     * the connection slot. We verify this by filling the pool with aborted streams
+     * and then confirming a subsequent request succeeds (which requires pool slots
+     * to have been released).
+     */
+    @Test
+    public void testHttpStreamManagerAbortStreamDelegation() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
+            HttpRequest request = createRequest(uri);
+
+            // Acquire and abort MAX_CONNECTIONS streams via the facade
+            for (int i = 0; i < MAX_CONNECTIONS; i++) {
+                final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
+                HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                    @Override
+                    public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                            HttpHeader[] nextHeaders) {
+                        headersReceived.complete(null);
+                    }
+
+                    @Override
+                    public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
+                        return 0;
+                    }
+
+                    @Override
+                    public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    }
+                };
+
+                HttpStreamBase stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+                headersReceived.get(60, TimeUnit.SECONDS);
+                streamManager.abortStream(stream);
+            }
+
+            Thread.sleep(1000);
+
+            // Pool should still be alive: a new request must succeed
+            final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
+            final AtomicInteger responseStatus = new AtomicInteger(-1);
+
+            HttpStreamBaseResponseHandler finalHandler = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                    responseStatus.set(responseStatusCode);
+                }
+
+                @Override
+                public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
+                    return bodyBytesIn.length;
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    reqCompleted.complete(null);
+                    stream.close();
+                }
+            };
+
+            streamManager.acquireStream(request, finalHandler).get(10, TimeUnit.SECONDS);
+            reqCompleted.get(10, TimeUnit.SECONDS);
+
+            Assert.assertEquals("Pool should still serve requests after aborts via facade",
+                    200, responseStatus.get());
+
+            // After the successful request completes, pool should be idle
+            Thread.sleep(200);
+            HttpManagerMetrics metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals(0, metrics.getLeasedConcurrency());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+
+    /**
+     * Verify that aborting a stream that has already completed normally is safe.
+     * The connection was already released by {@code onResponseComplete} — aborting
+     * after the fact should be a no-op (no double-release).
+     */
+    @Test
+    public void testAbortStreamAfterNormalCompletion() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+            HttpRequest request = createRequest(uri);
+
+            final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
+            final AtomicReference<HttpStreamBase> streamRef = new AtomicReference<>();
+
+            HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                }
+
+                @Override
+                public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
+                    return bodyBytesIn.length;
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    streamRef.set(stream);
+                    reqCompleted.complete(null);
+                    stream.close();
+                }
+            };
+
+            streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+            reqCompleted.get(60, TimeUnit.SECONDS);
+
+            // Request completed normally — connection already released
+            Thread.sleep(200);
+            HttpManagerMetrics metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals(0, metrics.getLeasedConcurrency());
+
+            // Abort after completion should be a no-op (stream already closed/null)
+            streamManager.abortStream(streamRef.get());
+
+            // Pool should still be healthy
+            metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals(0, metrics.getLeasedConcurrency());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+
+    /**
+     * Stress test: rapidly acquire and abort streams to verify no connection leaks
+     * under concurrent abort pressure. Verifies that after many aborts, the pool
+     * fully recovers and can serve new requests.
+     */
+    @Test
+    public void testRepeatedAbortDoesNotLeakConnections() throws Exception {
+        skipIfNetworkUnavailable();
+        URI uri = new URI(ENDPOINT);
+
+        final int numAbortCycles = 10;
+
+        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+            HttpRequest request = createRequest(uri);
+
+            for (int i = 0; i < numAbortCycles; i++) {
+                final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
+                HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
+                    @Override
+                    public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                            HttpHeader[] nextHeaders) {
+                        headersReceived.complete(null);
+                    }
+
+                    @Override
+                    public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    }
+                };
+
+                HttpStream stream = streamManager.acquireStream(request, handler).get(30, TimeUnit.SECONDS);
+                headersReceived.get(30, TimeUnit.SECONDS);
+                streamManager.abortStream(stream);
+
+                // Brief pause to let the native layer process
+                Thread.sleep(100);
+            }
+
+            // After all aborts, pool should be fully recovered
+            Thread.sleep(500);
+            HttpManagerMetrics metrics = streamManager.getManagerMetrics();
+            Assert.assertEquals("All connections should be released after " + numAbortCycles + " abort cycles",
+                    0, metrics.getLeasedConcurrency());
+
+            // Final verification: pool can serve a normal request
+            final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
+            final AtomicInteger responseStatus = new AtomicInteger(-1);
+
+            HttpStreamBaseResponseHandler finalHandler = new HttpStreamBaseResponseHandler() {
+                @Override
+                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
+                        HttpHeader[] nextHeaders) {
+                    responseStatus.set(responseStatusCode);
+                }
+
+                @Override
+                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
+                    reqCompleted.complete(null);
+                    stream.close();
+                }
+            };
+
+            streamManager.acquireStream(request, finalHandler).get(10, TimeUnit.SECONDS);
+            reqCompleted.get(10, TimeUnit.SECONDS);
+            Assert.assertEquals(200, responseStatus.get());
+        }
+
+        CrtResource.waitForNoResources();
+    }
+}

--- a/src/test/java/software/amazon/awssdk/crt/test/Http1StreamManagerAbortTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http1StreamManagerAbortTest.java
@@ -36,11 +36,6 @@ import software.amazon.awssdk.crt.io.TlsContextOptions;
 /**
  * Tests for {@link Http1StreamManager} connection release guarantees when streams
  * are cancelled or aborted externally (e.g., due to SDK timeout).
- *
- * <p>These tests verify the fix for the connection pool exhaustion regression where
- * calling {@code stream.cancel()} + {@code stream.close()} on a stream obtained from
- * {@code Http1StreamManager} bypassed the connection release path, permanently leaking
- * pool slots.
  */
 public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
     private final static String ENDPOINT = "https://d1cz66xoahf9cl.cloudfront.net";
@@ -133,8 +128,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
      * Verify that direct {@code cancel()} + {@code close()} on an activated stream
      * still releases the connection slot (due to the AtomicBoolean guard and
      * onResponseComplete being triggered by cancel on an active stream).
-     *
-     * <p>This is the pattern used by the SDK's {@code ResponseHandlerHelper.closeConnection()}.
      */
     @Test
     public void testDirectCancelCloseOnActivatedStreamReleasesConnection() throws Exception {
@@ -185,9 +178,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
     /**
      * Verify that aborting all streams in a full pool does not permanently exhaust it.
      * After aborting N streams (where N = maxConcurrency), a new request must still succeed.
-     *
-     * <p>This is the core regression test: before the fix, each abort would permanently
-     * leak a connection slot, and after maxConcurrency aborts the pool was permanently dead.
      */
     @Test
     public void testPoolRecoveryAfterMultipleAborts() throws Exception {
@@ -240,67 +230,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
             reqCompleted.get(10, TimeUnit.SECONDS);
 
             Assert.assertEquals("Pool should still serve requests after aborting all connections",
-                    200, responseStatus.get());
-        }
-
-        CrtResource.waitForNoResources();
-    }
-
-    /**
-     * Same as {@link #testPoolRecoveryAfterMultipleAborts()} but using direct
-     * cancel+close (the SDK's actual pattern) instead of abortStream().
-     */
-    @Test
-    public void testPoolRecoveryAfterMultipleDirectCancelClose() throws Exception {
-        skipIfNetworkUnavailable();
-        URI uri = new URI(ENDPOINT);
-
-        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
-            HttpRequest request = createRequest(uri);
-
-            for (int i = 0; i < MAX_CONNECTIONS; i++) {
-                final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
-                HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
-                    @Override
-                    public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
-                            HttpHeader[] nextHeaders) {
-                        headersReceived.complete(null);
-                    }
-
-                    @Override
-                    public void onResponseComplete(HttpStreamBase stream, int errorCode) {
-                    }
-                };
-
-                HttpStreamBase stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
-                headersReceived.get(60, TimeUnit.SECONDS);
-                stream.cancel();
-                stream.close();
-            }
-
-            Thread.sleep(1000);
-
-            final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
-            final AtomicInteger responseStatus = new AtomicInteger(-1);
-
-            HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
-                @Override
-                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
-                        HttpHeader[] nextHeaders) {
-                    responseStatus.set(responseStatusCode);
-                }
-
-                @Override
-                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
-                    reqCompleted.complete(null);
-                    stream.close();
-                }
-            };
-
-            streamManager.acquireStream(request, handler).get(10, TimeUnit.SECONDS);
-            reqCompleted.get(10, TimeUnit.SECONDS);
-
-            Assert.assertEquals("Pool should still serve requests after direct cancel+close",
                     200, responseStatus.get());
         }
 

--- a/src/test/java/software/amazon/awssdk/crt/test/Http1StreamManagerAbortTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/Http1StreamManagerAbortTest.java
@@ -47,23 +47,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
     private final static String PATH = "/random_32_byte.data";
     private final static int MAX_CONNECTIONS = 3;
 
-    private Http1StreamManager createHttp1StreamManager(URI uri, int maxConnections) {
-        try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
-                HostResolver resolver = new HostResolver(eventLoopGroup);
-                ClientBootstrap bootstrap = new ClientBootstrap(eventLoopGroup, resolver);
-                SocketOptions sockOpts = new SocketOptions();
-                TlsContextOptions tlsOpts = TlsContextOptions.createDefaultClient().withAlpnList("http/1.1");
-                TlsContext tlsContext = createHttpClientTlsContext(tlsOpts)) {
-            HttpClientConnectionManagerOptions options = new HttpClientConnectionManagerOptions()
-                    .withClientBootstrap(bootstrap)
-                    .withSocketOptions(sockOpts)
-                    .withTlsContext(tlsContext)
-                    .withUri(uri)
-                    .withMaxConnections(maxConnections);
-            return Http1StreamManager.create(options);
-        }
-    }
-
     private HttpStreamManager createStreamManager(URI uri, int maxConnections) {
         try (EventLoopGroup eventLoopGroup = new EventLoopGroup(1);
                 HostResolver resolver = new HostResolver(eventLoopGroup);
@@ -99,8 +82,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
      * Verify that {@code abortStream()} on an activated stream releases the
      * connection slot back to the pool.
      *
-     * <p>Sequence: acquire stream → stream activates → abort → verify pool slot freed.
-     *
      * <p>The handler returns 0 from onResponseBody to prevent the response window from
      * advancing, keeping the stream pinned in the "body in progress" state until we abort.
      */
@@ -109,7 +90,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
         skipIfNetworkUnavailable();
         URI uri = new URI(ENDPOINT);
 
-        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
             HttpRequest request = createRequest(uri);
 
             final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
@@ -122,7 +103,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
 
                 @Override
                 public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
-                    // Return 0 to not advance the window — keeps stream held open
                     return 0;
                 }
 
@@ -131,22 +111,16 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                 }
             };
 
-            HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
-
-            // Wait until headers arrive so we know the stream is activated and in-flight
+            HttpStreamBase stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
             headersReceived.get(60, TimeUnit.SECONDS);
 
-            // At this point, 1 connection is leased
             HttpManagerMetrics metrics = streamManager.getManagerMetrics();
             Assert.assertEquals("Should have 1 leased connection", 1, metrics.getLeasedConcurrency());
 
-            // Abort the stream via the manager API
             streamManager.abortStream(stream);
 
-            // Give the native layer a moment to process the cancellation
             Thread.sleep(500);
 
-            // Verify the connection slot was released
             metrics = streamManager.getManagerMetrics();
             Assert.assertEquals("Leased concurrency should return to 0 after abort",
                     0, metrics.getLeasedConcurrency());
@@ -167,7 +141,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
         skipIfNetworkUnavailable();
         URI uri = new URI(ENDPOINT);
 
-        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
             HttpRequest request = createRequest(uri);
 
             final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
@@ -180,7 +154,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
 
                 @Override
                 public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
-                    return 0; // Don't advance window — keep stream held
+                    return 0;
                 }
 
                 @Override
@@ -188,9 +162,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                 }
             };
 
-            HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
-
-            // Wait until headers arrive
+            HttpStreamBase stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
             headersReceived.get(60, TimeUnit.SECONDS);
 
             HttpManagerMetrics metrics = streamManager.getManagerMetrics();
@@ -202,7 +174,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
 
             Thread.sleep(500);
 
-            // Verify the connection slot was released
             metrics = streamManager.getManagerMetrics();
             Assert.assertEquals("Leased concurrency should return to 0 after direct cancel+close",
                     0, metrics.getLeasedConcurrency());
@@ -223,10 +194,9 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
         skipIfNetworkUnavailable();
         URI uri = new URI(ENDPOINT);
 
-        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
             HttpRequest request = createRequest(uri);
 
-            // Acquire and abort MAX_CONNECTIONS streams
             for (int i = 0; i < MAX_CONNECTIONS; i++) {
                 final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
                 HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
@@ -241,15 +211,14 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                     }
                 };
 
-                HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+                HttpStreamBase stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
                 headersReceived.get(60, TimeUnit.SECONDS);
                 streamManager.abortStream(stream);
             }
 
-            // Allow time for all aborts to process
             Thread.sleep(1000);
 
-            // Now verify the pool is alive: a new request should succeed
+            // Pool should still work: a new request must succeed
             final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
             final AtomicInteger responseStatus = new AtomicInteger(-1);
 
@@ -267,7 +236,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                 }
             };
 
-            HttpStream stream = streamManager.acquireStream(request, handler).get(10, TimeUnit.SECONDS);
+            streamManager.acquireStream(request, handler).get(10, TimeUnit.SECONDS);
             reqCompleted.get(10, TimeUnit.SECONDS);
 
             Assert.assertEquals("Pool should still serve requests after aborting all connections",
@@ -286,7 +255,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
         skipIfNetworkUnavailable();
         URI uri = new URI(ENDPOINT);
 
-        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
             HttpRequest request = createRequest(uri);
 
             for (int i = 0; i < MAX_CONNECTIONS; i++) {
@@ -303,17 +272,14 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                     }
                 };
 
-                HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+                HttpStreamBase stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
                 headersReceived.get(60, TimeUnit.SECONDS);
-
-                // Direct cancel+close as the SDK does
                 stream.cancel();
                 stream.close();
             }
 
             Thread.sleep(1000);
 
-            // Pool should still work
             final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
             final AtomicInteger responseStatus = new AtomicInteger(-1);
 
@@ -331,7 +297,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                 }
             };
 
-            HttpStream stream = streamManager.acquireStream(request, handler).get(10, TimeUnit.SECONDS);
+            streamManager.acquireStream(request, handler).get(10, TimeUnit.SECONDS);
             reqCompleted.get(10, TimeUnit.SECONDS);
 
             Assert.assertEquals("Pool should still serve requests after direct cancel+close",
@@ -350,11 +316,10 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
         skipIfNetworkUnavailable();
         URI uri = new URI(ENDPOINT);
 
-        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
             // Should not throw
             streamManager.abortStream(null);
 
-            // Pool should still be usable
             HttpManagerMetrics metrics = streamManager.getManagerMetrics();
             Assert.assertEquals(0, metrics.getLeasedConcurrency());
         }
@@ -371,7 +336,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
         skipIfNetworkUnavailable();
         URI uri = new URI(ENDPOINT);
 
-        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
             HttpRequest request = createRequest(uri);
 
             final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
@@ -384,7 +349,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
 
                 @Override
                 public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
-                    return 0; // Don't advance window — keep stream held
+                    return 0;
                 }
 
                 @Override
@@ -392,7 +357,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                 }
             };
 
-            HttpStream stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
+            HttpStreamBase stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
             headersReceived.get(60, TimeUnit.SECONDS);
 
             // Abort multiple times — should not throw or cause issues
@@ -424,89 +389,9 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                 }
             };
 
-            HttpStream stream2 = streamManager.acquireStream(request, handler2).get(10, TimeUnit.SECONDS);
+            streamManager.acquireStream(request, handler2).get(10, TimeUnit.SECONDS);
             reqCompleted.get(10, TimeUnit.SECONDS);
             Assert.assertEquals(200, responseStatus.get());
-        }
-
-        CrtResource.waitForNoResources();
-    }
-
-    /**
-     * Verify that the {@link HttpStreamManager} facade's {@code abortStream()} method
-     * properly delegates to the underlying {@code Http1StreamManager} and releases
-     * the connection slot. We verify this by filling the pool with aborted streams
-     * and then confirming a subsequent request succeeds (which requires pool slots
-     * to have been released).
-     */
-    @Test
-    public void testHttpStreamManagerAbortStreamDelegation() throws Exception {
-        skipIfNetworkUnavailable();
-        URI uri = new URI(ENDPOINT);
-
-        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
-            HttpRequest request = createRequest(uri);
-
-            // Acquire and abort MAX_CONNECTIONS streams via the facade
-            for (int i = 0; i < MAX_CONNECTIONS; i++) {
-                final CompletableFuture<Void> headersReceived = new CompletableFuture<>();
-                HttpStreamBaseResponseHandler handler = new HttpStreamBaseResponseHandler() {
-                    @Override
-                    public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
-                            HttpHeader[] nextHeaders) {
-                        headersReceived.complete(null);
-                    }
-
-                    @Override
-                    public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
-                        return 0;
-                    }
-
-                    @Override
-                    public void onResponseComplete(HttpStreamBase stream, int errorCode) {
-                    }
-                };
-
-                HttpStreamBase stream = streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
-                headersReceived.get(60, TimeUnit.SECONDS);
-                streamManager.abortStream(stream);
-            }
-
-            Thread.sleep(1000);
-
-            // Pool should still be alive: a new request must succeed
-            final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
-            final AtomicInteger responseStatus = new AtomicInteger(-1);
-
-            HttpStreamBaseResponseHandler finalHandler = new HttpStreamBaseResponseHandler() {
-                @Override
-                public void onResponseHeaders(HttpStreamBase stream, int responseStatusCode, int blockType,
-                        HttpHeader[] nextHeaders) {
-                    responseStatus.set(responseStatusCode);
-                }
-
-                @Override
-                public int onResponseBody(HttpStreamBase stream, byte[] bodyBytesIn) {
-                    return bodyBytesIn.length;
-                }
-
-                @Override
-                public void onResponseComplete(HttpStreamBase stream, int errorCode) {
-                    reqCompleted.complete(null);
-                    stream.close();
-                }
-            };
-
-            streamManager.acquireStream(request, finalHandler).get(10, TimeUnit.SECONDS);
-            reqCompleted.get(10, TimeUnit.SECONDS);
-
-            Assert.assertEquals("Pool should still serve requests after aborts via facade",
-                    200, responseStatus.get());
-
-            // After the successful request completes, pool should be idle
-            Thread.sleep(200);
-            HttpManagerMetrics metrics = streamManager.getManagerMetrics();
-            Assert.assertEquals(0, metrics.getLeasedConcurrency());
         }
 
         CrtResource.waitForNoResources();
@@ -522,7 +407,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
         skipIfNetworkUnavailable();
         URI uri = new URI(ENDPOINT);
 
-        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
             HttpRequest request = createRequest(uri);
 
             final CompletableFuture<Void> reqCompleted = new CompletableFuture<>();
@@ -550,7 +435,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
             streamManager.acquireStream(request, handler).get(60, TimeUnit.SECONDS);
             reqCompleted.get(60, TimeUnit.SECONDS);
 
-            // Request completed normally — connection already released
             Thread.sleep(200);
             HttpManagerMetrics metrics = streamManager.getManagerMetrics();
             Assert.assertEquals(0, metrics.getLeasedConcurrency());
@@ -558,7 +442,6 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
             // Abort after completion should be a no-op (stream already closed/null)
             streamManager.abortStream(streamRef.get());
 
-            // Pool should still be healthy
             metrics = streamManager.getManagerMetrics();
             Assert.assertEquals(0, metrics.getLeasedConcurrency());
         }
@@ -568,8 +451,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
 
     /**
      * Stress test: rapidly acquire and abort streams to verify no connection leaks
-     * under concurrent abort pressure. Verifies that after many aborts, the pool
-     * fully recovers and can serve new requests.
+     * under repeated abort pressure.
      */
     @Test
     public void testRepeatedAbortDoesNotLeakConnections() throws Exception {
@@ -578,7 +460,7 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
 
         final int numAbortCycles = 10;
 
-        try (Http1StreamManager streamManager = createHttp1StreamManager(uri, MAX_CONNECTIONS)) {
+        try (HttpStreamManager streamManager = createStreamManager(uri, MAX_CONNECTIONS)) {
             HttpRequest request = createRequest(uri);
 
             for (int i = 0; i < numAbortCycles; i++) {
@@ -595,15 +477,13 @@ public class Http1StreamManagerAbortTest extends HttpRequestResponseFixture {
                     }
                 };
 
-                HttpStream stream = streamManager.acquireStream(request, handler).get(30, TimeUnit.SECONDS);
+                HttpStreamBase stream = streamManager.acquireStream(request, handler).get(30, TimeUnit.SECONDS);
                 headersReceived.get(30, TimeUnit.SECONDS);
                 streamManager.abortStream(stream);
 
-                // Brief pause to let the native layer process
                 Thread.sleep(100);
             }
 
-            // After all aborts, pool should be fully recovered
             Thread.sleep(500);
             HttpManagerMetrics metrics = streamManager.getManagerMetrics();
             Assert.assertEquals("All connections should be released after " + numAbortCycles + " abort cycles",


### PR DESCRIPTION
## Summary

  - Make Http1StreamManager robust against external stream cancellation (cancel() + close()) by guaranteeing the connection slot is always released back to the pool
  - Add abortStream() API to Http1StreamManager and HttpStreamManager as the correct way for callers to cancel in-flight streams without leaking pool capacity

### Problem

  When a caller (e.g., the SDK's timeout handler) calls stream.cancel() + stream.close(). (See [Java SDK PR #6919](https://github.com/aws/aws-sdk-java-v2/pull/6919) that introduces a new regression) on a stream obtained from Http1StreamManager, the connection slot is permanently leaked from the pool. This happens because Http1StreamManager only releases connections inside its onResponseComplete wrapper, and cancel() + close() can prevent that callback from being delivered — either because the native handle is released before the callback fires, or because the stream was closed before activation made it a no-op.

Under load with aggressive timeouts (e.g., after a network blip), this quickly exhausts the entire pool, causing 100% request failures with no recovery until process restart.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
