### PR TITLE
feat: expose more metrics for S3

### DIFF
--- a/src/main/java/software/amazon/awssdk/crt/s3/S3Client.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3Client.java
@@ -262,6 +262,15 @@ public class S3Client extends CrtResource {
         return shutdownComplete;
     }
 
+    /**
+     * @return the maximum number of connections this client will establish to a single endpoint. Fixed for
+     * the lifetime of the client - derived from its configured throughput target, or overridden directly via
+     * {@link S3ClientOptions#withMaxConnections}.
+     */
+    public int getMaxActiveConnections() {
+        return s3ClientGetMaxActiveConnections(getNativeHandle());
+    }
+
     /*******************************************************************************
      * native methods
      ******************************************************************************/
@@ -293,6 +302,8 @@ public class S3Client extends CrtResource {
             boolean directIo) throws CrtRuntimeException;
 
     private static native void s3ClientDestroy(long client);
+
+    private static native int s3ClientGetMaxActiveConnections(long client);
 
     private static native long s3ClientMakeMetaRequest(long clientId, S3MetaRequest metaRequest, byte[] region,
             int metaRequestType, byte[] operationName,

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
@@ -102,7 +102,7 @@ public class S3RequestMetrics {
     }
 
     public String getServiceId() {
-        return "s3";
+        return "S3";
     }
 
     public String getServiceEndpoint() {
@@ -148,14 +148,14 @@ public class S3RequestMetrics {
         if (this.receiveStartTimestampNs == -1) {
             throw new CrtRuntimeException(AWS_ERROR_S3_METRIC_DATA_NOT_AVAILABLE);
         }
-        return this.receiveStartTimestampNs;
+        return this.receiveStartTimestampNs - this.startTimestampNs;
     }
 
     public long getTimeToLastByte() throws CrtRuntimeException {
         if (this.receiveEndTimestampNs == -1) {
             throw new CrtRuntimeException(AWS_ERROR_S3_METRIC_DATA_NOT_AVAILABLE);
         }
-        return this.receiveEndTimestampNs;
+        return this.receiveEndTimestampNs - this.startTimestampNs;
     }
 
     // Please use CRT.awsIsTransientError() to identify transient errors

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
@@ -23,6 +23,10 @@ public class S3RequestMetrics {
     // AWS_ERROR_S3_METRIC_DATA_NOT_AVAILABLE = 14358
     private static final int AWS_ERROR_S3_METRIC_DATA_NOT_AVAILABLE = 14358;
 
+    private static final String HTTPS_SCHEME = "https";
+    private static final String HTTP_SCHEME = "http";
+    private static final String SCHEME_SEPARATOR = "://";
+
     // Required timestamp metrics - always available (default to 0)
     private long s3RequestFirstAttemptStartTimestampNs = 0;
     private long startTimestampNs = 0;
@@ -62,6 +66,7 @@ public class S3RequestMetrics {
     // Required: always available (default to null, will be set by native code)
     private String requestPathQuery = null;
     private String hostAddress = null;
+    private boolean isHttps = false;
 
     // Required: always available (default to 0)
     private int requestType = 0;
@@ -106,7 +111,7 @@ public class S3RequestMetrics {
     }
 
     public String getServiceEndpoint() {
-        return this.hostAddress;
+        return (this.isHttps ? HTTPS_SCHEME : HTTP_SCHEME) + SCHEME_SEPARATOR + this.hostAddress;
     }
 
     public String getAwsExtendedRequestId() throws CrtRuntimeException {

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
@@ -166,4 +166,8 @@ public class S3RequestMetrics {
     public String getIpAddress() {
         return this.ipAddress;
     }
+
+    public int getResponseStatus() {
+        return this.responseStatus;
+    }
 }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
@@ -6,6 +6,7 @@ package software.amazon.awssdk.crt.s3;
 
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.CrtRuntimeException;
+import software.amazon.awssdk.crt.http.HttpManagerMetrics;
 
 /**
  * An Request is any HTTP request made to the S3 Server. Within CRT,
@@ -67,6 +68,9 @@ public class S3RequestMetrics {
     private String requestPathQuery = null;
     private String hostAddress = null;
     private boolean isHttps = false;
+    // Snapshot of the endpoint's HTTP connection manager metrics, taken right before this request asked
+    // for a connection. Reflects the manager's overall state at that instant, not just this request.
+    private HttpManagerMetrics httpManagerMetrics = null;
 
     // Required: always available (default to 0)
     private int requestType = 0;
@@ -174,5 +178,15 @@ public class S3RequestMetrics {
 
     public int getResponseStatus() {
         return this.responseStatus;
+    }
+
+    /**
+     * @return a snapshot of the endpoint's HTTP connection manager metrics, taken right before this
+     * request asked for a connection. This reflects the manager's overall state at that instant - e.g.
+     * concurrency leased out to other requests sharing the same manager - not a measurement scoped to
+     * this request alone.
+     */
+    public HttpManagerMetrics getHttpManagerMetrics() {
+        return this.httpManagerMetrics;
     }
 }

--- a/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
+++ b/src/main/java/software/amazon/awssdk/crt/s3/S3RequestMetrics.java
@@ -56,6 +56,7 @@ public class S3RequestMetrics {
     private long retryDelayEndTimestampNs = -1;
     private long retryDelayDurationNs = -1;
     private long serviceCallDurationNs = -1;
+    private long connectionAcquisitionDurationNs = -1;
 
     // Request/Response info metrics
     // Optional: may not be available (defaults to -1 for int, null for String)
@@ -144,6 +145,13 @@ public class S3RequestMetrics {
             throw new CrtRuntimeException(AWS_ERROR_S3_METRIC_DATA_NOT_AVAILABLE);
         }
         return this.serviceCallDurationNs;
+    }
+
+    public long getConnectionAcquisitionDurationNs() throws CrtRuntimeException {
+        if (this.connectionAcquisitionDurationNs == -1) {
+            throw new CrtRuntimeException(AWS_ERROR_S3_METRIC_DATA_NOT_AVAILABLE);
+        }
+        return this.connectionAcquisitionDurationNs;
     }
 
     public long getSigningDurationNs() throws CrtRuntimeException {

--- a/src/main/resources/META-INF/native-image/software.amazon.awssdk/crt/aws-crt/jni-config.json
+++ b/src/main/resources/META-INF/native-image/software.amazon.awssdk/crt/aws-crt/jni-config.json
@@ -2338,6 +2338,9 @@
         "name": "serviceCallDurationNs"
       },
       {
+        "name": "connectionAcquisitionDurationNs"
+      },
+      {
         "name": "responseStatus"
       },
       {
@@ -2354,6 +2357,12 @@
       },
       {
         "name": "hostAddress"
+      },
+      {
+        "name": "isHttps"
+      },
+      {
+        "name": "httpManagerMetrics"
       },
       {
         "name": "requestType"

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1067,6 +1067,8 @@ static void s_cache_s3_request_metrics(JNIEnv *env) {
     s3_request_metrics_properties.host_address_field_id =
         (*env)->GetFieldID(env, cls, "hostAddress", "Ljava/lang/String;");
 
+    s3_request_metrics_properties.is_https_field_id = (*env)->GetFieldID(env, cls, "isHttps", "Z");
+
     s3_request_metrics_properties.request_type_field_id = (*env)->GetFieldID(env, cls, "requestType", "I");
 
     s3_request_metrics_properties.ip_address_field_id = (*env)->GetFieldID(env, cls, "ipAddress", "Ljava/lang/String;");

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1069,6 +1069,9 @@ static void s_cache_s3_request_metrics(JNIEnv *env) {
 
     s3_request_metrics_properties.is_https_field_id = (*env)->GetFieldID(env, cls, "isHttps", "Z");
 
+    s3_request_metrics_properties.http_manager_metrics_field_id = (*env)->GetFieldID(
+        env, cls, "httpManagerMetrics", "Lsoftware/amazon/awssdk/crt/http/HttpManagerMetrics;");
+
     s3_request_metrics_properties.request_type_field_id = (*env)->GetFieldID(env, cls, "requestType", "I");
 
     s3_request_metrics_properties.ip_address_field_id = (*env)->GetFieldID(env, cls, "ipAddress", "Ljava/lang/String;");

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1072,8 +1072,8 @@ static void s_cache_s3_request_metrics(JNIEnv *env) {
 
     s3_request_metrics_properties.is_https_field_id = (*env)->GetFieldID(env, cls, "isHttps", "Z");
 
-    s3_request_metrics_properties.http_manager_metrics_field_id = (*env)->GetFieldID(
-        env, cls, "httpManagerMetrics", "Lsoftware/amazon/awssdk/crt/http/HttpManagerMetrics;");
+    s3_request_metrics_properties.http_manager_metrics_field_id =
+        (*env)->GetFieldID(env, cls, "httpManagerMetrics", "Lsoftware/amazon/awssdk/crt/http/HttpManagerMetrics;");
 
     s3_request_metrics_properties.request_type_field_id = (*env)->GetFieldID(env, cls, "requestType", "I");
 

--- a/src/native/java_class_ids.c
+++ b/src/native/java_class_ids.c
@@ -1051,6 +1051,9 @@ static void s_cache_s3_request_metrics(JNIEnv *env) {
     s3_request_metrics_properties.service_call_duration_ns_field_id =
         (*env)->GetFieldID(env, cls, "serviceCallDurationNs", "J");
 
+    s3_request_metrics_properties.connection_acquisition_duration_ns_field_id =
+        (*env)->GetFieldID(env, cls, "connectionAcquisitionDurationNs", "J");
+
     s3_request_metrics_properties.response_status_field_id = (*env)->GetFieldID(env, cls, "responseStatus", "I");
 
     s3_request_metrics_properties.request_id_field_id = (*env)->GetFieldID(env, cls, "requestId", "Ljava/lang/String;");

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -482,6 +482,7 @@ struct java_aws_s3_request_metrics {
     jfieldID operation_name_field_id;
     jfieldID request_path_query_field_id;
     jfieldID host_address_field_id;
+    jfieldID is_https_field_id;
     jfieldID request_type_field_id;
     // CRT info
     jfieldID ip_address_field_id;

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -475,6 +475,7 @@ struct java_aws_s3_request_metrics {
     jfieldID retry_delay_end_timestamp_ns_field_id;
     jfieldID retry_delay_duration_ns_field_id;
     jfieldID service_call_duration_ns_field_id;
+    jfieldID connection_acquisition_duration_ns_field_id;
     // Request/Response info
     jfieldID response_status_field_id;
     jfieldID request_id_field_id;

--- a/src/native/java_class_ids.h
+++ b/src/native/java_class_ids.h
@@ -483,6 +483,7 @@ struct java_aws_s3_request_metrics {
     jfieldID request_path_query_field_id;
     jfieldID host_address_field_id;
     jfieldID is_https_field_id;
+    jfieldID http_manager_metrics_field_id;
     jfieldID request_type_field_id;
     // CRT info
     jfieldID ip_address_field_id;

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -1133,6 +1133,9 @@ static void s_on_s3_meta_request_telemetry_callback(
     (*env)->SetObjectField(env, metrics_object, s3_request_metrics_properties.host_address_field_id, host_address);
     (*env)->DeleteLocalRef(env, host_address);
 
+    bool is_https = aws_s3_request_metrics_get_is_https(metrics);
+    (*env)->SetBooleanField(env, metrics_object, s3_request_metrics_properties.is_https_field_id, (jboolean)is_https);
+
     // CRT info (String) - from crt_info_metrics
     const struct aws_string *ip_address_string;
     if (aws_s3_request_metrics_get_ip_address(metrics, &ip_address_string) == AWS_OP_SUCCESS) {

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -562,6 +562,21 @@ JNIEXPORT void JNICALL
     aws_s3_client_release(client);
 }
 
+JNIEXPORT jint JNICALL Java_software_amazon_awssdk_crt_s3_S3Client_s3ClientGetMaxActiveConnections(
+    JNIEnv *env,
+    jclass jni_class,
+    jlong jni_s3_client) {
+    (void)jni_class;
+
+    struct aws_s3_client *client = (struct aws_s3_client *)jni_s3_client;
+    if (!client) {
+        aws_jni_throw_runtime_exception(env, "S3Client.getMaxActiveConnections: Invalid/null client");
+        return 0;
+    }
+
+    return (jint)aws_s3_client_get_max_active_connections(client, NULL);
+}
+
 static void s_on_s3_client_shutdown_complete_callback(void *user_data) {
     struct s3_client_callback_data *callback = (struct s3_client_callback_data *)user_data;
 

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -1080,6 +1080,14 @@ static void s_on_s3_meta_request_telemetry_callback(
             env, metrics_object, s3_request_metrics_properties.service_call_duration_ns_field_id, timestamp_value);
     }
 
+    if (aws_s3_request_metrics_get_conn_acquire_duration_ns(metrics, &timestamp_value) == AWS_OP_SUCCESS) {
+        (*env)->SetLongField(
+            env,
+            metrics_object,
+            s3_request_metrics_properties.connection_acquisition_duration_ns_field_id,
+            timestamp_value);
+    }
+
     // Request/Response info (int) - from req_resp_info_metrics
     int response_status;
     if (aws_s3_request_metrics_get_response_status_code(metrics, &response_status) == AWS_OP_SUCCESS) {

--- a/src/native/s3_client.c
+++ b/src/native/s3_client.c
@@ -1136,6 +1136,19 @@ static void s_on_s3_meta_request_telemetry_callback(
     bool is_https = aws_s3_request_metrics_get_is_https(metrics);
     (*env)->SetBooleanField(env, metrics_object, s3_request_metrics_properties.is_https_field_id, (jboolean)is_https);
 
+    struct aws_http_manager_metrics http_manager_metrics;
+    aws_s3_request_metrics_get_http_manager_metrics(metrics, &http_manager_metrics);
+    jobject http_manager_metrics_object = (*env)->NewObject(
+        env,
+        http_manager_metrics_properties.http_manager_metrics_class,
+        http_manager_metrics_properties.constructor_method_id,
+        (jlong)http_manager_metrics.available_concurrency,
+        (jlong)http_manager_metrics.pending_concurrency_acquires,
+        (jlong)http_manager_metrics.leased_concurrency);
+    (*env)->SetObjectField(
+        env, metrics_object, s3_request_metrics_properties.http_manager_metrics_field_id, http_manager_metrics_object);
+    (*env)->DeleteLocalRef(env, http_manager_metrics_object);
+
     // CRT info (String) - from crt_info_metrics
     const struct aws_string *ip_address_string;
     if (aws_s3_request_metrics_get_ip_address(metrics, &ip_address_string) == AWS_OP_SUCCESS) {

--- a/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
+++ b/src/test/java/software/amazon/awssdk/crt/test/S3ClientTest.java
@@ -2006,8 +2006,13 @@ public class S3ClientTest extends CrtTestFixture {
         public void validateMetrics() {
             Assert.assertTrue("API Call duration should be >= 0", apiCallDurationNs >= 0);
             Assert.assertTrue("API call should be successful", apiCallSuccessful);
-            Assert.assertEquals("Service ID should be s3", "s3", serviceId);
-            Assert.assertNotNull("Service endpoint should not be null", serviceEndpoint);
+            Assert.assertEquals("Service ID should be S3", "S3", serviceId);
+            // This test's S3Client uses no endpoint override and no explicit HTTP scheme, so the
+            // client defaults to https.
+            Assert.assertEquals("Service endpoint should be the https-qualified host",
+                    "https://" + ENDPOINT, serviceEndpoint);
+            Assert.assertEquals("Service endpoint should parse to the expected host",
+                    ENDPOINT, java.net.URI.create(serviceEndpoint).getHost());
             Assert.assertNotNull("Operation name should not be null", operationName);
             Assert.assertFalse("Operation name should not be empty", operationName.isEmpty());
             Assert.assertNotNull("Request ID should not be null", awsRequestId);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds/fixes S3 request telemetry exposed via S3RequestMetrics:

- getServiceId() — now returns "S3" (was "s3"), matching SDK convention
- getServiceEndpoint() — now returns a full scheme-qualified URL (e.g. https://bucket.s3.region.amazonaws.com) instead of a bare host, so it can be parsed with URI.create()
- getTimeToFirstByte() / getTimeToLastByte() — now return durations (delta from request start), not raw timestamps
- getConnectionAcquisitionDurationNs() — new, time spent acquiring a connection for the request
- getHttpManagerMetrics() — new, snapshot of the endpoint's connection pool state (available/pending/leased concurrency) taken just before this request asks for a connection
- S3Client.getMaxActiveConnections() — new, the connection concurrency cap of the client.

Requires https://github.com/awslabs/aws-c-s3/pull/673 for newly bound client level API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
